### PR TITLE
Add typed/rnrs/sorting-6

### DIFF
--- a/typed-racket-more/typed/rnrs/sorting-6.rkt
+++ b/typed-racket-more/typed/rnrs/sorting-6.rkt
@@ -1,0 +1,8 @@
+#lang s-exp typed-racket/base-env/extra-env-lang
+
+(require rnrs/sorting-6)
+
+(type-environment
+ [list-sort (-poly (a) (-> (-> a a Univ) (-lst a) (-lst a)))]
+ [vector-sort (-poly (a) (-> (-> a a Univ) (-vec a) (-vec a)))]
+ [vector-sort! (-poly (a) (-> (-> a a Univ) (-vec a) -Void))])


### PR DESCRIPTION
This is a small addition to `typed-racket-more`, adding a `typed/rnrs/sorting-6` module. Here's my reasoning for adding it:

- For some reason, Racket does not provide built-in `vector-sort` and `vector-sort!` functions. This does, and they operate on plain Racket vectors.
- Including this polymorphically with `require/typed` is impossible, since the wrapped value causes contract errors (this might actually be a bug with polymorphic vectors; I should look into that more).
- Even if it were possible (or if you require it with a more specific, non-polymorphic type), the generated contracts make these functions considerably more expensive than they should be.

Even if it's uncommonly used, I figure it can't hurt to stick in the library. I found myself wanting it, at least.