### PR TITLE
Modernize typed/net/url

### DIFF
--- a/typed-racket-more/typed/net/url-connect.rkt
+++ b/typed-racket-more/typed/net/url-connect.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/base
+
+(require typed/openssl
+         typed/openssl/types)
+
+(require/typed/provide
+ net/url-connect
+ [current-https-protocol (U SSL-Client-Context SSL-Protocol)])

--- a/typed-racket-more/typed/net/url-structs.rkt
+++ b/typed-racket-more/typed/net/url-structs.rkt
@@ -1,0 +1,20 @@
+#lang typed/racket/base
+
+(require/typed/provide
+ net/url-structs
+ [#:struct path/param
+           ([path : (U String 'up 'same)]
+            [param : (Listof String)])]
+ [#:struct url
+           ([scheme : (Option String)]
+            [user : (Option String)]
+            [host : (Option String)]
+            [port : (Option Natural)]
+            [path-absolute? : Boolean]
+            [path : (Listof path/param)]
+            [query : (Listof (Pairof Symbol (Option String)))]
+            [fragment : (Option String)])])
+
+(define-type Path/Param path/param)
+(define-type URL url)
+(provide Path/Param URL)

--- a/typed-racket-more/typed/net/url.rkt
+++ b/typed-racket-more/typed/net/url.rkt
@@ -1,86 +1,77 @@
 #lang typed/racket/base
 
-(require typed/private/utils)
+;; net/url-structs
+(require typed/net/url-structs)
+(provide (all-from-out typed/net/url-structs))
 
-(require-typed-struct/provide path/param ([path : (U String 'up 'same)] [param : (Listof String)]) net/url)
+;; opaque types
+(require/typed/provide
+ net/url
+ [#:opaque URL-Exception url-exception?]
+ [#:opaque HTTP-Connection http-connection?])
 
-(require-typed-struct/provide
- url ([scheme : (Option String)]
-      [user : (Option String)]
-      [host : (Option String)]
-      [port : (Option Integer)]
-      [path-absolute? : Boolean]
-      [path : (Listof path/param)]
-      [query : (Listof (Pair Symbol (Option String)))]
-      [fragment : (Option String)])
- net/url)
 
-(require/opaque-type URL-Exception url-exception? net/url)
-(provide URL-Exception url-exception?)
-
-(require/opaque-type HTTP-Connection http-connection? net/url)
-(provide HTTP-Connection http-connection?)
-
-(define-type-alias PortT (case-lambda (url -> Input-Port) (url (Listof String)-> Input-Port)))
-(define-type-alias PortT/String (case-lambda (url String -> Input-Port) (url String (Listof String)-> Input-Port)))
-(define-type-alias PortT/Bytes (case-lambda (url Bytes -> Input-Port) (url Bytes (Listof String)-> Input-Port)))
+;; convenience type aliases
+;; PortT/String is unused, but was provided by earlier versions of this module, so it's included here
+(define-type PortT ([URL] [(Listof String)] . ->* . Input-Port))
+(define-type PortT/String ([URL] [String (Listof String)] . ->* . Input-Port))
+(define-type PortT/Bytes ([URL] [Bytes (Listof String)] . ->* . Input-Port))
 (provide PortT PortT/String PortT/Bytes)
 
-(require/typed/provide net/url
-
-  [path->url (Path-String -> url)]
-  [url->path (case-lambda (url -> Path) (url (U 'unix 'windows) -> Path))]
-
-  [file-url-path-convention-type (Parameter (U 'unix 'windows))]
-
-  [get-pure-port
-   (case-> (url [#:redirections Natural] -> Input-Port)
-           (url (Listof String) [#:redirections Natural] -> Input-Port))]
-  [head-pure-port PortT]
-  [delete-pure-port PortT]
-
-  [get-impure-port PortT]
-  [head-impure-port PortT]
-  [delete-impure-port PortT]
-
-  [post-pure-port PortT/Bytes]
-  [put-pure-port PortT/Bytes]
-
-  [post-impure-port PortT/Bytes]
-  [put-impure-port PortT/Bytes]
-
-  [display-pure-port (Input-Port -> Void)]
-  [purify-port (Input-Port -> String)]
-
-  [get-pure-port/headers
-   (case-> (url [#:redirections Natural]
-                [#:status? Boolean]
-                [#:connection (Option HTTP-Connection)]
-                -> (values Input-Port String))
-           (url (Listof String)
-                [#:redirections Natural]
-                [#:status? Boolean]
-                [#:connection (Option HTTP-Connection)]
-                -> (values Input-Port String)))]
-
-  [make-http-connection (-> HTTP-Connection)]
-  [http-connection-close (HTTP-Connection -> Void)]
-
-  [call/input-url (All (T) (case-lambda
-                             [url (url -> Input-Port) (Input-Port -> T) -> T]
-                             [url (url (Listof String) -> Input-Port) (Input-Port -> T) (Listof String) -> T]))]
-
-  [current-proxy-servers (Parameter (Listof (List String String Integer)))]
-
-  [http-sendrecv/url
-   (url [#:method (U Bytes String Symbol)]
-        [#:headers (Listof (U Bytes String))]
-        [#:data (Option (U Bytes String))]
-        [#:content-decode (Listof Symbol)]
-        -> (values Bytes (Listof Bytes) Input-Port))]
-
-  [netscape/string->url (String -> url)]
-  [string->url (String -> url)]
-  [url->string (url -> String)]
-  [combine-url/relative (url String -> url)])
+(require/typed/provide
+ net/url
+ 
+ [string->url (String -> URL)]
+ [combine-url/relative (URL String -> URL)]
+ [netscape/string->url (String -> URL)]
+ [url->string (URL -> String)]
+ 
+ [path->url ((U Path-String Path-For-Some-System) -> URL)]
+ [url->path ([URL] [(U 'unix 'windows)] . ->* . Path-For-Some-System)]
+ [relative-path->relative-url-string ((U Path-String Path-For-Some-System) -> String)]
+ 
+ [file-url-path-convention-type (Parameterof (U 'unix 'windows))]
+ [current-url-encode-mode (Parameterof (U 'recommended 'unreserved))]
+ 
+ [get-pure-port ([URL] [(Listof String) #:redirections Natural] . ->* . Input-Port)]
+ [head-pure-port PortT]
+ [delete-pure-port PortT]
+ 
+ [get-impure-port PortT]
+ [head-impure-port PortT]
+ [delete-impure-port PortT]
+ 
+ [post-pure-port PortT/Bytes]
+ [put-pure-port PortT/Bytes]
+ 
+ [post-impure-port PortT/Bytes]
+ [put-impure-port PortT/Bytes]
+ 
+ [display-pure-port (Input-Port -> Void)]
+ [purify-port (Input-Port -> String)]
+ 
+ [get-pure-port/headers ([URL]
+                         [(Listof String)
+                          #:redirections Natural
+                          #:status? Boolean
+                          #:connection (Option HTTP-Connection)]
+                         . ->* . (Values Input-Port String))]
+ 
+ [make-http-connection (-> HTTP-Connection)]
+ [http-connection-close (HTTP-Connection -> Void)]
+ 
+ [call/input-url
+  (All [a] (case->
+            [URL (URL -> Input-Port) (Input-Port -> a) -> a]
+            [URL (URL (Listof String) -> Input-Port) (Input-Port -> a) (Listof String) -> a]))]
+ 
+ [current-proxy-servers (Parameterof (Listof (List String String Integer)))]
+ 
+ [http-sendrecv/url
+  (URL
+   [#:method (U Bytes String Symbol)]
+   [#:headers (Listof (U Bytes String))]
+   [#:data (Option (U Bytes String))]
+   [#:content-decode (Listof Symbol)]
+   -> (Values Bytes (Listof Bytes) Input-Port))])
 


### PR DESCRIPTION
This updates `typed/net/url` with the following changes:

- Uses more modern TR forms instead of the older, legacy forms.
- Functions previously declared using `case->` now use `->*` when appropriate.
- Includes some additional functions from `net/url` that were missing.
- The `typed/net/url-structs` and `typed/net/url-connect` modules have been spun off to be equivalent to their untyped counterparts.
- The type alias `URL` has been added for the `url` struct to fit with naming conventions.