### PR TITLE
Add type for base64-encode optional argument

### DIFF
--- a/typed-racket-more/typed/net/base64.rkt
+++ b/typed-racket-more/typed/net/base64.rkt
@@ -6,7 +6,7 @@
   [base64-encode-stream (case-lambda (Input-Port Output-Port -> Void)
                                      (Input-Port Output-Port Bytes -> Void))]
   [base64-decode-stream (Input-Port Output-Port -> Void)]
-  [base64-encode (Bytes -> Bytes)]
+  [base64-encode (->* (Bytes) (Bytes) Bytes)]
   [base64-decode (Bytes -> Bytes)])
 
 (provide base64-encode-stream base64-decode-stream base64-encode base64-decode)


### PR DESCRIPTION
base64-encode takes an optional argument newline-bstr which is absent from the type provided.