### PR TITLE
adjustments to accommodate a different macro system

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/colon.rkt
+++ b/typed-racket-lib/typed-racket/base-env/colon.rkt
@@ -44,7 +44,7 @@
                      "Declaration for `~a' provided, but `~a' has no definition"
                      (syntax-e #'i)
                      (syntax-e #'i)))
-     (syntax-property (syntax/loc stx (begin (quote-syntax (:-internal i ty))
+     (syntax-property (syntax/loc stx (begin (quote (:-internal i ty))
                                              (#%plain-app values)))
                       'disappeared-use #'i)]
     [(_ orig-stx _ i:id x ...)

--- a/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -61,7 +61,7 @@
 (define-syntax-class internal-class-data
   #:literal-sets (kernel-literals)
   #:literals (class-internal values)
-  (pattern (let-values ([() (begin (quote-syntax
+  (pattern (let-values ([() (begin (quote
                                     (class-internal
                                      (#:forall type-parameter:id ...)
                                      (#:all-inits all-init-names:id ...)
@@ -173,7 +173,7 @@
   #:literals (values void :-internal)
   #:attributes (name type)
   (pattern (let-values
-             ([() (begin (quote-syntax (:-internal name:id type:expr))
+             ([() (begin (quote (:-internal name:id type:expr))
                          (#%plain-app values))])
              (#%plain-app void))))
 
@@ -659,7 +659,7 @@
            (hash-set! annotations name type))
          other-exprs]
         ;; FIXME: use internal-forms for this instead
-        [(quote-syntax (:-augment name-stx:id type-stx))
+        [(quote (:-augment name-stx:id type-stx))
          (define name (syntax-e #'name-stx))
          (define type (parse-type #'type-stx))
          (unless (check-duplicate-member augment-annotations name type)

--- a/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
@@ -75,11 +75,11 @@
 (define-syntax-class internal^
    #:attributes (value)
    #:literal-sets (kernel-literals internal-form-literals)
-   (pattern (define-values () (begin (quote-syntax value:expr) (#%plain-app values))))
+   (pattern (define-values () (begin (quote value:expr) (#%plain-app values))))
    ;; handles form that splicing-syntax-parameterize expands to
-   (pattern (define-values () (letrec-syntaxes+values _ () (quote-syntax value:expr) (#%plain-app values))))
+   (pattern (define-values () (letrec-syntaxes+values _ () (quote value:expr) (#%plain-app values))))
    ;; for use in forms like classes that transform definitions
-   (pattern (let-values ([() (begin (quote-syntax value:expr) (#%plain-app values))])
+   (pattern (let-values ([() (begin (quote value:expr) (#%plain-app values))])
               (#%plain-app void))))
 
 (define-syntax (define-internal-classes stx)
@@ -125,7 +125,7 @@
 ;; the `define-values` protocol used for other internal forms.
 (define-syntax-class typecheck-failure
   #:literal-sets (kernel-literals internal-literals)
-  (pattern (quote-syntax (typecheck-fail-internal stx message:str var))))
+  (pattern (quote (typecheck-fail-internal stx message:str var))))
 
 ;;; Internal form creation
 (begin-for-syntax
@@ -133,5 +133,5 @@
     (quasisyntax/loc stx
       (define-values ()
         (begin
-          (quote-syntax #,stx)
+          (quote #,stx)
           (#%plain-app values))))))

--- a/typed-racket-lib/typed-racket/typecheck/tc-let-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-let-unit.rkt
@@ -184,16 +184,16 @@
 
   ;; Set up vertices for Tarjan's algorithm, where each letrec-values
   ;; clause is a vertex but mapped in the table for each of the clause names
-  (define vertices (make-bound-id-table))
+  (define vertices (make-free-id-table))
   (for ([clause other-clauses])
     (match-define (lr-clause names expr) clause)
     (define relevant-free-vars
       (for/list ([var (in-list (free-vars expr))]
-                 #:when (member var flat-names bound-identifier=?))
+                 #:when (member var flat-names free-identifier=?))
         var))
     (define vertex (make-vertex clause relevant-free-vars))
     (for ([name (in-list names)])
-      (bound-id-table-set! vertices name vertex)))
+      (free-id-table-set! vertices name vertex)))
 
   (define components (tarjan vertices))
 
@@ -201,7 +201,7 @@
   (define (no-self-cycle? vertex)
     (match-define (lr-clause names _) (vertex-data vertex))
     (for/and ([id (in-list names)])
-      (andmap (λ (id2) (not (bound-identifier=? id id2)))
+      (andmap (λ (id2) (not (free-identifier=? id id2)))
               (vertex-adjacent vertex))))
 
   ;; The components with only one entry are non-recursive if they also

--- a/typed-racket-more/typed/untyped-utils.rkt
+++ b/typed-racket-more/typed/untyped-utils.rkt
@@ -43,10 +43,15 @@
                     [(untyped3-name ...)  (generate-temporaries #'(name ...))]
                     [(macro-name ...)  (generate-temporaries #'(name ...))]
                     [typed-module  (generate-temporary #'typed-module)]
-                    [untyped-module  (generate-temporary #'untyped-module)])
+                    [untyped-module  (generate-temporary #'untyped-module)]
+                    [*typed/racket/base (datum->syntax #'from-module-spec
+                                                       'typed/racket/base)]
+                    [*require (datum->syntax #'from-module-spec
+                                             'require)])
        (syntax/loc stx
          (begin
-           (module typed-module typed/racket/base
+           (module typed-module *typed/racket/base ; to bind in `T`s
+             (*require typed/racket/base) ; to bind introduced `begin`, etc.
              (begin form ...)
              (require (rename-in (only-in from-module-spec name ...)
                                  [name untyped2-name] ...))


### PR DESCRIPTION
These changes make TR work with both the current macro expander and one that has a different underlying model of binding (but is only slightly different on the outside).