### PR TITLE
Add typed/json which exports almost all of json

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -78,6 +78,7 @@ The following libraries are included with Typed Racket in the
 @defmodule/incl[typed/rackunit]
 @defmodule/incl[typed/srfi/14]
 @defmodule/incl[typed/syntax/stx]
+@defmodule/incl[typed/json]
 
 Other libraries included in the main distribution that are either
 written in Typed Racket or have adapter modules that are typed:

--- a/typed-racket-more/typed/json.rkt
+++ b/typed-racket-more/typed/json.rkt
@@ -1,0 +1,19 @@
+#lang typed/racket/base
+
+;; a typed wrapper for the json library
+
+(provide JSExpr)
+
+(define-type JSExpr
+  (U 'null Boolean String Integer Inexact-Real (Listof JSExpr) (HashTable Symbol JSExpr)))
+
+(require/typed/provide json
+                       [jsexpr? (Any -> Boolean)]
+                       [write-json (->* (JSExpr)
+                                        (Output-Port #:encode (U 'control 'all))
+                                        Any)]
+                       [read-json (->* () (Input-Port) (U JSExpr EOF))]
+                       [jsexpr->string (JSExpr [#:encode (U 'control 'all)] -> String)]
+                       [jsexpr->bytes (JSExpr [#:encode (U 'control 'all)] -> Bytes)]
+                       [string->jsexpr (String -> JSExpr)]
+                       [bytes->jsexpr (Bytes -> JSExpr)])


### PR DESCRIPTION
This doesn't include `jsexpr?`, nor does it support for custom JavaScript nulls, but is otherwise entirely functional. The former has been excluded due to its inability to be typechecked properly (see [this SO question](http://stackoverflow.com/questions/27304901/how-can-i-use-jsons-jsexpr-predicate-with-typed-racket) and [this mailing list thread](http://lists.racket-lang.org/users/archive/2014-December/065095.html)). The latter has been excluded for similar reasons as well as its relative uselessness.

I've been using these type definitions in working code for some time, and I've encountered no problems despite those missing bindings.
