### PR TITLE
Improve occurrence typing on Listof types

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -20,7 +20,7 @@
  "base-structs.rkt"
  racket/file
  (only-in racket/private/pre-base new-apply-proc)
- (only-in (types abbrev) [-Boolean B] [-Symbol Sym] -Flat)
+ (only-in (types abbrev) [-Boolean B] [-Symbol Sym] -Flat -lst**)
  (only-in (types numeric-tower) [-Number N])
  (only-in (rep type-rep)
           make-ClassTop
@@ -466,132 +466,87 @@
 [cdr   (-poly (a b)
               (->acc (list (Un -Null (-pair a b))) b (list -cdr)))]
 
-;; these type signatures do not cover all valid uses of these pair accessors
 [caar (-poly (a b c)
-             (cl->* [->acc (list (-pair (-pair a b) c)) a (list -car -car)]
-                    [-> (-lst (-pair a b)) a]
-                    [-> (-pair (-lst a) b) a]
-                    [-> (-lst (-lst a)) a]))]
+             (->acc (list (Un -Null (-pair (Un -Null (-pair a b)) c))) a (list -car -car)))]
 [cdar (-poly (a b c)
-             (cl->* [->acc (list (-pair (-pair a b) c)) b (list -cdr -car)]
-                    [-> (-lst (-pair a b)) b]
-                    [-> (-pair (-lst a) b) (-lst a)]
-                    [-> (-lst (-lst a)) (-lst a)]))]
+             (->acc (list (Un -Null (-pair (Un -Null (-pair a b)) c))) b (list -cdr -car)))]
 [cadr (-poly (a b c)
-             [->acc (list (Un -Null (-pair a (Un -Null (-pair b c))))) b (list -car -cdr)])]
-[cddr  (-poly (a b c)
-              (cl->* [->acc (list (-pair a (-pair b c))) c (list -cdr -cdr)]
-                     [->acc (list (-lst a)) (-lst a) (list -cdr -cdr)]))]
+             (->acc (list (Un -Null (-pair a (Un -Null (-pair b c))))) b (list -car -cdr)))]
+[cddr (-poly (a b c)
+             (->acc (list (Un -Null (-pair a (Un -Null (-pair b c))))) c (list -cdr -cdr)))]
 
 [caaar (-poly (a b c d)
-              (cl->* [->acc (list (-pair (-pair (-pair a b) c) d)) a (list -car -car -car)]
-                     [-> (-lst (-lst (-lst a))) a]))]
+              (->acc (list (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair a b)) c)) d))) a (list -car -car -car)))]
 [cdaar (-poly (a b c d)
-              (cl->* [->acc (list (-pair (-pair (-pair a b) c) d)) b (list -cdr -car -car)]
-                     [-> (-lst (-lst (-lst a))) (-lst a)]))]
+              (->acc (list (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair a b)) c)) d))) b (list -cdr -car -car)))]
 [cadar (-poly (a b c d)
-              (cl->* [->acc (list (-pair (-pair a (-pair b c)) d)) b (list -car -cdr -car)]
-                     [-> (-lst (-lst a)) a]))]
+              (->acc (list (Un -Null (-pair (Un -Null (-pair a (Un -Null (-pair b c)))) d))) b (list -car -cdr -car)))]
 [cddar (-poly (a b c d)
-              (cl->* [->acc (list (-pair (-pair a (-pair b c)) d)) c (list -cdr -cdr -car)]
-                     [-> (-lst (-lst a)) (-lst a)]))]
+              (->acc (list (Un -Null (-pair (Un -Null (-pair a (Un -Null (-pair b c)))) d))) c (list -cdr -cdr -car)))]
 [caadr (-poly (a b c d)
-              (cl->* [->acc (list (-pair a (-pair (-pair b c) d))) b (list -car -car -cdr)]
-                     [-> (-lst (-lst a)) a]))]
+              (->acc (list (Un -Null (-pair a (Un -Null (-pair (Un -Null (-pair b c)) d))))) b (list -car -car -cdr)))]
 [cdadr (-poly (a b c d)
-              (cl->* [->acc (list (-pair a (-pair (-pair b c) d))) c (list -cdr -car -cdr)]
-                     [-> (-lst (-lst a)) (-lst a)]))]
+              (->acc (list (Un -Null (-pair a (Un -Null (-pair (Un -Null (-pair b c)) d))))) c (list -cdr -car -cdr)))]
 [caddr  (-poly (a b c d)
-              (cl->* [->acc (list (-pair a (-pair b (-pair c d)))) c (list -car -cdr -cdr)]
-                     [-> (-lst a) a]))]
+              (->acc (list (Un -Null (-pair a (Un -Null (-pair b (Un -Null (-pair c d))))))) c (list -car -cdr -cdr)))]
 [cdddr (-poly (a b c d)
-              (cl->* [->acc (list (-pair a (-pair b (-pair c d)))) d (list -cdr -cdr -cdr)]
-                     [-> (-lst a) (-lst a)]))]
+              (->acc (list (Un -Null (-pair a (Un -Null (-pair b (Un -Null (-pair c d))))))) d (list -cdr -cdr -cdr)))]
 
 [caaaar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair (-pair (-pair a b) c) d) e)) a (list -car -car -car -car)]
-                      [-> (-lst (-lst (-lst (-lst a)))) a]))]
+               (->acc (list (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair a b)) c)) d)) e))) a (list -car -car -car -car)))]
 [cdaaar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair (-pair (-pair a b) c) d) e)) b (list -cdr -car -car -car)]
-                      [-> (-lst (-lst (-lst (-lst a)))) (-lst a)]))]
+               (->acc (list (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair a b)) c)) d)) e))) b (list -cdr -car -car -car)))]
 [cadaar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair (-pair a (-pair b c)) d) e)) b (list -car -cdr -car -car)]
-                      [-> (-lst (-lst (-lst a))) a]))]
+               (->acc (list (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair a (Un -Null (-pair b c)))) d)) e))) b (list -car -cdr -car -car)))]
 [cddaar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair (-pair b (-pair b c)) d) e)) c (list -cdr -cdr -car -car)]
-                      [-> (-lst (-lst (-lst a))) (-lst a)]))]
+               (->acc (list (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair b (Un -Null (-pair b c)))) d)) e))) c (list -cdr -cdr -car -car)))]
 [caadar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair a (-pair (-pair b c) d)) e)) b (list -car -car -cdr -car)]
-                      [-> (-lst (-lst (-lst a))) a]))]
+               (->acc (list (Un -Null (-pair (Un -Null (-pair a (Un -Null (-pair (Un -Null (-pair b c)) d)))) e))) b (list -car -car -cdr -car)))]
 [cdadar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair a (-pair (-pair b c) d)) e)) c (list -cdr -car -cdr -car)]
-                      [-> (-lst (-lst (-lst a))) (-lst a)]))]
+               (->acc (list (Un -Null (-pair (Un -Null (-pair a (Un -Null (-pair (Un -Null (-pair b c)) d)))) e))) c (list -cdr -car -cdr -car)))]
 [caddar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair a (-pair b (-pair c d))) e)) c (list -car -cdr -cdr -car)]
-                      [-> (-lst (-lst a)) a]))]
+               (->acc (list (Un -Null (-pair (Un -Null (-pair a (Un -Null (-pair b (Un -Null (-pair c d)))))) e))) c (list -car -cdr -cdr -car)))]
 [cdddar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair a (-pair b (-pair c d))) e)) d (list -cdr -cdr -cdr -car)]
-                      [-> (-lst (-lst a)) (-lst a)]))]
+               (->acc (list (Un -Null (-pair (Un -Null (-pair a (Un -Null (-pair b (Un -Null (-pair c d)))))) e))) d (list -cdr -cdr -cdr -car)))]
 [caaadr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair (-pair (-pair b c) d) e))) b (list -car -car -car -cdr)]
-                      [-> (-lst (-lst (-lst a))) a]))]
+               (->acc (list (Un -Null (-pair a (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair b c)) d)) e))))) b (list -car -car -car -cdr)))]
 [cdaadr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair (-pair (-pair b c) d) e))) c (list -cdr -car -car -cdr)]
-                      [-> (-lst (-lst (-lst a))) (-lst a)]))]
+               (->acc (list (Un -Null (-pair a (Un -Null (-pair (Un -Null (-pair (Un -Null (-pair b c)) d)) e))))) c (list -cdr -car -car -cdr)))]
 [cadadr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair (-pair b (-pair c d)) e))) c (list -car -cdr -car -cdr)]
-                      [-> (-lst (-lst a)) a]))]
+               (->acc (list (Un -Null (-pair a (Un -Null (-pair (Un -Null (-pair b (Un -Null (-pair c d)))) e))))) c (list -car -cdr -car -cdr)))]
 [cddadr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair (-pair b (-pair c d)) e))) d (list -cdr -cdr -car -cdr)]
-                      [-> (-lst (-lst a)) (-lst a)]))]
+               (->acc (list (Un -Null (-pair a (Un -Null (-pair (Un -Null (-pair b (Un -Null (-pair c d)))) e))))) d (list -cdr -cdr -car -cdr)))]
 [caaddr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair b (-pair (-pair c d) e)))) c (list -car -car -cdr -cdr)]
-                      [-> (-lst (-lst a)) a]))]
+               (->acc (list (Un -Null (-pair a (Un -Null (-pair b (Un -Null (-pair (Un -Null (-pair c d)) e))))))) c (list -car -car -cdr -cdr)))]
 [cdaddr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair b (-pair (-pair c d) e)))) d (list -cdr -car -cdr -cdr)]
-                      [-> (-lst (-lst a)) (-lst a)]))]
+               (->acc (list (Un -Null (-pair a (Un -Null (-pair b (Un -Null (-pair (Un -Null (-pair c d)) e))))))) d (list -cdr -car -cdr -cdr)))]
 [cadddr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair b (-pair c (-pair d e))))) d (list -car -cdr -cdr -cdr)]
-                      [-> (-lst a) a]))]
+               (->acc (list (Un -Null (-pair a (Un -Null (-pair b (Un -Null (-pair c (Un -Null (-pair d e))))))))) d (list -car -cdr -cdr -cdr)))]
 [cddddr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair b (-pair c (-pair d e))))) e (list -cdr -cdr -cdr -cdr)]
-                      [-> (-lst a) (-lst a)]))]
+               (->acc (list (Un -Null (-pair a (Un -Null (-pair b (Un -Null (-pair c (Un -Null (-pair d e))))))))) e (list -cdr -cdr -cdr -cdr)))]
 
 [first (-poly (a b)
-              (cl->*
-               (->acc (list (-pair a (-lst b))) a (list -car))
-               (->* (list (-lst a)) a)))]
+              (->acc (list (Un -Null (-pair a (-lst b)))) a (list -car)))]
 [second (-poly (a r t)
-               (cl->* [->acc (list (-lst* a r #:tail (-lst t))) r (list -car -cdr)]
-                      [->* (list (-lst a)) a]))]
+               [->acc (list (-lst** a r #:tail (-lst t))) r (list -car -cdr)])]
 [third (-poly (a b r t)
-              (cl->* [->acc (list (-lst* a b r #:tail (-lst t))) r (list -car -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+              [->acc (list (-lst** a b r #:tail (-lst t))) r (list -car -cdr -cdr)])]
 [fourth  (-poly (a b c r t)
-              (cl->* [->acc (list (-lst* a b c r #:tail (-lst t))) r (list -car -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+                [->acc (list (-lst** a b c r #:tail (-lst t))) r (list -car -cdr -cdr -cdr)])]
 [fifth   (-poly (a b c d r t)
-              (cl->* [->acc (list (-lst* a b c d r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+                [->acc (list (-lst** a b c d r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr)])]
 [sixth   (-poly (a b c d e r t)
-              (cl->* [->acc (list (-lst* a b c d e r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+                [->acc (list (-lst** a b c d e r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr)])]
 [seventh (-poly (a b c d e f r t)
-              (cl->* [->acc (list (-lst* a b c d e f r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+                [->acc (list (-lst** a b c d e f r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr)])]
 [eighth  (-poly (a b c d e f g r t)
-              (cl->* [->acc (list (-lst* a b c d e f g r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+                [->acc (list (-lst** a b c d e f g r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr)])]
 [ninth   (-poly (a b c d e f g h r t)
-              (cl->* [->acc (list (-lst* a b c d e f g h r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+                [->acc (list (-lst** a b c d e f g h r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr)])]
 [tenth   (-poly (a b c d e f g h i r t)
-              (cl->* [->acc (list (-lst* a b c d e f g h i r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+                [->acc (list (-lst** a b c d e f g h i r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr)])]
 [rest (-poly (a b)
-             (cl->*
-              (->acc (list (-pair a (-lst b))) (-lst b) (list -cdr))
-              (->* (list (-lst a)) (-lst a))))]
+             (->acc (list (Un -Null (-pair a (-lst b)))) (-lst b) (list -cdr)))]
 
 [cons (-poly (a b)
              (cl->* [->* (list a (-lst a)) (-lst a)]
@@ -2891,13 +2846,9 @@
 
 ;; Section 17.2 (Unsafe Data Extraction)
 [unsafe-car (-poly (a b)
-                   (cl->*
-                    (->acc (list (-pair a b)) a (list -car))
-                    (->* (list (-lst a)) a)))]
+                   (->acc (list (Un -Null (-pair a b))) a (list -car)))]
 [unsafe-cdr (-poly (a b)
-                   (cl->*
-                    (->acc (list (-pair a b)) b (list -cdr))
-                    (->* (list (-lst a)) (-lst a))))]
+                   (->acc (list (Un -Null (-pair a b))) b (list -cdr)))]
 [unsafe-vector-length ((make-VectorTop) . -> . -Index)]
 [unsafe-vector*-length ((make-VectorTop) . -> . -Index)]
 [unsafe-struct-ref top-func]

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -462,13 +462,9 @@
 
 ;; Section 4.9 (Pairs and Lists)
 [car   (-poly (a b)
-              (cl->*
-               (->acc (list (-pair a b)) a (list -car))
-               (->* (list (-lst a)) a)))]
+              (->acc (list (Un -Null (-pair a b))) a (list -car)))]
 [cdr   (-poly (a b)
-              (cl->*
-               (->acc (list (-pair a b)) b (list -cdr))
-               (->* (list (-lst a)) (-lst a))))]
+              (->acc (list (Un -Null (-pair a b))) b (list -cdr)))]
 
 ;; these type signatures do not cover all valid uses of these pair accessors
 [caar (-poly (a b c)
@@ -482,11 +478,10 @@
                     [-> (-pair (-lst a) b) (-lst a)]
                     [-> (-lst (-lst a)) (-lst a)]))]
 [cadr (-poly (a b c)
-             (cl->* [->acc (list (-pair a (-pair b c))) b (list -car -cdr)]
-                    [-> (-lst a) a]))]
+             [->acc (list (Un -Null (-pair a (Un -Null (-pair b c))))) b (list -car -cdr)])]
 [cddr  (-poly (a b c)
               (cl->* [->acc (list (-pair a (-pair b c))) c (list -cdr -cdr)]
-                     [-> (-lst a) (-lst a)]))]
+                     [->acc (list (-lst a)) (-lst a) (list -cdr -cdr)]))]
 
 [caaar (-poly (a b c d)
               (cl->* [->acc (list (-pair (-pair (-pair a b) c) d)) a (list -car -car -car)]

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -521,6 +521,11 @@
           ;; constrain b1 to be below T, but don't mention the new vars
           [((Poly: v1 b1) T) (cgen (context-add context #:bounds v1) b1 T)]
 
+          ;; Mu's just get unfolded
+          ;; We unfold S first so that unions are handled in S before T
+          [((? Mu? s) t) (cg (unfold s) t)]
+          [(s (? Mu? t)) (cg s (unfold t))]
+
           ;; constrain *each* element of es to be below T, and then combine the constraints
           [((Union: es) T)
            (define cs (for/list/fail ([e (in-list es)]) (cg e T)))
@@ -609,11 +614,6 @@
            (cgen/list context (list k v) (list k* v*))]
           [((Set: t) (Sequence: (list t*)))
            (cg t t*)]
-
-          ;; Mu's just get unfolded
-          ;; We unfold S first so that unions are handled in S before T
-          [((? Mu? s) t) (cg (unfold s) t)]
-          [(s (? Mu? t)) (cg s (unfold t))]
 
           ;; resolve applications
           [((App: _ _ _) _)

--- a/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
@@ -31,12 +31,6 @@
     [((Pair: t s) (list rst ... (CdrPE:)))
      (build-type -pair t (update s ft pos? rst))]
 
-    ;; listof and car/cdr
-    [((and ts (Listof: t)) (list rst ... (CarPE:)))
-     (build-type -pair (update t ft pos? rst) ts)]
-    [((and ts (Listof: t)) (list rst ... (CdrPE:)))
-     (build-type -pair t (update ts ft pos? rst))]
-
     ;; syntax ops
     [((Syntax: t) (list rst ... (SyntaxPE:)))
      (build-type -Syntax (update t ft pos? rst))]

--- a/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
@@ -31,6 +31,12 @@
     [((Pair: t s) (list rst ... (CdrPE:)))
      (build-type -pair t (update s ft pos? rst))]
 
+    ;; listof and car/cdr
+    [((and ts (Listof: t)) (list rst ... (CarPE:)))
+     (build-type -pair (update t ft pos? rst) ts)]
+    [((and ts (Listof: t)) (list rst ... (CdrPE:)))
+     (build-type -pair t (update ts ft pos? rst))]
+
     ;; syntax ops
     [((Syntax: t) (list rst ... (SyntaxPE:)))
      (build-type -Syntax (update t ft pos? rst))]

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -74,6 +74,11 @@
 
 (define (-ne-lst t) (-pair t (-lst t)))
 
+;; Like lst* but each pair may be Null instead
+(define (-lst** #:tail [tail -Null] . args)
+  (for/fold ([tl tail]) ([a (in-list (reverse args))])
+    (Un -Null (-pair a tl))))
+
 ;; Convenient constructor for Values
 ;; (wraps arg types with Result)
 (define/cond-contract (-values args)

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -232,8 +232,9 @@
 (define (simple-> doms rng)
   (->* doms rng))
 
-(define (->acc dom rng path)
+(define (->acc dom rng path #:rest [rest #f])
   (make-Function (list (make-arr* dom rng
+                                  #:rest rest
                                   #:filters (-FS (-not-filter (-val #f) (make-Path path (list 0 0)))
                                                  (-filter (-val #f) (make-Path path (list 0 0))))
                                   #:object (make-Path path (list 0 0))))))

--- a/typed-racket-test/unit-tests/infer-tests.rkt
+++ b/typed-racket-test/unit-tests/infer-tests.rkt
@@ -266,6 +266,16 @@
      (-lst (-opt -String))
      (Un -Null (-pair (-v a) (Un -Null (-pair (-v b) (-v c)))))
      #:vars '(a b c)]
+    [infer-t
+     (-lst (-v X))
+     (make-ListDots (-v A) 'B)
+     #:vars '(X)
+     #:indices '(B)]
+    [infer-t
+     (Un -Null (-pair (-v X) (-lst (-v Y))))
+     (make-ListDots (-v A) 'B)
+     #:vars '(X Y)
+     #:indices '(B)]
 
     ;; Currently Broken
     ;(infer-t (make-ListDots -Symbol 'b) (-pair -Symbol (-lst -Symbol)) #:indices '(b))

--- a/typed-racket-test/unit-tests/infer-tests.rkt
+++ b/typed-racket-test/unit-tests/infer-tests.rkt
@@ -257,6 +257,16 @@
       #:vars '(a)
       #:result [(-seq (-v a)) (-seq (-val 'b))]]
 
+    ;; Related to PR 14947
+    [infer-t
+     (-lst (-opt -String))
+     (Un -Null (-pair (-v a) (-v b)))
+     #:vars '(a b)]
+    [infer-t
+     (-lst (-opt -String))
+     (Un -Null (-pair (-v a) (Un -Null (-pair (-v b) (-v c)))))
+     #:vars '(a b c)]
+
     ;; Currently Broken
     ;(infer-t (make-ListDots -Symbol 'b) (-pair -Symbol (-lst -Symbol)) #:indices '(b))
     [i2-t (-v a) N ('a N)]

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -3514,6 +3514,68 @@
                (let ([y x])
                  (if (cadr y) (string-append (cadr x)) "")))
              -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (U #f String))))
+               (define x (list (list "foo")))
+               (if (caar x) (string-append (caar x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (Listof (U #f String)))))
+               (define x (list (list (list "foo"))))
+               (if (caaar x) (string-append (caaar x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (U #f String))))
+               (define x (list (list "foo" "bar")))
+               (if (cadar x) (string-append (cadar x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (U #f String))))
+               (define x (list (list "foo") (list "bar")))
+               (if (caadr x) (string-append (caadr x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (U #f String)))
+               (define x (list "foo" "bar" "baz"))
+               (if (caddr x) (string-append (caddr x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (Listof (Listof (U #f String))))))
+               (define x (list (list (list (list "foo")))))
+               (if (caaaar x) (string-append (caaaar x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (Listof (U #f String)))))
+               (define x (list (list (list "foo" "bar"))))
+               (if (cadaar x) (string-append (cadaar x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (Listof (U #f String)))))
+               (define x (list (list (list "foo") (list "bar"))))
+               (if (caadar x) (string-append (caadar x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (U #f String))))
+               (define x (list (list "foo" "bar" "baz")))
+               (if (caddar x) (string-append (caddar x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (Listof (U #f String)))))
+               (define x (list (list (list "foo"))
+                               (list (list "bar"))))
+               (if (caaadr x) (string-append (caaadr x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (Listof (U #f String))))
+               (define x (list (list) (list)
+                               (list "foo")))
+               (if (cadadr x) (string-append (cadadr x)) ""))
+             -String]
+       [tc-e (let ()
+               (: x (Listof (U #f String)))
+               (define x (list "foo" "bar" "baz" "quux"))
+               (if (cadddr x) (string-append (cadddr x)) ""))
+             -String]
        [tc-err (let ()
                  (: x (Listof (U #f String)))
                  (define x (list "foo" "bar"))


### PR DESCRIPTION
This PR improves occurrence typing to use `car`/`cdr` information for `Listof` types. It also simplifies the types of operations like `car` and improves type inference a little bit.

Code review concerns: was there any reason this wasn't done before? (unsound maybe?) The new type for `car` seems simpler (only one case instead of two) but is it harder to understand for users?

Also, I haven't actually adjusted the types for all of the `car` variants yet (the changes are straightforward). I'll do that if code review checks out.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/racket/typed-racket/15)

<!-- Reviewable:end -->
