### PR TITLE
Adjust named-let to use the return type annotation whenever possible

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -439,26 +439,29 @@ This file defines two sorts of primitives. All of them are provided into any mod
            (~and (~seq (~optional (~seq : ret-ty))
                        (bs:optionally-annotated-binding ...) body ...)
                  (~seq rest ...)))
-     (quasisyntax/loc stx
-       (#,(syntax-parse #'(rest ...)
-            #:literals (:)
-            [(: ret-ty (bs:annotated-binding ...) . body)
-             (quasisyntax/loc stx
-               (-letrec ([nm : (bs.ty ... -> ret-ty)
-                             #,(quasisyntax/loc stx
-                                 (lambda (bs.ann-name ...) . #,(syntax/loc stx body)))])
-                        #,(quasisyntax/loc stx nm)))]
-            [(: ret-ty (bs:optionally-annotated-binding ...) body ... bod)
-             (quasisyntax/loc stx
-               (letrec ([nm #,(quasisyntax/loc stx
-                                (lambda (bs.ann-name ...) body ... (ann #,(syntax/loc stx bod) ret-ty)))])
-                 #,(quasisyntax/loc stx nm)))]
-            [((bs:optionally-annotated-binding ...) . body)
-             (quasisyntax/loc stx
-               (letrec ([nm #,(quasisyntax/loc stx
-                                (lambda (bs.ann-name ...) . #,(syntax/loc stx body)))])
-                 #,(quasisyntax/loc stx nm)))])
-        bs.rhs ...))]
+     (syntax-parse #'(rest ...)
+       #:literals (:)
+       [(: ret-ty (bs:annotated-binding ...) . body)
+        (quasisyntax/loc stx
+          ((-letrec ([nm : (bs.ty ... -> ret-ty)
+                         #,(quasisyntax/loc stx
+                             (lambda (bs.ann-name ...) . #,(syntax/loc stx body)))])
+                    #,(quasisyntax/loc stx nm))
+           bs.rhs ...))]
+       [(: ret-ty (bs:optionally-annotated-binding ...) body ... bod)
+        (quasisyntax/loc stx
+          (ann
+           ((letrec ([nm #,(quasisyntax/loc stx
+                             (lambda (bs.ann-name ...) body ... (ann #,(syntax/loc stx bod) ret-ty)))])
+              #,(quasisyntax/loc stx nm))
+            bs.rhs ...)
+           ret-ty))]
+       [((bs:optionally-annotated-binding ...) . body)
+        (quasisyntax/loc stx
+          ((letrec ([nm #,(quasisyntax/loc stx
+                            (lambda (bs.ann-name ...) . #,(syntax/loc stx body)))])
+             #,(quasisyntax/loc stx nm))
+           bs.rhs ...))])]
     [(-let vars:lambda-type-vars
            ([bn:optionally-annotated-name e] ...)
            . rest)

--- a/typed-racket-test/succeed/gh-issue-43.rkt
+++ b/typed-racket-test/succeed/gh-issue-43.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket
+
+(let loop : Integer ([n 10])
+  (cond
+    [(= n 5) n]
+    [else (loop (sub1 n))]))
+
+(let loop : Integer ([n : Integer 10])
+  (cond
+    [(= n 5) n]
+    [else (loop (sub1 n))]))


### PR DESCRIPTION
Fixes #43. This just adds an explicit annotation around the entire `let` expression to enforce the return type while still maintaining type inference on the bindings.