### PR TITLE
Add sealing contracts for row polymorphic types

### DIFF
--- a/typed-racket-lib/typed-racket/env/row-constraint-env.rkt
+++ b/typed-racket-lib/typed-racket/env/row-constraint-env.rkt
@@ -39,7 +39,8 @@
 ;; lookup-row-constraints : Symbol -> RowConstraint
 ;; returns the mapped-to constraints or #f
 (define (lookup-row-constraints var)
-  (cdr (assq var (current-row-constraints))))
+  (define result (assq var (current-row-constraints)))
+  (and result (cdr result)))
 
 ;; extend : Env Symbol RowConstraint -> Env
 ;; extend type environment with a var-constraints pair

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/parametric.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/parametric.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-;; Static contract for parametric->/c.
+;; Static contract for parametric->/c and sealing->/sc.
 
 (require
   "../structures.rkt"
@@ -8,17 +8,25 @@
   "../terminal.rkt"
   racket/match
   racket/contract
-  (for-template racket/base racket/contract/parametric)
+  (for-template racket/base racket/contract/parametric
+                typed-racket/utils/sealing-contract)
   (for-syntax racket/base syntax/parse))
 
 (provide
   (contract-out
     [parametric->/sc ((listof identifier?) static-contract? . -> . static-contract?)]
-    [parametric-var/sc (identifier? . -> . static-contract?)])
+    [parametric-var/sc (identifier? . -> . static-contract?)]
+    [sealing->/sc ((listof identifier?)
+                   (list/c (listof symbol?) (listof symbol?) (listof symbol?))
+                   static-contract? . -> . static-contract?)]
+    [sealing-var/sc (identifier? . -> . static-contract?)])
   parametric->/sc:
+  sealing->/sc:
   (rename-out
     [parametric-var/sc parametric-var/sc:]
-    [parametric-combinator? parametric->/sc?]))
+    [parametric-combinator? parametric->/sc?]
+    [sealing-var/sc sealing-var/sc:]
+    [sealing-combinator? sealing->/sc?]))
 
 
 (struct parametric-combinator combinator (vars)
@@ -53,4 +61,39 @@
 
 (define-terminal-sc parametric-var/sc (id) #:impersonator
   #:printer (v p mode) (display (syntax-e (parametric-var/sc-id v)) p)
+   id)
+
+;; combinator for sealing-> contracts for row polymorphism
+(struct sealing-combinator combinator (vars members)
+  #:transparent
+  #:property prop:combinator-name "sealing->/sc"
+  #:methods gen:sc
+    [(define (sc-map v f)
+       (match v
+        [(sealing-combinator (list arg) vars members)
+         (sealing-combinator (list (f arg 'covariant)) vars members)]))
+     (define (sc-traverse v f)
+       (match v
+        [(sealing-combinator (list arg) vars members)
+         (f arg 'covariant)
+         (void)]))
+     (define (sc->contract v f)
+       (match v
+        [(sealing-combinator (list arg) vars members)
+         #`(sealing->/c #,(car vars) #,members #,(f arg))]))
+     (define (sc->constraints v f)
+       (match v
+        [(sealing-combinator (list arg) vars members)
+         (merge-restricts* 'impersonator  (list (f arg)))]))])
+
+(define (sealing->/sc vars members body)
+  (sealing-combinator (list body) vars members))
+
+(define-match-expander sealing->/sc:
+  (syntax-parser
+    [(_ vars members body)
+     #'(sealing-combinator (list body) vars members)]))
+
+(define-terminal-sc sealing-var/sc (id) #:impersonator
+  #:printer (v p mode) (display (syntax-e (sealing-var/sc-id v)) p)
    id)

--- a/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
@@ -99,8 +99,10 @@
   (define (recur sc)
     (cond [(and cache (hash-ref cache sc #f)) => car]
           [(arr/sc? sc) (make-contract sc)]
-          [(parametric->/sc? sc)
-           (match-define (parametric->/sc: vars _) sc)
+          [(or (parametric->/sc? sc) (sealing->/sc? sc))
+           (match-define (or (parametric->/sc: vars _)
+                             (sealing->/sc: vars _ _))
+                         sc)
            (parameterize ([bound-names (append vars (bound-names))])
              (make-contract sc))]
           ;; If any names are bound, the contract can't be shared
@@ -167,6 +169,7 @@
     (define/match (free? sc _)
       [((or (recursive-sc-use name*)
             (parametric-var/sc: name*)
+            (sealing-var/sc: name*)
             (name/sc: name*))
         _)
        (when (free-identifier=? name name*)

--- a/typed-racket-lib/typed-racket/static-contracts/parametric-check.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/parametric-check.rkt
@@ -41,7 +41,7 @@
        (add-equation! eqs (get-var sc)
                       (lambda () (for/sum ((e elems))
                                    (variable-ref (get-var e)))))]
-      [(parametric-var/sc: id)
+      [(or (parametric-var/sc: id) (sealing-var/sc: id))
        (add-equation! eqs (get-var sc) (lambda () 1))]
       [(recursive-sc names values body)
        (for ([name names] [value values])

--- a/typed-racket-lib/typed-racket/utils/sealing-contract.rkt
+++ b/typed-racket-lib/typed-racket/utils/sealing-contract.rkt
@@ -1,0 +1,127 @@
+#lang racket/base
+
+;; This module provides a sealing->/c which operates like the parametric->/c
+;; contract except for classes and with partial sealing instead of fully
+;; opaque sealing.
+
+(require racket/class
+         racket/contract
+         racket/match
+         (for-syntax racket/base
+                     syntax/parse))
+
+(provide sealing->/c)
+
+(define-syntax (sealing->/c stx)
+  (syntax-parse stx
+    [(_ ?var:id [(?i:id ...) (?f:id ...) (?m:id ...)] ?c)
+     #`(sealing-contract (quote #,(syntax->datum stx))
+                         (quote ((?i ...) (?f ...) (?m ...)))
+                         (λ (?var) ?c))]))
+
+;; represents a sealing function contract
+;; name     - a datum for the printed form of the contract
+;; unsealed - init/field/method names left unsealed by sealers/unsealers
+;; proc     - a procedure that constructs the whole contract
+(struct sealing-contract (name unsealed proc)
+        #:property prop:contract
+        (build-contract-property
+         #:name (λ (ctc) (sealing-contract-name ctc))
+         #:stronger
+         (λ (this that)
+           (cond
+            [(sealing-contract? that)
+             (define this-unsealed (sealing-contract-unsealed this))
+             (define that-unsealed (sealing-contract-unsealed that))
+             (match-define (list this-inits this-fields this-methods) this-unsealed)
+             (match-define (list that-inits that-fields that-methods) that-unsealed)
+             (define (that-subset-of-this? this that)
+               (for/and ([that-member (in-list that)])
+                 (member that-member this)))
+             (that-subset-of-this? this-inits that-inits)
+             (that-subset-of-this? this-fields that-fields)
+             (that-subset-of-this? this-methods that-methods)
+             (cond [that-subset-of-this?
+                    (define sealer/unsealer
+                      (seal/unseal (gensym) #t that-unsealed))
+                    ;; see if the instantiated contract is stronger
+                    (contract-stronger? ((sealing-contract-proc this)
+                                         sealer/unsealer)
+                                        ((sealing-contract-proc that)
+                                         sealer/unsealer))]
+                   [else #f])]
+            [else #f]))
+         #:projection
+         (λ (ctc)
+           (define unsealed (sealing-contract-unsealed ctc))
+           (define body (sealing-contract-proc ctc))
+           (λ (blame)
+             (define negative? (blame-swapped? blame))
+             (define (make-seal-function orig-fun)
+               (define sealing-key (gensym))
+               (define sealer/unsealer
+                 (seal/unseal sealing-key negative? unsealed))
+               (define body-proj
+                 (contract-projection (body sealer/unsealer)))
+               ((body-proj blame) orig-fun))
+             (λ (val)
+               (unless (procedure? val)
+                 (raise-blame-error
+                  blame val
+                  '(expected "a procedure" given: "~e") val))
+               ;; ok to return an unrelated function since this
+               ;; is an impersonator contract
+               (make-keyword-procedure (λ (kws kw-args . rst)
+                                         (keyword-apply (make-seal-function val)
+                                                        kws kw-args rst))))))))
+
+;; represents a contract for each polymorphic seal/unseal corresponding
+;; to a variable
+;; key       - a fresh symbol used as a key
+;; positive? - whether the contract starts in positive/negative
+;; unsealed - names that are to be unsealed by sealers/unsealers
+(struct seal/unseal (key positive? unsealed)
+        #:property prop:contract
+        (build-contract-property
+         #:name (λ (ctc)
+                  (if positive?
+                      `(seal/c ,(seal/unseal-key ctc)
+                               ,(seal/unseal-unsealed ctc))
+                      '(unseal/c ,(seal/unseal-key ctc))))
+         #:stronger (λ (this that) (eq? this that))
+         #:projection
+         (λ (ctc)
+           (define sealing-key (seal/unseal-key ctc))
+           (define unsealed (seal/unseal-unsealed ctc))
+           (λ (blame)
+             (λ (val)
+               (unless (class? val)
+                 (raise-blame-error
+                  blame val
+                  '(expected: "a class" given: "~e") val))
+               (match-define (list init field method) unsealed)
+               (if (equal? (blame-original? blame)
+                           (seal/unseal-positive? ctc))
+                   (class-seal val sealing-key init field method
+                               (inst-err val blame)
+                               (subclass-err val blame))
+                   (class-unseal val sealing-key
+                                 (unseal-err val blame))))))))
+
+;; error functions for use with class-seal, class-unseal
+(define ((inst-err val blame) cls)
+  (raise-blame-error
+   blame val
+   "cannot instantiated a row polymorphic class"))
+
+(define ((subclass-err val blame) cls names)
+  (raise-blame-error
+   blame val
+   "cannot subclass a row polymorphic class with disallowed members ~a"
+   names))
+
+(define ((unseal-err val blame) cls)
+  (raise-blame-error
+   blame val
+   '(expected "matching row polymorphic class"
+     given: "an unrelated class")))

--- a/typed-racket-test/fail/sealing-contract-1.rkt
+++ b/typed-racket-test/fail/sealing-contract-1.rkt
@@ -1,0 +1,24 @@
+#;
+(exn-pred #rx"an unrelated class")
+#lang racket/base
+
+(module u racket
+  ;; drops cls on the floor, doesn't match spec
+  (define (mixin cls)
+    (class object% (super-new)))
+
+  (provide mixin))
+
+(module t typed/racket
+  ;; expects a mixin that adds n
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r [n (-> Integer Integer)])))])
+
+  (mixin (class object%
+           (super-new)
+           (define/public (m x) x))))
+
+(require 't)

--- a/typed-racket-test/fail/sealing-contract-2.rkt
+++ b/typed-racket-test/fail/sealing-contract-2.rkt
@@ -1,0 +1,26 @@
+#;
+(exn-pred #rx"disallowed members \\(m\\)")
+#lang racket/base
+
+(module u racket
+  ;; adds m instead of n like the spec says
+  (define (mixin cls)
+    (class cls
+      (super-new)
+      (define/public (m x) x)))
+
+  (provide mixin))
+
+(module t typed/racket
+  ;; expects a mixin that adds n
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r [n (-> Integer Integer)])))])
+
+  (mixin (class object%
+           (super-new)
+           (define/public (m x) x))))
+
+(require 't)

--- a/typed-racket-test/fail/sealing-contract-3.rkt
+++ b/typed-racket-test/fail/sealing-contract-3.rkt
@@ -1,0 +1,26 @@
+#;
+(exn-pred #rx"disallowed members \\(f\\)")
+#lang racket/base
+
+(module u racket
+  ;; adds f instead of g like the spec says
+  (define (mixin cls)
+    (class cls
+      (super-new)
+      (field [f 0])))
+
+  (provide mixin))
+
+(module t typed/racket
+  ;; expects a mixin that adds g
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r (field [g Integer]))))])
+
+  (mixin (class object%
+           (super-new)
+           (field [f 1]))))
+
+(require 't)

--- a/typed-racket-test/fail/sealing-contract-4.rkt
+++ b/typed-racket-test/fail/sealing-contract-4.rkt
@@ -1,0 +1,35 @@
+#;
+(exn-pred #rx"unrelated class")
+#lang racket/base
+
+(module u racket
+  (define state #f)
+
+  ;; don't allow smuggling with mutation either
+  (define (mixin cls)
+    (define result
+      (if (not state)
+          (class cls
+            (super-new)
+            (define/public (n x) x))
+          ;; should subclass from cls, not state since otherwise
+          ;; we lose the `m` method
+          (class state (super-new))))
+    (set! state cls)
+    result)
+
+  (provide mixin))
+
+(module t typed/racket
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r [n (-> Integer Integer)])))])
+
+  (mixin (class object% (super-new)))
+  (mixin (class object%
+           (super-new)
+           (define/public (m x) x))))
+
+(require 't)

--- a/typed-racket-test/succeed/sealing-contract-1.rkt
+++ b/typed-racket-test/succeed/sealing-contract-1.rkt
@@ -1,0 +1,23 @@
+#lang racket/base
+
+(module u racket
+  (define (mixin cls)
+    (class cls
+      (super-new)
+      (define/public (n x) (add1 x))))
+
+  (provide mixin))
+
+(module t typed/racket
+  ;; expects a mixin that adds n
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r [n (-> Integer Integer)])))])
+
+  (mixin (class object%
+           (super-new)
+           (define/public (m x) x))))
+
+(require 't)

--- a/typed-racket-test/succeed/sealing-contract-2.rkt
+++ b/typed-racket-test/succeed/sealing-contract-2.rkt
@@ -1,0 +1,23 @@
+#lang racket/base
+
+(module u racket
+  (define (mixin cls)
+    (class cls
+      (super-new)
+      (field [g 0])))
+
+  (provide mixin))
+
+(module t typed/racket
+  ;; expects a mixin that adds g
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r (field [g Integer]))))])
+
+  (mixin (class object%
+           (super-new)
+           (field [f 1]))))
+
+(require 't)

--- a/typed-racket-test/succeed/sealing-contract-3.rkt
+++ b/typed-racket-test/succeed/sealing-contract-3.rkt
@@ -1,0 +1,26 @@
+#lang racket/base
+
+(module u racket
+  (define state #f)
+
+  (define (mixin cls)
+    (class cls
+      (super-new)
+      (define/public (n x) x)))
+
+  (provide mixin))
+
+(module t typed/racket
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r [n (-> Integer Integer)])))])
+
+  ;; ok to call mixin with different types
+  (mixin (class object% (super-new)))
+  (mixin (class object%
+           (super-new)
+           (define/public (m x) x))))
+
+(require 't)


### PR DESCRIPTION
This enables contract generation for row polymorphic types for values from untyped code.

Depends on the class sealing/unsealing operations that are in a PR for core Racket: https://github.com/plt/racket/pull/912

The implementation for static contracts is pretty close to `parametric->/sc`. The `utils/sealing-contract.rkt` file does the heavy lifting and implements a contract combinator that is related to `parametric->/c`.