### PR TITLE
Improve rackunit support with test-case, test-suite, and check-docs

### DIFF
--- a/typed-racket-more/typed/rackunit/docs-complete.rkt
+++ b/typed-racket-more/typed/rackunit/docs-complete.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/base
+
+(require/typed/provide
+ rackunit/docs-complete
+ [check-docs (Symbol
+              [#:skip (U Regexp
+                         Symbol
+                         (Listof (U Regexp Symbol))
+                         (Symbol -> Any)
+                         #f)]
+              -> Any)])

--- a/typed-racket-more/typed/rackunit/main.rkt
+++ b/typed-racket-more/typed/rackunit/main.rkt
@@ -142,7 +142,8 @@
 (define current-seed : (Parameter Seed)
   (make-parameter #f))
 
-(: test-suite-test-case-around (test-suite-handler-here -> ((Thunk Any) -> Any)))
+; taken directly from rackunit/private/test-suite
+(: test-suite-test-case-around (test-suite-handler-here -> ((Thunk Any) -> Void)))
 (define (test-suite-test-case-around fhere)
   (lambda (thunk)
     (let* ([name (current-test-name)]
@@ -150,7 +151,8 @@
            [seed (current-seed)])
       (current-seed (fhere test name thunk seed)))))
 
-(: test-suite-check-around (test-suite-handler-here -> ((Thunk Any) -> Any)))
+; taken directly from rackunit/private/test-suite
+(: test-suite-check-around (test-suite-handler-here -> ((Thunk Any) -> Void)))
 (define (test-suite-check-around fhere)
   (lambda (thunk)
     (let* ([name #f]
@@ -158,6 +160,7 @@
            [seed (current-seed)])
       (current-seed (fhere test name thunk seed)))))
 
+; adapted from rackunit/private/test-suite
 (define-syntax (test-suite stx)
   (syntax-parse stx
     [(_ name:expr

--- a/typed-racket-more/typed/rackunit/main.rkt
+++ b/typed-racket-more/typed/rackunit/main.rkt
@@ -93,11 +93,12 @@
   [t:check-around check-around]
   [t:current-check-handler current-check-handler]
   [t:current-check-around current-check-around])
-(define-rewriter t:test-case test-case
-  [t:current-test-case-around current-test-case-around]
-  [t:check-around check-around]
-  [t:current-check-handler current-check-handler]
-  [t:current-check-around current-check-around])
+
+(define-syntax-rule (test-case name expr ...)
+  (parameterize
+      ([current-test-name (ann name String)])
+    (test-begin expr ...)))
+
 (provide test-begin test-case)
 
 (require/opaque-type TestCase test-case? rackunit)

--- a/typed-racket-more/typed/rackunit/main.rkt
+++ b/typed-racket-more/typed/rackunit/main.rkt
@@ -1,5 +1,6 @@
 #lang typed/racket
-(require typed/private/utils
+(require typed/racket/class
+         typed/private/utils
          typed/private/rewriter
          "type-env-ext.rkt"
          (for-syntax syntax/parse))
@@ -108,7 +109,7 @@
 (require/typed
  rackunit/private/monad
  [#:opaque monad monad?])
-(define-type Seed (Option monad))
+(define-type Seed (U #f monad (Object)))
 
 (define-type test-suite-handler-down
   (rackunit-test-suite (Option String) (Thunk Any) (Thunk Any) Seed -> Seed))


### PR DESCRIPTION
This fixes issues #6 and #7.

The `test-case` macro was extremely simple to reimplement in typed racket, but `test-suite` is a different beast. This reimplements the `test-suite` macro entirely within typed racket, something that required reimplementing the `current-seed` parameter and the `test-suite-test-case-around` and `test-suite-check-around` functions.

The precise type of `Seed` is somewhat unclear from the rackunit code, since it appears to be simply threaded through the code, and it can be anything at all, in theory. However, rackunit itself uses a monad type it defines itself in the `run-tests` function from `rackunit/text-ui`, so this code assumes seeds will be of that type.