### PR TITLE
Add support for use-dir? param of in-directory

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -144,7 +144,7 @@
    (->opt [-Input-Port -Symbol] (-seq -Bytes))]
   ;; in-directory
   [(make-template-identifier '*in-directory 'racket/private/for)
-   (->opt [(Un (-val #f) -Pathlike)] (-seq -Path))]
+   (->opt [(Un (-val #f) -Pathlike) (-> -Path Univ)] (-seq -Path))]
   ;; in-producer
   [(make-template-identifier 'in-producer 'racket/private/for)
    (-polydots (a b)

--- a/typed-racket-test/unit-tests/special-env-typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/special-env-typecheck-tests.rkt
@@ -128,6 +128,7 @@
 
    ;; more sequences
    [tc-e (sequence-ref (in-directory) 0) -Path]
+   [tc-e (sequence-ref (in-directory "foo" (λ (p) #t)) 0) -Path]
    [tc-e (in-mlist (ann (mcons 'a null) (MListof 'a))) (-seq (-val 'a))]
    [tc-e (in-producer (λ () 'hi)) (-seq (-val 'hi))]
    [tc-e (in-producer (λ: ([x : String]) 'hi) symbol? "foo")


### PR DESCRIPTION
In Racket 6.0.0.1, a `use-dir?` parameter was added to [`in-directory`](http://docs.racket-lang.org/reference/sequences.html?q=in-directory#%28def._%28%28lib._racket%2Fprivate%2Fbase..rkt%29._in-directory%29%29). This adds support for that optional parameter and adds the relevant typecheck test.

This change is actually more important than it might seem, since using the `in-directory` form directly inside of a `for` loop expands to a version that uses the second parameter whether or not it is supplied, so it breaks all for loops that use the form.