### PR TITLE
Fix expansion of keyword types in kw-convert

### DIFF
--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -317,12 +317,17 @@
 
 (define SomeValues/c (or/c Values? AnyValues? ValuesDots?))
 
+(define (keyword-sorted/c kws)
+  (or (empty? kws)
+      (= (length kws) 1)
+      (apply keyword<? (map Keyword-kw kws))))
+
 ;; arr is NOT a Type
 (def-type arr ([dom (listof Type/c)]
                [rng SomeValues/c]
                [rest (or/c #f Type/c)]
                [drest (or/c #f (cons/c Type/c (or/c natural-number/c symbol?)))]
-               [kws (listof Keyword?)])
+               [kws (and/c (listof Keyword?) keyword-sorted/c)])
   [#:intern (list (map Rep-seq dom) (Rep-seq rng) (and rest (Rep-seq rest))
                   (and drest (cons (Rep-seq (car drest)) (cdr drest)))
                   (map Rep-seq kws))]

--- a/typed-racket-lib/typed-racket/types/kw-types.rkt
+++ b/typed-racket-lib/typed-racket/types/kw-types.rkt
@@ -11,63 +11,56 @@
 ;; convert : [Listof Keyword] [Listof Type] [Listof Type] [Option Type]
 ;;           [Option Type] [Option (Pair Type symbol)] boolean -> Type
 (define (convert kw-t plain-t opt-t rng rest drest split?)
-  (define-values (mand-kw-t opt-kw-t) (partition (match-lambda [(Keyword: _ _ m) m]) kw-t))
-
   (when drest
     (int-err "drest passed to kw-convert"))
-
-  (define arities
-    (for/list ([i (in-range (length opt-t))])
-      (make-arr* (append plain-t (take opt-t i))
-                 rng
-                 #:kws kw-t
-                 #:rest rest
-                 #:drest drest)))
   ;; the kw function protocol passes rest args as an explicit list
   (define rest-type (if rest (-lst rest) empty))
-  (define ts 
-    (flatten
-     (list
-      (for/list ([k (in-list kw-t)])
-        (match k
-          [(Keyword: _ t #t) t]
-          [(Keyword: _ t #f) (list (-opt t) -Boolean)]))
-      plain-t
-      (for/list ([t (in-list opt-t)]) (-opt t))
-      (for/list ([t (in-list opt-t)]) -Boolean)
-      rest-type)))
-  ;; the kw protocol puts the arguments in keyword-sorted order in the
-  ;; function header, so we need to sort the types to match
-  (define sorted-kws
-    (sort kw-t keyword<? #:key (match-lambda [(Keyword: kw _ _) kw])))
-  (define ts/true
-    (flatten
-     (list
-      (for/list ([k (in-list sorted-kws)])
-        (match k
-          [(Keyword: _ t #t) t]
-          [(Keyword: _ t #f) (list t (-val #t))]))
-      plain-t
-      (for/list ([t (in-list opt-t)]) t)
-      (for/list ([t (in-list opt-t)]) (-val #t))
-      rest-type)))
-  (define ts/false
-    (flatten
-     (list
-      (for/list ([k (in-list sorted-kws)])
-        (match k
-          [(Keyword: _ t #t) t]
-          [(Keyword: _ t #f) (list (-val #f) (-val #f))]))
-      plain-t
-      (for/list ([t (in-list opt-t)]) (-val #f))
-      (for/list ([t (in-list opt-t)]) (-val #f))
-      rest-type)))
+
   (make-Function
-    (if split?
-        (remove-duplicates
-          (list (make-arr* ts/true rng #:drest drest)
-                (make-arr* ts/false rng #:drest drest)))
-        (list (make-arr* ts rng #:rest rest #:drest drest)))))
+    (cond
+      [(not split?)
+       (define ts 
+         (flatten
+          (list
+           (for/list ([k (in-list kw-t)])
+             (match k
+               [(Keyword: _ t #t) t]
+               [(Keyword: _ t #f) (list (-opt t) -Boolean)]))
+           plain-t
+           (for/list ([t (in-list opt-t)]) (-opt t))
+           (for/list ([t (in-list opt-t)]) -Boolean)
+           rest-type)))
+       (list (make-arr* ts rng #:rest rest #:drest drest))]
+      [else
+       ;; the kw protocol puts the arguments in keyword-sorted order in the
+       ;; function header, so we need to sort the types to match
+       (define sorted-kws
+         (sort kw-t keyword<? #:key (match-lambda [(Keyword: kw _ _) kw])))
+       (define ts/true
+         (flatten
+          (list
+           (for/list ([k (in-list sorted-kws)])
+             (match k
+               [(Keyword: _ t #t) t]
+               [(Keyword: _ t #f) (list t (-val #t))]))
+           plain-t
+           (for/list ([t (in-list opt-t)]) t)
+           (for/list ([t (in-list opt-t)]) (-val #t))
+           rest-type)))
+       (define ts/false
+         (flatten
+          (list
+           (for/list ([k (in-list sorted-kws)])
+             (match k
+               [(Keyword: _ t #t) t]
+               [(Keyword: _ t #f) (list (-val #f) (-val #f))]))
+           plain-t
+           (for/list ([t (in-list opt-t)]) (-val #f))
+           (for/list ([t (in-list opt-t)]) (-val #f))
+           rest-type)))
+       (remove-duplicates
+         (list (make-arr* ts/true rng #:drest drest)
+               (make-arr* ts/false rng #:drest drest)))])))
 
 
 ;; This is used to fix the filters of keyword types.

--- a/typed-racket-lib/typed-racket/types/kw-types.rkt
+++ b/typed-racket-lib/typed-racket/types/kw-types.rkt
@@ -4,6 +4,7 @@
          "../utils/tc-utils.rkt"
          "../base-env/annotate-classes.rkt"
          "tc-result.rkt"
+         unstable/list
          racket/list racket/set racket/dict racket/match
          racket/format racket/string
          syntax/parse)
@@ -14,7 +15,12 @@
   (when drest
     (int-err "drest passed to kw-convert"))
   ;; the kw function protocol passes rest args as an explicit list
-  (define rest-type (if rest (-lst rest) empty))
+  (define rest-type (if rest (list (-lst rest)) empty))
+
+  ;; the kw protocol puts the arguments in keyword-sorted order in the
+  ;; function header, so we need to sort the types to match
+  (define sorted-kws
+    (sort kw-t keyword<? #:key (match-lambda [(Keyword: kw _ _) kw])))
 
   (make-Function
     (cond
@@ -22,7 +28,7 @@
        (define ts 
          (flatten
           (list
-           (for/list ([k (in-list kw-t)])
+           (for/list ([k (in-list sorted-kws)])
              (match k
                [(Keyword: _ t #t) t]
                [(Keyword: _ t #f) (list (-opt t) -Boolean)]))
@@ -32,36 +38,30 @@
            rest-type)))
        (list (make-arr* ts rng #:rest rest #:drest drest))]
       [else
-       ;; the kw protocol puts the arguments in keyword-sorted order in the
-       ;; function header, so we need to sort the types to match
-       (define sorted-kws
-         (sort kw-t keyword<? #:key (match-lambda [(Keyword: kw _ _) kw])))
-       (define ts/true
-         (flatten
-          (list
-           (for/list ([k (in-list sorted-kws)])
-             (match k
-               [(Keyword: _ t #t) t]
-               [(Keyword: _ t #f) (list t (-val #t))]))
-           plain-t
-           (for/list ([t (in-list opt-t)]) t)
-           (for/list ([t (in-list opt-t)]) (-val #t))
-           rest-type)))
-       (define ts/false
-         (flatten
-          (list
-           (for/list ([k (in-list sorted-kws)])
-             (match k
-               [(Keyword: _ t #t) t]
-               [(Keyword: _ t #f) (list (-val #f) (-val #f))]))
-           plain-t
-           (for/list ([t (in-list opt-t)]) (-val #f))
-           (for/list ([t (in-list opt-t)]) (-val #f))
-           rest-type)))
-       (remove-duplicates
-         (list (make-arr* ts/true rng #:drest drest)
-               (make-arr* ts/false rng #:drest drest)))])))
+       ;; The different types for each possibile combination of keywords
+       (define keyword-possibilities
+         (map append*
+           (apply cartesian-product
+             (for/list ([k (in-list sorted-kws)])
+               (match k
+                 [(Keyword: _ t #t) (list (list t))]
+                 [(Keyword: _ t #f) (list (list t (-val #t))
+                                          (list (-val #f) (-val #f)))])))))
 
+       ;; The different types for each possibile supplied number of optional arguments
+       (define optional-possibilities
+         (for/list ([supplied (in-range (add1 (length opt-t)))])
+            (define unsupplied (- (length opt-t) supplied))
+            (append
+              (take opt-t supplied)
+              (make-list unsupplied (-val #f))
+              (make-list supplied (-val #t))
+              (make-list unsupplied (-val #f)))))
+
+       (remove-duplicates
+         (for*/list ([kw-pos (in-list keyword-possibilities)]
+                     [opt-pos (in-list optional-possibilities)])
+          (make-arr* (append kw-pos plain-t opt-pos rest-type) rng #:drest drest)))])))
 
 ;; This is used to fix the filters of keyword types.
 ;; TODO: This should also explore deeper into the actual types and remove filters in there as well.

--- a/typed-racket-test/fail/gh56.rkt
+++ b/typed-racket-test/fail/gh56.rkt
@@ -1,0 +1,5 @@
+#lang typed/racket
+
+(: f (Number [#:y Boolean] -> Number))
+(define (f x #:y [y #f] #:z [z 'this-can-be-anything])
+   (if y "y is truthy" x))


### PR DESCRIPTION
I believe that this is correct but expensive. The tests seemed to pass except it didn't finish and was churning away, so I think this caused one test to take much longer. That is highly likely but I don't see a way around checking the body with all the types it could be called with.
