### PR TITLE
Fix the types for pin-over and pin-under in typed/pict

### DIFF
--- a/typed-racket-more/typed/pict.rkt
+++ b/typed-racket-more/typed/pict.rkt
@@ -166,15 +166,17 @@
 
  [pin-over
   (cl->*
-    (-> -pict -Real -Real -pict)
+    (-> -pict -Real -Real -pict -pict)
     (-> -pict -pict-path
         (-> -pict -pict-path (-values (list -Real -Real)))
+        -pict
         -pict))]
  [pin-under
   (cl->*
-    (-> -pict -Real -Real -pict)
+    (-> -pict -Real -Real -pict -pict)
     (-> -pict -pict
         (-> -pict -pict (-values (list -Real -Real)))
+        -pict
         -pict))]
 
  [table


### PR DESCRIPTION
Self-explanatory; these types were just missing a parameter for each case.