### PR TITLE
Add contract generation support for Async-Channelof

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -351,6 +351,7 @@
         [(Box: t) (box/sc (t->sc/both t))]
         [(Pair: t1 t2)
          (cons/sc (t->sc t1) (t->sc t2))]
+        [(Async-Channel: t) (async-channel/sc (t->sc t))]
         [(Promise: t)
          (promise/sc (t->sc t))]
         [(Opaque: p?)

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
@@ -12,9 +12,11 @@
          (for-template racket/base
                        racket/contract/base
                        racket/set
+                       racket/async-channel
                        unstable/contract
                        "../../utils/evt-contract.rkt")
-         racket/contract)
+         racket/contract
+         racket/async-channel)
 
 
 (begin-for-syntax
@@ -158,4 +160,5 @@
   ((sequence/sc . (#:covariant)) sequence/c #:impersonator)
   ((channel/sc . (#:invariant)) channel/c #:chaperone)
   ((continuation-mark-key/sc (#:invariant)) continuation-mark-key/c #:chaperone)
-  ((evt/sc (#:covariant)) tr:evt/c #:chaperone))
+  ((evt/sc (#:covariant)) tr:evt/c #:chaperone)
+  ((async-channel/sc (#:invariant)) async-channel/c #:chaperone))


### PR DESCRIPTION
Fairly self-explanatory, this allows contract generation for `Async-Channelof` types. This depends on the plt/racket#860 pull request, so it shouldn't be pulled until those changes are merged.