### PR TITLE
Make Path a subtype of Module-Path

### DIFF
--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -115,8 +115,9 @@
 (define/decl -Pattern (Un -Bytes -Regexp -Byte-Regexp -String))
 (define/decl -Keyword (make-Base 'Keyword #'keyword? keyword?))
 (define/decl -Thread (make-Base 'Thread #'thread? thread?))
+(define/decl -Path (make-Base 'Path #'path? path?))
 (define/decl -Module-Path
-  (Un -Symbol -String
+  (Un -Symbol -String -Path
       (-lst* (-val 'quote) -Symbol)
       (-lst* (-val 'lib) -String)
       (-lst* (-val 'file) -String)
@@ -139,7 +140,6 @@
 	     (conjoin  compiled-expression? (negate compiled-module-expression?))))
 (define/decl -Compiled-Expression (Un -Compiled-Module-Expression -Compiled-Non-Module-Expression))
 (define/decl -Cont-Mark-Set (make-Base 'Continuation-Mark-Set #'continuation-mark-set? continuation-mark-set?))
-(define/decl -Path (make-Base 'Path #'path? path?))
 (define/decl -OtherSystemPath
   (make-Base 'OtherSystemPath
 	     #'(and/c path-for-some-system? (not/c path?))

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -1730,6 +1730,11 @@
               #:ret (ret -Boolean -true-filter))
         (tc-e (let: ((e : Compiled-Expression (compile #'(module + racket 2))))
                 (compiled-module-expression? e)) -Boolean)
+        
+        ;Dynamic Require
+        (tc-e (dynamic-require "module/path" #f) -Void)
+        (tc-e (dynamic-require 'module/path #f) -Void)
+        (tc-e (dynamic-require (string->path "module/path") #f) -Void)
 
         ;Impersonator Property
         (tc-e (make-impersonator-property 'prop)


### PR DESCRIPTION
As noted in the [`module-path?`](http://docs.racket-lang.org/reference/Module_Names_and_Loading.html?q=module-path%3F#%28def._%28%28quote._~23~25kernel%29._module-path~3f%29%29) documentation:

> Note that a path (in the sense of [`path?`](http://docs.racket-lang.org/reference/Manipulating_Paths.html?q=module-path%3F#%28def._%28%28quote._~23~25kernel%29._path~3f%29%29)) is a module path.

This extends the `Module-Path` type to include `Path` as a subtype. It also adds some simple tests through typechecking calls to `dynamic-require`.