### PR TITLE
Add initial support for prefab struct types

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -784,6 +784,20 @@ this top type.
 @ex[(struct-info (arity-at-least 0))]
 }
 
+@defform[(Prefab key type ...)]{
+  Represents a @rtech{prefab} structure type with the given prefab structure
+  key (such as one returned by @racket[prefab-struct-key] or accepted by
+  @racket[make-prefab-struct]) and with the given types for each field.
+
+  In the case of prefab structure types with supertypes, the field types of the
+  supertypes come after the field types of the child structure type.
+
+  @ex[#s(salad "potato" "mayo")
+      (: q-salad (Prefab (salad food 1) String String Symbol))
+      (define q-salad
+        #s((salad food 1) "quinoa" "EVOO" salad))]
+}
+
 @defalias[→ ->]
 @defalias[case→ case->]
 @defalias[∀ All]

--- a/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
@@ -17,7 +17,7 @@
 (define-other-types
   -> ->* case-> U Rec All Opaque Vector
   Parameterof List List* Class Object Values Instance Refinement
-  pred Struct Struct-Type Top Bot)
+  pred Struct Struct-Type Prefab Top Bot)
 
 (provide (rename-out [All ∀]
                      [U Un]

--- a/typed-racket-lib/typed-racket/core.rkt
+++ b/typed-racket-lib/typed-racket/core.rkt
@@ -113,7 +113,8 @@
                        (cond [(andmap equal? tgs tcs) ""]
                              [indented?
                               (format "\n[more precisely: ~a]"
-                                      (pretty-format-type (make-Values tcs) #:indent 17))]
+                                      (pretty-format-type (make-Values (map -result tcs))
+                                                          #:indent 17))]
                              [else (format " [more precisely: ~a]" (cons 'Values tcs))])
                        ;; did any get pruned?
                        (cond [(andmap equal? t tcs) ""]

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -547,6 +547,12 @@
                         [else empty])])
              (% cset-meet proc-c (cgen/flds context flds flds*)))]
 
+          ;; two prefab structs with the same key
+          [((Prefab: k flds) (Prefab: k* flds*))
+           #:when (equal? k k*)
+           ;; FIXME: should account for mutable fields
+           (cgen/list context flds flds*)]
+
           ;; two struct names, need to resolve b/c one could be a parent
           [((Name: n _ #t) (Name: n* _ #t))
            (if (free-identifier=? n n*)

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -552,7 +552,7 @@
            #:when (and (prefab-key-subtype? k k*)
                        (>= (length ss) (length ts)))
            (% cset-meet*
-              (for/list/fail ([s (in-list (take ss (length ts)))]
+              (for/list/fail ([s (in-list ss)]
                               [t (in-list ts)]
                               [mut? (in-list (prefab-key->field-mutability k*))])
                 (if mut?

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -5,7 +5,7 @@
 (require "../utils/utils.rkt"
          (except-in (rep type-rep object-rep) make-arr)
          (rename-in (types abbrev union utils filter-ops resolve
-                           classes)
+                           classes prefab)
                     [make-arr* make-arr])
          (utils tc-utils stxclass-util literal-syntax-class)
          syntax/stx (prefix-in c: (contract-req))
@@ -95,6 +95,7 @@
 (define-literal-syntax-class #:for-label Vector)
 (define-literal-syntax-class #:for-label Struct)
 (define-literal-syntax-class #:for-label Struct-Type)
+(define-literal-syntax-class #:for-label Prefab)
 (define-literal-syntax-class #:for-label Values)
 (define-literal-syntax-class #:for-label values)
 (define-literal-syntax-class #:for-label Top)
@@ -341,11 +342,20 @@
       [(:Struct-Type^ t)
        (define v (parse-type #'t))
        (match (resolve v)
-         [(? Struct? s) (make-StructType s)]
+         [(or (? Struct? s) (? Prefab? s)) (make-StructType s)]
          [_ (parse-error #:delayed? #t
                          "expected a structure type for argument to Struct-Type"
                          "given" v)
             (Un)])]
+      [(:Prefab^ key ts ...)
+       #:fail-unless (prefab-key? (syntax->datum #'key)) "expected a prefab key"
+       (define num-fields (length (syntax->list #'(ts ...))))
+       (define new-key (normalize-prefab-key (syntax->datum #'key) num-fields))
+       (unless (= (prefab-key->field-count new-key) num-fields)
+         (parse-error "the number of fields in the prefab key and type disagree"
+                      "key" (prefab-key->field-count new-key)
+                      "fields" num-fields))
+       (make-Prefab new-key (parse-types #'(ts ...)))]
       [(:Instance^ t)
        (let ([v (parse-type #'t)])
          (if (not (or (F? v) (Mu? v) (Name? v) (Class? v) (Error? v)))

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -402,9 +402,18 @@
   ;; This should eventually be based on understanding of struct properties.
   [#:key '(struct procedure)])
 
+;; Represents prefab structs
+;; key  : prefab key encoding mutability, auto-fields, etc.
+;; flds : the types of all of the prefab fields
+(def-type Prefab ([key prefab-key?]
+                  [flds (listof Type/c)])
+  [#:frees (λ (f) (combine-frees (map f flds)))]
+  [#:fold-rhs (*Prefab key (map type-rec-id flds))]
+  [#:key 'prefab])
+
 ;; A structure type descriptor
 (def-type StructTypeTop () [#:fold-rhs #:base] [#:key 'struct-type])
-(def-type StructType ([s (or/c F? B? Struct?)]) [#:key 'struct-type])
+(def-type StructType ([s (or/c F? B? Struct? Prefab?)]) [#:key 'struct-type])
 
 ;; the supertype of all of these values
 (def-type BoxTop () [#:fold-rhs #:base] [#:key 'box])

--- a/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
@@ -46,10 +46,11 @@
 ;;; Helpers
 
 (define-splicing-syntax-class dtsi-fields
- #:attributes (mutable type-only maker)
+ #:attributes (mutable prefab type-only maker)
  (pattern
   (~seq
     (~or (~optional (~and #:mutable (~bind (mutable #t))))
+         (~optional (~and #:prefab (~bind (prefab #t))))
          (~optional (~and #:type-only (~bind (type-only #t))))
          (~optional (~seq #:maker maker))) ...)))
 
@@ -59,11 +60,12 @@
 
 
 (define-syntax-class define-typed-struct-body
-  #:attributes (name mutable type-only maker nm (tvars 1) (fields 1) (types 1))
+  #:attributes (name mutable prefab type-only maker nm (tvars 1) (fields 1) (types 1))
   (pattern ((~optional (tvars:id ...) #:defaults (((tvars 1) null)))
             nm:struct-name ([fields:id : types:expr] ...) options:dtsi-fields)
            #:attr name #'nm.nm
            #:attr mutable (attribute options.mutable)
+           #:attr prefab (attribute options.prefab)
            #:attr type-only (attribute options.type-only)
            #:attr maker (or (attribute options.maker) #'nm.nm)))
 

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-hetero.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-hetero.rkt
@@ -81,6 +81,8 @@
     (match (single-value #'struct)
       [(tc-result1: (and struct-t (app resolve (Struct: _ _ (list (fld: flds _ _) ...) _ _ _))))
        (tc/hetero-ref #'index flds struct-t "struct")]
+      [(tc-result1: (and struct-t (app resolve (Prefab: _ (list flds ...)))))
+       (tc/hetero-ref #'index flds struct-t "prefab struct")]
       [s-ty (tc/app-regular #'form expected)]))
   ;; vector-ref on het vectors
   (pattern (~and form ((~or vector-ref unsafe-vector-ref unsafe-vector*-ref) vec:expr index:expr))

--- a/typed-racket-lib/typed-racket/typecheck/tc-literal.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-literal.rkt
@@ -133,7 +133,7 @@
 (define (tc-prefab struct-inst expected)
   (define expected-ts
     (match (and expected (resolve expected))
-      [(Prefab: _ ts) (in-list ts)]
+      [(Prefab: _ ts) (in-sequence-forever (in-list ts) #f)]
       [_ (in-cycle (in-value #f))]))
   (define key (prefab-struct-key struct-inst))
   (define struct-vec (struct->vector struct-inst))

--- a/typed-racket-lib/typed-racket/typecheck/tc-literal.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-literal.rkt
@@ -3,7 +3,8 @@
 (require "../utils/utils.rkt"
          racket/match
          (typecheck signatures check-below)
-         (types abbrev numeric-tower resolve subtype union generalize)
+         (types abbrev numeric-tower resolve subtype union generalize
+                prefab)
          (rep type-rep)
          (only-in (infer infer) restrict)
          (utils stxclass-util)
@@ -124,8 +125,21 @@
                  [ks (hash-map h (lambda (x y) (tc-literal x)))]
                  [vs (hash-map h (lambda (x y) (tc-literal y)))])
             (make-Hashtable (generalize (apply Un ks)) (generalize (apply Un vs))))])]
+    [(~var i (3d prefab-struct-key))
+     (tc-prefab (syntax-e #'i) expected)]
     [_ Univ]))
 
-
-
-
+;; Typecheck a prefab struct literal
+(define (tc-prefab struct-inst expected)
+  (define expected-ts
+    (match (and expected (resolve expected))
+      [(Prefab: _ ts) (in-list ts)]
+      [_ (in-cycle (in-value #f))]))
+  (define key (prefab-struct-key struct-inst))
+  (define struct-vec (struct->vector struct-inst))
+  (define fields
+    (for/list ([elem (in-vector struct-vec 1)]
+               [expected-t expected-ts])
+      (tc-literal elem expected-t)))
+  (make-Prefab (normalize-prefab-key key (length fields))
+               fields))

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -283,6 +283,9 @@
 
   (parsed-struct sty names desc (struct-info-property nm/par) type-only))
 
+;; tc/prefab : (Listof identifier) (U identifier (list identifier identifier))
+;;             (Listof identifier) (Listof syntax)
+;;             -> Void
 ;; check and register types for a prefab struct
 (define (tc/prefab vars nm/par fld-names tys
                    #:maker [maker #f]

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -27,7 +27,7 @@
   (pattern name:id #:attr par #f))
 
 ;; sty : (U Struct? Prefab?)
-;; names : Listof[Identifier]
+;; names : struct-names
 ;; desc : struct-desc
 ;; struct-info : struct-info?
 ;; type-only : Boolean

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -233,12 +233,6 @@
       (struct-names-type-name (parsed-struct-names parsed-struct))))
   (refine-variance! names stys tvarss))
 
-;; get-struct-name : (U Struct Prefab) -> Symbol
-;; Extract the struct name from a Struct type or Prefab type
-(define (get-struct-name sty)
-  (cond [(Struct? sty) (Struct-name sty)]
-        [(Prefab? sty) (car (Prefab-key sty))]))
-
 ;; check and register types for a define struct
 ;; tc/struct : Listof[identifier] (U identifier (list identifier identifier))
 ;;             Listof[identifier] Listof[syntax]

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -33,17 +33,11 @@
   (parameterize ([current-orig-stx form])
     (syntax-parse form
       [t:typed-struct
-       (if (attribute t.prefab)
-           (tc/prefab (attribute t.tvars)
-                      #'t.nm
-                      (syntax->list #'(t.fields ...))
-                      (syntax->list #'(t.types ...))
-                      #:maker (attribute t.maker)
-                      #:mutable (attribute t.mutable))
-           (tc/struct (attribute t.tvars) #'t.nm (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
-                      #:mutable (attribute t.mutable)
-                      #:maker (attribute t.maker)
-                      #:type-only (attribute t.type-only)))]
+       (tc/struct (attribute t.tvars) #'t.nm (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
+                  #:mutable (attribute t.mutable)
+                  #:maker (attribute t.maker)
+                  #:type-only (attribute t.type-only)
+                  #:prefab? (attribute t.prefab))]
       [t:typed-struct/exec
        (tc/struct null #'t.nm (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
                   #:proc-ty #'t.proc-type)])))

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -33,10 +33,17 @@
   (parameterize ([current-orig-stx form])
     (syntax-parse form
       [t:typed-struct
-       (tc/struct (attribute t.tvars) #'t.nm (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
-                  #:mutable (attribute t.mutable)
-                  #:maker (attribute t.maker)
-                  #:type-only (attribute t.type-only))]
+       (if (attribute t.prefab)
+           (tc/prefab (attribute t.tvars)
+                      #'t.nm
+                      (syntax->list #'(t.fields ...))
+                      (syntax->list #'(t.types ...))
+                      #:maker (attribute t.maker)
+                      #:mutable (attribute t.mutable))
+           (tc/struct (attribute t.tvars) #'t.nm (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
+                      #:mutable (attribute t.mutable)
+                      #:maker (attribute t.maker)
+                      #:type-only (attribute t.type-only)))]
       [t:typed-struct/exec
        (tc/struct null #'t.nm (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
                   #:proc-ty #'t.proc-type)])))

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -14,7 +14,7 @@
          (prefix-in c: (contract-req))
          (rename-in (rep type-rep filter-rep object-rep)
                     [make-Base make-Base*])
-         (types union numeric-tower)
+         (types union numeric-tower prefab)
          ;; Using this form so all-from-out works
          "base-abbrev.rkt" "match-expanders.rkt"
 
@@ -66,6 +66,8 @@
 (define -evt make-Evt)
 (define -weak-box make-Weak-Box)
 (define -inst make-Instance)
+(define (-prefab key . types)
+  (make-Prefab (normalize-prefab-key key (length types)) types))
 
 (define (-seq . args) (make-Sequence args))
 

--- a/typed-racket-lib/typed-racket/types/prefab.rkt
+++ b/typed-racket-lib/typed-racket/types/prefab.rkt
@@ -73,12 +73,10 @@
 ;; a struct with this key should have
 (define (prefab-key->field-count key)
   (let loop ([key key] [count 0])
-    (if (null? key)
-        count
-        (loop (cddddr key)
-              (+ (cadr key)
-                 (car (caddr key))
-                 count)))))
+    (cond [(null? key) count]
+          [else
+           (match-define (list _ len (list auto-len _) _ rst ...) key)
+           (loop rst (+ len auto-len count))])))
 
 ;; Convert a prefab key to a shortened version
 (define (abbreviate-prefab-key key)

--- a/typed-racket-lib/typed-racket/types/prefab.rkt
+++ b/typed-racket-lib/typed-racket/types/prefab.rkt
@@ -14,7 +14,9 @@
                        [abbreviate-prefab-key
                         (-> prefab-key? prefab-key?)]
                        [prefab-key-subtype?
-                        (-> prefab-key? prefab-key? any)])
+                        (-> prefab-key? prefab-key? any)]
+                       [prefab-key->field-mutability
+                        (-> prefab-key? (listof boolean?))])
 
 ;; Convert a prefab key to its expanded version
 (define (normalize-prefab-key key field-length)
@@ -110,3 +112,16 @@
 (define (suffix? l1 l2)
   (for/or ([n (in-range (add1 (length l2)))])
     (equal? (drop l2 n) l1)))
+
+;; Returns a list of flags indicating the mutability of prefab struct types
+;; in order from parent to the children (#t is mutable, #f is not)
+;; Precondition: the key is fully expanded
+(define (prefab-key->field-mutability key)
+  (let loop ([key key])
+    (cond [(null? key) null]
+          [else
+           (match-define (list sym len auto mut parents ...) key)
+           (define mut-list (vector->list mut))
+           (append (loop parents)
+                   (for/list ([idx (in-range len)])
+                     (and (member idx mut-list) #t)))])))

--- a/typed-racket-lib/typed-racket/types/prefab.rkt
+++ b/typed-racket-lib/typed-racket/types/prefab.rkt
@@ -1,0 +1,112 @@
+#lang racket/base
+
+;; Utilities for dealing with prefab struct types
+
+(require "../utils/utils.rkt"
+         (contract-req)
+         racket/list
+         racket/match)
+
+(provide/cond-contract [normalize-prefab-key
+                        (-> prefab-key? integer? prefab-key?)]
+                       [prefab-key->field-count
+                        (-> prefab-key? integer?)]
+                       [abbreviate-prefab-key
+                        (-> prefab-key? prefab-key?)]
+                       [prefab-key-subtype?
+                        (-> prefab-key? prefab-key? any)])
+
+;; Convert a prefab key to its expanded version
+(define (normalize-prefab-key key field-length)
+  (cond [(symbol? key) `(,key ,field-length (0 #f) #())]
+        [(list? key)
+         (define base-sym (car key))
+         (define-values (base-clauses rst)
+           (splitf-at (cdr key) (λ (x) (not (symbol? x)))))
+         (define parent-fragments
+           (let loop ([key rst] [fragments null])
+             (cond [(null? key) fragments]
+                   [else
+                    (define-values (clauses rst)
+                      (splitf-at (cdr key) (λ (x) (not (symbol? x)))))
+                    (loop rst (cons (cons (car key) clauses)
+                                    fragments))])))
+         (define-values (processed-parents remaining-length)
+           (for/fold ([processed null]
+                      [field-length field-length])
+                     ([parent (in-list parent-fragments)])
+             (match parent
+               [(list _ n (and auto (list auto-n _)) _)
+                (values (cons parent processed)
+                        (- field-length n auto-n))]
+               [(list sym (? number? n) (and auto (list auto-n _)))
+                (values (cons `(,sym ,n ,auto #()) processed)
+                        (- field-length n auto-n))]
+               [(list sym (? number? n) (? vector? mut))
+                (values (cons `(,sym ,n (0 #f) ,mut) processed)
+                        (- field-length n))]
+               [(list sym n)
+                (values (cons `(,sym ,n (0 #f) #()) processed)
+                        (- field-length n))])))
+         (define processed-base
+           (match base-clauses
+             [(list n _ _) (cons base-sym base-clauses)]
+             [(list (? number? n) (and auto (list auto-n _)))
+              `(,base-sym ,n ,auto #())]
+             [(list (? number? n) (? vector? mut))
+              `(,base-sym ,n (0 #f) ,mut)]
+             [(list (and auto (list auto-n _)) (? vector? mut))
+              `(,base-sym ,(- remaining-length auto-n) ,auto ,mut)]
+             [(list (? number? n))
+              `(,base-sym ,n (0 #f) #())]
+             [(list (and auto (list auto-n _)))
+              `(,base-sym ,(- remaining-length auto-n) ,auto #())]
+             [(list (? vector? mut))
+              `(,base-sym ,remaining-length (0 #f) ,mut)]
+             [(list)
+              `(,base-sym ,remaining-length (0 #f) #())]))
+         (append processed-base (apply append processed-parents))]))
+
+;; Accepts a normalized prefab key and returns the number of fields
+;; a struct with this key should have
+(define (prefab-key->field-count key)
+  (let loop ([key key] [count 0])
+    (if (null? key)
+        count
+        (loop (cddddr key)
+              (+ (cadr key)
+                 (car (caddr key))
+                 count)))))
+
+;; Convert a prefab key to a shortened version
+(define (abbreviate-prefab-key key)
+  (let loop ([key key] [first? #t])
+    (cond [(null? key) null]
+          [(symbol? key) key]
+          [(list? key)
+           (define sym (car key))
+           (define-values (other-clauses rst)
+             (splitf-at (cdr key) (λ (x) (not (symbol? x)))))
+           (define simplified-clauses
+             (for/list ([elem (in-list other-clauses)]
+                        #:unless (and first? (number? elem))
+                        #:unless (and (list? elem)
+                                      (= (car elem) 0))
+                        #:unless (and (vector? elem)
+                                      (= (vector-length elem) 0)))
+               elem))
+           (if (and (null? simplified-clauses)
+                    (null? rst))
+               sym
+               (cons sym (append simplified-clauses
+                                 (loop rst #f))))])))
+
+;; Determine if the first prefab key can be a subtype of the second
+;; Invariant: the keys are fully expanded (normalized)
+(define (prefab-key-subtype? key1 key2)
+  (or (equal? key1 key2)
+      (suffix? key2 key1)))
+
+(define (suffix? l1 l2)
+  (for/or ([n (in-range (add1 (length l2)))])
+    (equal? (drop l2 n) l1)))

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -13,6 +13,7 @@
                   "types/kw-types.rkt"
                   "types/utils.rkt"
                   "types/resolve.rkt"
+                  "types/prefab.rkt"
                   "utils/utils.rkt"
                   "utils/tc-utils.rkt")
          (for-syntax racket/base syntax/parse))
@@ -406,6 +407,7 @@
     [(StructType: ty) `(Struct-Type ,(t->s ty))]
     [(StructTypeTop:) 'Struct-TypeTop]
     [(StructTop: (Struct: nm _ _ _ _ _)) `(Struct ,(syntax-e nm))]
+    [(Prefab: key fields) `(Prefab ,(abbreviate-prefab-key key) ,@fields)]
     [(BoxTop:) 'BoxTop]
     [(Weak-BoxTop:) 'Weak-BoxTop]
     [(ChannelTop:) 'ChannelTop]

--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -557,7 +557,17 @@
          [((Prefab: k1 ss) (Prefab: k2 ts))
           (and (prefab-key-subtype? k1 k2)
                (and (>= (length ss) (length ts))
-                    (subtypes* A0 (take ss (length ts)) ts)))]
+                    (for/fold ([A A0])
+                              ([s (in-list (take ss (length ts)))]
+                               [t (in-list ts)]
+                               [mut? (in-list (prefab-key->field-mutability k2))]
+                               #:break (not A))
+                      (and A
+                           (if mut?
+                               (subtype-seq A
+                                            (subtype* t s)
+                                            (subtype* s t))
+                               (subtype* A s t))))))]
          ;; subtyping on values is pointwise, except special case for Bottom
          [((Values: (list (Result: (== -Bottom) _ _))) _)
           A0]

--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -558,7 +558,7 @@
           (and (prefab-key-subtype? k1 k2)
                (and (>= (length ss) (length ts))
                     (for/fold ([A A0])
-                              ([s (in-list (take ss (length ts)))]
+                              ([s (in-list ss)]
                                [t (in-list ts)]
                                [mut? (in-list (prefab-key->field-mutability k2))]
                                #:break (not A))

--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -5,7 +5,7 @@
          (rep type-rep filter-rep object-rep rep-utils)
          (utils tc-utils early-return)
          (types utils resolve base-abbrev match-expanders
-                numeric-tower substitute current-seen)
+                numeric-tower substitute current-seen prefab)
          (for-syntax racket/base syntax/parse unstable/sequence))
 
 (lazy-require
@@ -554,6 +554,10 @@
          ;; subtyping on structs follows the declared hierarchy
          [((Struct: nm (? Type/c? parent) _ _ _ _) other)
           (subtype* A0 parent other)]
+         [((Prefab: k1 ss) (Prefab: k2 ts))
+          (and (prefab-key-subtype? k1 k2)
+               (and (>= (length ss) (length ts))
+                    (subtypes* A0 (take ss (length ts)) ts)))]
          ;; subtyping on values is pointwise, except special case for Bottom
          [((Values: (list (Result: (== -Bottom) _ _))) _)
           A0]

--- a/typed-racket-test/succeed/prefab.rkt
+++ b/typed-racket-test/succeed/prefab.rkt
@@ -1,0 +1,36 @@
+#lang typed/racket
+
+;; Test prefab struct declarations
+
+(struct foo ([x : Symbol]) #:prefab)
+(struct bar foo ([y : String] [z : String]) #:prefab)
+
+(: a-bar (Prefab (bar foo 1) Symbol String String))
+(define a-bar (bar 'foo "bar1" "bar2"))
+
+(foo-x (foo 'foo))
+(bar-y (bar 'foo "bar1" "bar2"))
+
+;; prefab keys may be normalized or not
+(: a-bar-2 (Prefab (bar 2 foo 1 (0 #f) #()) Symbol String String))
+(define a-bar-2 (bar 'foo "bar1" "bar2"))
+
+;; prefab subtyping is computed via the key and field length
+(: a-bar-3 (Prefab foo Symbol))
+(define a-bar-3 (bar 'foo "bar1" "bar2"))
+
+;; Mutable prefab structs
+
+(struct baz ([x : String]) #:mutable #:prefab)
+
+(define a-baz (baz "baz"))
+(set-baz-x! a-baz "baz2")
+(baz-x a-baz)
+
+;; Polymorphic prefab structs
+
+(struct (X) poly ([x : X]) #:prefab)
+
+(poly-x (poly "foo"))
+(poly-x (poly 3))
+(poly-x #s(poly "foo"))

--- a/typed-racket-test/unit-tests/all-tests.rkt
+++ b/typed-racket-test/unit-tests/all-tests.rkt
@@ -43,4 +43,5 @@
   "generalize-tests.rkt"
   "rep-tests.rkt"
   "prims-tests.rkt"
-  "tooltip-tests.rkt")
+  "tooltip-tests.rkt"
+  "prefab-tests.rkt")

--- a/typed-racket-test/unit-tests/parse-type-tests.rkt
+++ b/typed-racket-test/unit-tests/parse-type-tests.rkt
@@ -262,6 +262,10 @@
    [(String [#:a String] String * -> String)
     (->optkey -String [] #:rest -String #:a -String #f -String)]
 
+   ;;; Prefab structs
+   [(Prefab foo String) (-prefab 'foo -String)]
+   [FAIL (Prefab (foo 0) String)]
+
    ;;; Classes
    [(Class) (-class)]
    [(Class (init [x Number] [y Number]))

--- a/typed-racket-test/unit-tests/prefab-tests.rkt
+++ b/typed-racket-test/unit-tests/prefab-tests.rkt
@@ -1,0 +1,80 @@
+#lang racket/base
+
+;; Unit tests for prefab type helpres
+
+(require "test-utils.rkt"
+         racket/list
+         rackunit
+         typed-racket/types/prefab)
+
+(provide tests)
+(gen-test-main)
+
+(define-check (check-normalize key n norm)
+  (check-equal? (normalize-prefab-key key n) norm))
+
+;; check that the abbreviate function is consistent with how
+;; Racket abbreviates in the run-time
+(define-check (check-abbreviate key n)
+  (check-equal? (abbreviate-prefab-key key)
+                (prefab-struct-key
+                  (apply make-prefab-struct key (make-list n 0)))))
+
+(define tests
+ (test-suite
+  "Tests for prefab type helpers"
+  (check-normalize '(foo) 1 '(foo 1 (0 #f) #()))
+  (check-normalize '(foo) 3 '(foo 3 (0 #f) #()))
+  (check-normalize '(foo 1) 1 '(foo 1 (0 #f) #()))
+  (check-normalize '(foo 3) 3 '(foo 3 (0 #f) #()))
+  (check-normalize '(foo bar 3) 4 '(foo 1 (0 #f) #() bar 3 (0 #f) #()))
+  (check-normalize '(foo 3 bar 3) 6 '(foo 3 (0 #f) #() bar 3 (0 #f) #()))
+  (check-normalize '(foo 1 #()) 1 '(foo 1 (0 #f) #()))
+  (check-normalize '(foo 1 #(0)) 1 '(foo 1 (0 #f) #(0)))
+  (check-normalize '(foo 5 (0 #f)) 5 '(foo 5 (0 #f) #()))
+  (check-normalize '(foo 5 (1 #f)) 6 '(foo 5 (1 #f) #()))
+  (check-normalize '(foo 5 (0 #f) #()) 5 '(foo 5 (0 #f) #()))
+  (check-normalize '(foo bar 4) 7 '(foo 3 (0 #f) #() bar 4 (0 #f) #()))
+  (check-normalize '(foo (1 #f) bar 4) 8 '(foo 3 (1 #f) #() bar 4 (0 #f) #()))
+  (check-normalize '(foo #(1) bar 4) 7 '(foo 3 (0 #f) #(1) bar 4 (0 #f) #()))
+  (check-normalize '(foo bar 4 (1 #f)) 8 '(foo 3 (0 #f) #() bar 4 (1 #f) #()))
+  (check-normalize '(foo bar 1 baz 4 (1 #f))
+                   8
+                   '(foo 2 (0 #f) #() bar 1 (0 #f) #() baz 4 (1 #f) #()))
+
+  (check-equal? (prefab-key->field-count '(foo 1 (0 #f) #()))
+                1)
+  (check-equal? (prefab-key->field-count '(foo 1 (1 #f) #()))
+                2)
+  (check-equal? (prefab-key->field-count
+                 '(foo 1 (1 #f) #() bar 1 (0 #f) #()))
+                3)
+  (check-equal? (prefab-key->field-count
+                 '(foo 1 (1 #f) #() bar 1 (0 #f) #() baz 2 (0 #f) #()))
+                5)
+
+  (check-abbreviate '(foo) 1)
+  (check-abbreviate '(foo 1) 1)
+  (check-abbreviate '(foo 3) 3)
+  (check-abbreviate '(foo bar 3) 4)
+  (check-abbreviate '(foo 3 bar 3) 6)
+  (check-abbreviate '(foo 1 #()) 1)
+  (check-abbreviate '(foo 1 #(0)) 1)
+  (check-abbreviate '(foo 5 (0 #f)) 5)
+  (check-abbreviate '(foo 5 (1 #f)) 6)
+  (check-abbreviate '(foo 5 (0 #f) #()) 5)
+  (check-abbreviate '(foo 5 (1 #f) #()) 6)
+  (check-abbreviate '(foo 5 (0 #f) #(1)) 5)
+  (check-abbreviate '(foo 5 (1 #f) #(1)) 6)
+  (check-abbreviate '(foo 5 (0 #f) #() bar 1) 6)
+  (check-abbreviate '(foo 5 (0 #f) #(1) bar 1) 6)
+  (check-abbreviate '(foo 5 (1 #f) #(1) bar 1) 7)
+  (check-abbreviate '(foo 5 (1 #f) #(1) bar 1 #()) 7)
+  (check-abbreviate '(foo 5 (0 #f) #(1) bar 1 #()) 6)
+  (check-abbreviate '(foo 5 (0 #f) #() bar 1 #()) 6)
+  (check-abbreviate '(foo 5 (1 #f) #(1) bar 1 #(0)) 7)
+
+  (check-true (prefab-key-subtype? '(foo 1 (0 #f) #() bar 1 (0 #f) #())
+                                   '(bar 1 (0 #f) #())))
+  (check-false (prefab-key-subtype? '(foo 1 (0 #f) #())
+                                    '(bar 1 (0 #f) #())))))

--- a/typed-racket-test/unit-tests/prefab-tests.rkt
+++ b/typed-racket-test/unit-tests/prefab-tests.rkt
@@ -77,4 +77,14 @@
   (check-true (prefab-key-subtype? '(foo 1 (0 #f) #() bar 1 (0 #f) #())
                                    '(bar 1 (0 #f) #())))
   (check-false (prefab-key-subtype? '(foo 1 (0 #f) #())
-                                    '(bar 1 (0 #f) #())))))
+                                    '(bar 1 (0 #f) #())))
+
+  (check-equal? (prefab-key->field-mutability
+                 '(foo 1 (0 #f) #() bar 1 (0 #f) #()))
+                (list #f #f))
+  (check-equal? (prefab-key->field-mutability
+                 '(foo 2 (0 #f) #(0) bar 3 (0 #f) #(1)))
+                (list #f #t #f #t #f))
+  (check-equal? (prefab-key->field-mutability
+                 '(foo 2 (0 #f) #(0) bar 3 (0 #f) #(1) baz 1 (0 #f) #(0)))
+                (list #t #f #t #f #t #f))))

--- a/typed-racket-test/unit-tests/subtype-tests.rkt
+++ b/typed-racket-test/unit-tests/subtype-tests.rkt
@@ -347,4 +347,18 @@
    [FAIL
     (-class #:method ((m (-> -Nat))) #:augment ((m (-> -Nat))))
     (-class #:method ((m (-> -Nat))))]
+
+   ;; prefab structs
+   [(-prefab 'foo -String) (-prefab 'foo -String)]
+   [(-prefab 'foo -String) (-prefab 'foo (-opt -String))]
+   [(-prefab '(bar foo 1) -String -Symbol) (-prefab 'foo -String)]
+   [(-prefab '(bar foo 1) -String -Symbol) (-prefab 'foo (-opt -String))]
+   [FAIL
+    (-prefab '(foo #(0)) -String) (-prefab '(foo #(0)) (-opt -String))]
+   [(-prefab '(foo 1 #(0)) -String -Symbol)
+    (-prefab '(foo #(0)) -String)]
+   [(-prefab '(bar foo 1 #(0)) -String -Symbol)
+    (-prefab '(foo #(0)) -String)]
+   [FAIL
+    (-prefab '(foo #()) -String) (-prefab '(foo #(0)) (-opt -String))]
    ))

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -96,6 +96,10 @@
   ;; test: syntax? tc-results? [(option/c tc-results?)]
   ;;       [(listof (list id type))] -> void?
   ;; Checks that the expression typechecks using the expected type to the golden result.
+  ;;
+  ;; The new-mapping argument (here and in subsequent functions) is used to extend the
+  ;; lexical type environment in the test case with additional bindings. Its use is to
+  ;; simulate forms that are difficult to put in unit tests, like `struct`.
   (define (test expr golden (expected #f) (new-mapping '()))
     (test/proc expr (lambda (_) golden) expected new-mapping))
 

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -39,7 +39,7 @@
     (for-template (only-in typed-racket/typed-racket do-standard-inits))
     (typecheck typechecker check-below)
     (utils mutated-vars tc-utils)
-    (env mvar-env))
+    (env lexical-env mvar-env))
   (provide
     test-literal test-literal/fail
     test test/proc test/fail)
@@ -93,25 +93,31 @@
                #:expected golden
                (string-append base-message extra-message1 extra-message2)))))
 
-  ;; test: syntax? tc-results? [(option/c tc-results?)] -> void?
+  ;; test: syntax? tc-results? [(option/c tc-results?)]
+  ;;       [(listof (list id type))] -> void?
   ;; Checks that the expression typechecks using the expected type to the golden result.
-  (define (test expr golden (expected #f))
-    (test/proc expr (lambda (_) golden) expected))
+  (define (test expr golden (expected #f) (new-mapping '()))
+    (test/proc expr (lambda (_) golden) expected new-mapping))
 
-  ;; test/proc: syntax? (syntax? -> tc-results?) [(option/c tc-results?)] -> void?
+  ;; test/proc: syntax? (syntax? -> tc-results?) [(option/c tc-results?)]
+  ;;            [(listof (list id type))] -> void?
   ;; Checks that the expression typechecks to golden result. The golden result is computed by applying
   ;; the golden function to the expanded syntax of the expression.
-  (define (test/proc expr golden-fun (expected #f))
+  (define (test/proc expr golden-fun (expected #f) (new-mapping '()))
     (define expanded-expr (tr-expand expr))
-    (define result (tc expanded-expr expected))
+    (define result (with-lexical-env/extend-types
+                     (map car new-mapping)
+                     (map cadr new-mapping)
+                     (tc expanded-expr expected)))
     (define golden (golden-fun expanded-expr))
     (check-tc-results result golden #:name "tc-expr"))
 
 
-  ;; test/fail syntax? tc-results? (or/c string? regexp?) (option/c tc-results?) -> void?
+  ;; test/fail syntax? tc-results? (or/c string? regexp?) (option/c tc-results?)
+  ;;           [(listof (list id type))] -> void?
   ;; Checks that the expression doesn't typecheck using the expected type, returns the golden type,
   ;; and raises an error message matching the golden message
-  (define (test/fail code golden message expected)
+  (define (test/fail code golden message expected (new-mapping '()))
     (dynamic-wind
       void
       (λ ()
@@ -125,7 +131,10 @@
                                         "tc-expr raised the wrong error message")))))])
           (define result
             (parameterize ([delay-errors? #t])
-              (tc (tr-expand code) expected)))
+              (with-lexical-env/extend-types
+                (map car new-mapping)
+                (map cadr new-mapping)
+                (tc (tr-expand code) expected))))
           (check-tc-results result golden #:name "tc-expr")
           (report-first-error)
           (raise (cross-phase-failure
@@ -195,6 +204,11 @@
     (pattern (~seq #:expected v:expr))
     (pattern (~seq) #:attr v #'#f))
 
+  (define-splicing-syntax-class extend-env
+    (pattern (~seq #:extend-env ([name:id type:expr] ...))
+             #:with v #'(list (list (quote-syntax name) type) ...))
+    (pattern (~seq) #:attr v #''()))
+
   ;; for specifying the error message in a test
   (define-splicing-syntax-class expected-msg
     (pattern (~seq #:msg v:expr))
@@ -222,10 +236,10 @@
      (quasisyntax/loc stx
        (test-phase1 code
          (test/proc (quote-syntax code) p)))]
-    [(_ code:expr return:return ex:expected)
+    [(_ code:expr return:return ex:expected env:extend-env)
      (quasisyntax/loc stx
        (test-phase1 code
-         (test (quote-syntax code) return.v ex.v)))]))
+         (test (quote-syntax code) return.v ex.v env.v)))]))
 
 (define-syntax (tc-e/t stx)
   (syntax-parse stx
@@ -243,10 +257,10 @@
 ;; check that typechecking this expression fails
 (define-syntax (tc-err stx)
   (syntax-parse stx
-    [(_ code:expr ret:err-return ex:expected msg:expected-msg)
+    [(_ code:expr ret:err-return ex:expected env:extend-env msg:expected-msg)
      (quasisyntax/loc stx
         (test-phase1 #,(syntax/loc #'code (FAIL code))
-           (test/fail (quote-syntax code) ret.v msg.v ex.v)))]))
+           (test/fail (quote-syntax code) ret.v msg.v ex.v env.v)))]))
 
 (define-syntax (tc-l/err stx)
   (syntax-parse stx


### PR DESCRIPTION
The main thing that is missing from this PR is contract generation support. It turns out that the contract system doesn't provide a suitable contract combinator for prefab structs, so we'll have to make one. I'm planning to follow up with that in a separate PR.

The first few commits and 04ac72e are misc commits that are related (came up while developing) but aren't directly about prefabs.

Other missing features: individually mutable fields, support for auto-values, and typechecking for functions like `make-prefab-struct`.

For the first two, I'm planning to generally improve struct support (not just prefabs) in a separate PR.