### PR TITLE
`define-runtime-module-path-index` for reference to a contract submodule

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -437,8 +437,19 @@
             ;; `typed/racket`. That makes for confusing non-local
             ;; dependencies, though, so we do it here. 
             (require typed-racket/utils/redirect-contract)
+            ;; We need a submodule for a for-syntax use of
+            ;; `define-runtime-module-path`:
+            (module #%contract-defs-reference racket/base
+              (require racket/runtime-path
+                       (for-syntax racket/base))
+              (define-runtime-module-path-index contract-defs-submod
+                '(submod ".." #%contract-defs))
+              (provide contract-defs-submod))
+            (require (submod "." #%contract-defs-reference))
+            ;; Create the redirection funtion using a reference to
+            ;; the submodule that is friendly to `raco exe`:
             (define mk-redirect
-              (make-make-redirect-to-contract (#%variable-reference))))
+              (make-make-redirect-to-contract contract-defs-submod)))
 
            ;; This submodule contains all the definitions of
            ;; contracted identifiers. For an exported definition like

--- a/typed-racket-lib/typed-racket/utils/redirect-contract.rkt
+++ b/typed-racket-lib/typed-racket/utils/redirect-contract.rkt
@@ -23,15 +23,12 @@
 ;; This code was originally written by mflatt for the plai-typed
 ;; language, and then slightly adapted for TR by samth.
 
-(define ((make-make-redirect-to-contract varref) id)
+(define ((make-make-redirect-to-contract contract-defs-submod-modidx) id)
   (define (redirect stx)
     (cond
      [(identifier? stx)
       (with-syntax ([mp (collapse-module-path-index
-                           (module-path-index-join
-                            '(submod "." #%contract-defs)
-                            (variable-reference->module-path-index
-                             varref)))]
+                         contract-defs-submod-modidx)]
                     [i (datum->syntax id (syntax-e id) stx stx)])
         #`(let ()
             (local-require (only-in mp [#,(datum->syntax #'mp (syntax-e #'i)) i]))


### PR DESCRIPTION
This change is meant to fix problems with `raco exe` --- along with a repair in `raco exe`.