### PR TITLE
fixed mutation let-aliasing bug

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-let-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-let-unit.rkt
@@ -52,7 +52,7 @@
         (match e-r
           [(list (tc-result: e-ts (FilterSet: fs+ fs-) os) ...)
            (values e-ts
-                   os
+                   (map (λ (o n) (if (is-var-mutated? n) -empty-obj o)) os names)
                    (apply append
                           (for/list ([n (in-list names)]
                                      [t (in-list e-ts)]

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -3392,6 +3392,16 @@
                (void))
              -Void]
        
+       [tc-err (let ()
+                 (: foo (-> Any Number))
+                 (define foo
+                   (λ (x) (let ([x* x])
+                            (begin
+                              (set! x* "sneaky string")
+                              (if (number? x)
+                                  x*
+                                  42))))))]
+       
        ;; tests looking up path-types into unions
        [tc-e (let ()
                (: foo ((U (Pairof Number Number) (Pairof Number String)) -> Number))


### PR DESCRIPTION
let-aliasing initially forgot to check if a variable that might act as
an alias was ever mutated. fixed by disallowing a mutated variable to
act as an alias.