### PR TITLE
Prevent type alias placeholders from collapsing in unions with symbols

### DIFF
--- a/typed-racket-lib/typed-racket/env/type-alias-helper.rkt
+++ b/typed-racket-lib/typed-racket/env/type-alias-helper.rkt
@@ -90,8 +90,8 @@
     (register-type-name
      id
      (if args
-         (make-Poly (map syntax-e args) (make-Value (gensym)))
-         (make-Value (gensym))))
+         (make-Poly (map syntax-e args) -Alias-Placeholder)
+         -Alias-Placeholder))
     (values id (list id type-stx args))))
 
 ;; register-all-type-aliases : Listof<Id> Dict<Id, TypeAliasInfo> -> Void

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -6,6 +6,7 @@
 ;; extends it with more types and type abbreviations.
 
 (require "../utils/utils.rkt"
+         "../utils/tc-utils.rkt"
          (rep type-rep filter-rep object-rep rep-utils)
          (env mvar-env)
          racket/match racket/list (prefix-in c: (contract-req))
@@ -51,6 +52,11 @@
 ;; Needed for evt checking in subtype.rkt
 (define/decl -Symbol (make-Base 'Symbol #'symbol? symbol? #f))
 (define/decl -String (make-Base 'String #'string? string? #f))
+
+;; Used by type-alias-helper.rkt for recursive alias placeholder values
+(define/decl -Alias-Placeholder (make-Base 'Alias-Placeholder
+                                           #'(int-err "Encountered unresolved alias placeholder")
+                                           (lambda _ #f) #f))
 
 ;; Void is needed for Params
 (define/decl -Void (make-Base 'Void #'void? void? #f))

--- a/typed-racket-test/succeed/gh-issue-26.rkt
+++ b/typed-racket-test/succeed/gh-issue-26.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket
+
+(define-type T1 (Listof (U T2 Symbol)))
+(define-type T2 (Setof (U T1 Symbol)))
+
+(: x1 T1)
+(define x1 (list (set 'foo)))
+
+(: x2 T2)
+(define x2 (set (list 'foo)))


### PR DESCRIPTION
This implements the solution proposed by @takikawa for issue #26. It also includes his example as an integration test. All existing tests pass with this change.