### PR TITLE
Adjust the fix in 619d6945c3263d21e

### DIFF
--- a/typed-racket-lib/typed-racket/env/type-name-env.rkt
+++ b/typed-racket-lib/typed-racket/env/type-name-env.rkt
@@ -11,6 +11,7 @@
          (types utils))
 
 (provide register-type-name
+         remove-type-name
          lookup-type-name
          register-type-names
          add-alias
@@ -35,6 +36,10 @@
 ;; listof[identifier] listof[type] -> void
 (define (register-type-names ids types)
   (for-each register-type-name ids types))
+
+;; remove a name from the mapping
+(define (remove-type-name id)
+  (free-id-table-remove! the-mapping id))
 
 ;; given an identifier, return the type associated with it
 ;; optional argument is failure continuation - default calls lookup-fail

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -6,7 +6,6 @@
 ;; extends it with more types and type abbreviations.
 
 (require "../utils/utils.rkt"
-         "../utils/tc-utils.rkt"
          (rep type-rep filter-rep object-rep rep-utils)
          (env mvar-env)
          racket/match racket/list (prefix-in c: (contract-req))
@@ -52,11 +51,6 @@
 ;; Needed for evt checking in subtype.rkt
 (define/decl -Symbol (make-Base 'Symbol #'symbol? symbol? #f))
 (define/decl -String (make-Base 'String #'string? string? #f))
-
-;; Used by type-alias-helper.rkt for recursive alias placeholder values
-(define/decl -Alias-Placeholder (make-Base 'Alias-Placeholder
-                                           #'(int-err "Encountered unresolved alias placeholder")
-                                           (lambda _ #f) #f))
 
 ;; Void is needed for Params
 (define/decl -Void (make-Base 'Void #'void? void? #f))

--- a/typed-racket-test/succeed/gh-issue-26.rkt
+++ b/typed-racket-test/succeed/gh-issue-26.rkt
@@ -8,3 +8,14 @@
 
 (: x2 T2)
 (define x2 (set (list 'foo)))
+
+;; Demonstrates a bug in the initial fix
+(define-type S2 (U Null (Pairof String S2)))
+(define-type S3 (U Null (Pairof Integer S3)))
+(define-type S1 (Listof (U S1 S2 S3)))
+
+(: y1 S1)
+(define y1 (list (cons "foo" null)))
+
+(: y2 S1)
+(define y2 (list (cons 3 null)))


### PR DESCRIPTION
For unions of multiple type aliases the new placeholder would cause union collapsing incorrectly. Put an uninterned symbol in the placeholder types to avoid this.

@samth @lexi-lambda any feedback?