### PR TITLE
Added occurrence typing for private fields.

### DIFF
--- a/typed-racket-lib/typed-racket/rep/object-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/object-rep.rkt
@@ -16,6 +16,7 @@
 (def-pathelem StructPE ([t Type?] [idx natural-number/c])
   [#:frees (λ (f) (f t))]
   [#:fold-rhs (*StructPE (type-rec-id t) idx)])
+(def-pathelem FieldPE () [#:fold-rhs #:base])
 
 (def-object Empty () [#:fold-rhs #:base])
 

--- a/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -804,7 +804,7 @@
     (for/list ([m (in-set method-names)])
       (define external (dict-ref internal-external-mapping m))
       (define maybe-type (dict-ref type-map external #f))
-      (->* (list (make-Univ))
+      (->* (list Univ)
            (cond [(and maybe-type
                        (not (equal? (car maybe-type) top-func))
                        (not inner?))
@@ -813,7 +813,7 @@
                        (not (equal? (car maybe-type) top-func)))
                   (Un (-val #f)
                       (function->method (car maybe-type) self-type))]
-                 [else (make-Univ)]))))
+                 [else Univ]))))
 
   (define method-types
     (make-method-types (hash-ref parse-info 'method-internals) methods))
@@ -835,10 +835,8 @@
       (define external (dict-ref internal-external-mapping f))
       (define maybe-type (dict-ref type-map external #f))
       (values
-       (-> (make-Univ) (or (and maybe-type (car maybe-type))
-                           (make-Univ)))
-       (-> (make-Univ) (or (and maybe-type (car maybe-type))
-                           -Bottom)
+       (-> Univ (or (and maybe-type (car maybe-type)) Univ))
+       (-> Univ (or (and maybe-type (car maybe-type)) -Bottom)
            -Void))))
 
   (define (make-private-field-types field-names getter-ids type-map)
@@ -850,14 +848,13 @@
         ;; This case is more complicated than for public fields because private
         ;; fields support occurrence typing. The object is set as the field's
         ;; accessor id, so that *its* range type is refined for occurrence typing.
-        (list (make-arr* (list (make-Univ))
+        (list (make-arr* (list Univ)
                          (or (and maybe-type (car maybe-type))
-                             (make-Univ))
+                             Univ)
                          #:filters -no-filter
                          #:object
                          (make-Path (list (make-FieldPE)) getter-id))))
-       (-> (make-Univ) (or (and maybe-type (car maybe-type))
-                           -Bottom)
+       (-> Univ (or (and maybe-type (car maybe-type)) -Bottom)
            -Void))))
 
   (define-values (field-get-types field-set-types)
@@ -878,7 +875,7 @@
       (or (and maybe-type
                (not (equal? maybe-type top-func))
                (function->method maybe-type self-type))
-          (make-Univ))))
+          Univ)))
 
   (define private-method-types
     (make-private-like-types (hash-ref parse-info 'private-names)
@@ -942,7 +939,7 @@
           (append all-types
                   init-types
                   init-rest-type
-                  (list self-type (make-Univ)))))
+                  (list self-type Univ))))
 
 ;; check-methods : Listof<Symbol> Listof<Syntax> Dict<Symbol, Symbol> Dict Type
 ;;                 -> Dict<Symbol, Type>

--- a/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
@@ -56,6 +56,19 @@
         [else (let ([flds* (append lhs (cons (make-fld ty* acc-id #f) (cdr rhs)))])
                 (make-Struct nm par flds* proc poly pred))]))]
 
+    ;; class field ops
+    ;;
+    ;; A refinement of a private field in a class is really a refinement of the
+    ;; return type of the accessor function for that field (rather than a variable).
+    ;; We cannot just refine the type of the argument to the accessor, since that
+    ;; is an object type that doesn't mention private fields. Thus we use the
+    ;; FieldPE path element as a marker to refine the result of the accessor
+    ;; function.
+    [((Function: (list (arr: doms (Values: (list (Result: rng _ _))) _ _ _)))
+      (list rst ... (FieldPE:)))
+     (make-Function
+      (list (make-arr* doms (update rng ft pos? rst))))]
+
     ;; otherwise
     [(t '())
      (if pos?

--- a/typed-racket-lib/typed-racket/types/path-type.rkt
+++ b/typed-racket-lib/typed-racket/types/path-type.rkt
@@ -57,6 +57,11 @@
     [((PolyDots: _ body-t) _) (path-type path body-t resolved)]
     [((PolyRow: _ _ body-t) _) (path-type path body-t resolved)]
     
+    ;; for private fields in classes
+    [((Function: (list (arr: doms (Values: (list (Result: rng _ _))) _ _ _)))
+      (list rst ... (FieldPE:)))
+     (path-type rst rng)]
+
     ;; types which need resolving
     [((? needs-resolving?) _) #:when (not (set-member? resolved t))
      (path-type path (resolve-once t) (set-add resolved t))]

--- a/typed-racket-test/unit-tests/class-tests.rkt
+++ b/typed-racket-test/unit-tests/class-tests.rkt
@@ -1965,39 +1965,42 @@
            ;; let-aliasing + occ. typing on fields
            (let ([y x]) (if (string? y) (string-append x) "")))
          (-class)]
+   ;; Failure tests for occurrence typing on private fields. The types
+   ;; are obfuscated a bit to prevent interference from type aliases in
+   ;; another test.
    [tc-err (let ()
              (define c%
                (class object%
                  (super-new)
-                 (: x (U String #f))
+                 (: x (U String 'obfuscate))
                  (define x "foo")
-                 (set! x #f) ; prevents occ. typing
+                 (set! x 'obfuscate) ; prevents occ. typing
                  (: m (-> String))
                  (define/public (m)
                    (if (string? x) (string-append x "bar") "baz"))))
              (error "foo"))
-           #:msg #rx"expected: String.*given: \\(U False String\\)"]
+           #:msg #rx"expected: String.*given: \\(U String 'obfuscate\\)"]
    [tc-err (let ()
              (define c%
                (class object%
                  (super-new)
-                 (: x (U String #f))
+                 (: x (U String 'obfuscate))
                  (define x "foo")
-                 (field [f (begin (set! x #f) "hello")])
+                 (field [f (begin (set! x 'obfuscate) "hello")])
                  (: m (-> String))
                  (define/public (m)
                    (if (string? x) (string-append x "bar") "baz"))))
              (error "foo"))
-           #:msg #rx"expected: String.*given: \\(U False String\\)"]
+           #:msg #rx"expected: String.*given: \\(U String 'obfuscate\\)"]
    [tc-err (let ()
              (define c%
                (class object%
                  (super-new)
-                 (: x (U String #f))
+                 (: x (U String 'obfuscate))
                  (define x "foo")
-                 (define/public (n) (set! x #f))
+                 (define/public (n) (set! x 'obfuscate))
                  (: m (-> String))
                  (define/public (m)
                    (if (string? x) (string-append x "bar") "baz"))))
              (error "foo"))
-           #:msg #rx"expected: String.*given: \\(U False String\\)"]))
+           #:msg #rx"expected: String.*given: \\(U String 'obfuscate\\)"]))


### PR DESCRIPTION
Adds occurrence typing for private fields. This has been implemented on an experimental branch for a while. The new thing is that it now comes with mutation checking in the class body to disable occurrence typing when necessary.

Code reviewers: my main concern is that the use of `FieldPE` path elements on the object of the accessor function is too hacky (see code in `tc-envops.rkt`). I can't think of any other way to implement it though.