### PR TITLE
Add missing type signatures for net/uri-codec

### DIFF
--- a/typed-racket-more/typed/net/uri-codec.rkt
+++ b/typed-racket-more/typed/net/uri-codec.rkt
@@ -6,9 +6,21 @@
   [uri-encode ( String -> String )]
   [uri-decode ( String -> String )]
 
+  [uri-path-segment-encode (-> String String)]
+  [uri-path-segment-decode (-> String String)]
+
+  [uri-userinfo-encode (-> String String)]
+  [uri-userinfo-decode (-> String String)]
+
+  [uri-unreserved-encode (-> String String)]
+  [uri-unreserved-decode (-> String String)]
+
+  [uri-path-segment-unreserved-encode (-> String String)]
+  [uri-path-segment-unreserved-decode (-> String String)]
+
   [form-urlencoded-encode ( String -> String )]
   [form-urlencoded-decode ( String -> String )]
 
   [alist->form-urlencoded ( (Listof (cons Symbol String)) -> String )]
   [form-urlencoded->alist ( String -> (Listof (cons Symbol String)) )]
-  [current-alist-separator-mode (Parameter Symbol)])
+  [current-alist-separator-mode (Parameter (U 'amp 'semi 'amp-or-semi 'semi-or-amp))])


### PR DESCRIPTION
While trying to use uri-unreserved-encode discovered it and several other functions in net/uri-codec were not provided by typed/net/uri-codec

Have added the missing type signatures for these unctions. Have also made the signature of current-alist-separator-mode more precise, as previously it would typecheck when you passed it an invalid value.