### PR TITLE
Simplify the type of =

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -891,12 +891,8 @@
 ;; There are 25 values that answer true to zero?. They are either reals, or inexact complexes.
 ;; Note -RealZero contains NaN and zero? returns #f on it
 [zero?
-  (cl->*
-    (-> -ExactNumber B : (-FS (-filter (-val 0) 0) (-not-filter (-val 0) 0)))
-    (-> -Real B : (-FS (-filter -RealZero 0)
-                       (-not-filter (Un -Zero -InexactRealPosZero -InexactRealNegZero) 0)))
-    (-> N B : (-FS (-filter (Un -RealZero -InexactComplex -InexactImaginary) 0)
-                   (-not-filter (Un -Zero -InexactRealPosZero -InexactRealNegZero) 0))))]
+  (-> N B : (-FS (-filter (Un -RealZero -InexactComplex -InexactImaginary) 0)
+                 (-not-filter (Un -Zero -InexactRealPosZero -InexactRealNegZero) 0)))]
 
 [number? (make-pred-ty N)]
 [integer? (asym-pred Univ B (-FS (-filter (Un -Int -Flonum -SingleFlonum) 0) ; inexact-integers exist...

--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -891,8 +891,8 @@
 ;; There are 25 values that answer true to zero?. They are either reals, or inexact complexes.
 ;; Note -RealZero contains NaN and zero? returns #f on it
 [zero?
-  (-> N B : (-FS (-filter (Un -RealZero -InexactComplex -InexactImaginary) 0)
-                 (-not-filter (Un -Zero -InexactRealPosZero -InexactRealNegZero) 0)))]
+  (-> N B : (-FS (-filter (Un -RealZeroNoNan -InexactComplex -InexactImaginary) 0)
+                 (-not-filter -RealZeroNoNan 0)))]
 
 [number? (make-pred-ty N)]
 [integer? (asym-pred Univ B (-FS (-filter (Un -Int -Flonum -SingleFlonum) 0) ; inexact-integers exist...
@@ -920,46 +920,14 @@
 
 [=
  (from-cases
-  (map (lambda (l) (apply exclude-zero l))
-       (list (list -Byte -PosByte)
-             (list -Index -PosIndex)
-             (list -NonNegFixnum -PosFixnum)
-             (list -NonPosFixnum -NegFixnum)
-             (list -Nat -PosInt)
-             (list -NonPosInt -NegInt)
-             (list -Int (Un -PosInt -NegInt))
-             (list -NonNegRat -PosRat)
-             (list -NonPosRat -NegRat)
-             (list -Rat (Un -PosRat -NegRat))
-             (list -NonNegFlonum -PosFlonum -FlonumZero)
-             (list -NonPosFlonum -NegFlonum -FlonumZero)
-             (list -Flonum (Un -PosFlonum -NegFlonum) -FlonumZero)
-             (list -NonNegSingleFlonum -PosSingleFlonum -SingleFlonumZero)
-             (list -NonPosSingleFlonum -NegSingleFlonum -SingleFlonumZero)
-             (list -SingleFlonum (Un -PosSingleFlonum -NegSingleFlonum) -SingleFlonumZero)
-             (list -NonNegInexactReal -PosInexactReal -InexactRealZero)
-             (list -NonPosInexactReal -NegInexactReal -InexactRealZero)
-             (list -InexactReal (Un -PosInexactReal -NegInexactReal) -InexactRealZero)
-             (list -NonNegReal -PosReal -RealZero)
-             (list -NonPosReal -NegReal -RealZero)
-             (list -Real (Un -PosReal -NegReal) -RealZero)))
+   (-> -Real -RealZero B : (-FS (-filter -RealZeroNoNan 0) (-not-filter -RealZeroNoNan 0)))
+   (-> -RealZero -Real B : (-FS (-filter -RealZeroNoNan 1) (-not-filter -RealZeroNoNan 1)))
   (map (lambda (t) (commutative-equality/filter -ExactNumber t))
        (list -One -PosByte -Byte -PosIndex -Index
              -PosFixnum -NonNegFixnum -NegFixnum -NonPosFixnum -Fixnum
              -PosInt -Nat -NegInt -NonPosInt -Int
              -PosRat -NonNegRat -NegRat -NonPosRat -Rat
              -ExactNumber))
-  (map (lambda (t) (commutative-equality/filter -Flonum t))
-       (list -FlonumZero -PosFlonum -NonNegFlonum -NegFlonum -NonPosFlonum -Flonum))
-  (map (lambda (t) (commutative-equality/filter -SingleFlonum t))
-       (list -SingleFlonumZero -PosSingleFlonum -NonNegSingleFlonum
-             -NegSingleFlonum -NonPosSingleFlonum -SingleFlonum))
-  (map (lambda (t) (commutative-equality/filter -InexactReal t))
-       (list -InexactRealZero -PosInexactReal -NonNegInexactReal
-             -NegInexactReal -NonPosInexactReal -InexactReal))
-  ;; this case should take care of mixed type equality. the filters give
-  ;; sign information, and we get exactness information from the original
-  ;; types
   (map (lambda (t) (commutative-equality/filter -Real t))
        (list -RealZero -PosReal -NonNegReal -NegReal -NonPosReal -Real))
   (->* (list N N) N B))]

--- a/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
@@ -13,6 +13,7 @@
 (provide add-scope)
 
 (provide/cond-contract
+  [restrict-values (-> SomeValues/c (listof Type/c) SomeValues/c)]
   [values->tc-results (->* (SomeValues/c (listof Object?)) ((listof Type/c)) full-tc-results/c)]
   [replace-names (-> (listof (list/c identifier? Object?)) tc-results/c tc-results/c)])
 
@@ -31,6 +32,10 @@
                          [t (in-list ts)])
     (subst-tc-results res (list 0 arg) o #t t)))
 
+;; Restrict the objects in v refering to the current functions arguments to be of the types ts.
+(define (restrict-values v ts)
+  (for/fold ([v v]) ([t (in-list ts)] [arg (in-naturals)])
+    (subst-type v (list 0 arg) (-arg-path arg) #t t)))
 
 ;; replace-names: (listof (list/c identifier? Object?) tc-results? -> tc-results?
 ;; For each name replaces all uses of it in res with the corresponding object.

--- a/typed-racket-lib/typed-racket/types/numeric-tower.rkt
+++ b/typed-racket-lib/typed-racket/types/numeric-tower.rkt
@@ -17,7 +17,7 @@
          -FlonumPosZero -FlonumNegZero -FlonumZero -FlonumNan -PosFlonum -NonNegFlonum -NegFlonum -NonPosFlonum -Flonum
          -SingleFlonumPosZero -SingleFlonumNegZero -SingleFlonumZero -SingleFlonumNan -PosSingleFlonum -NonNegSingleFlonum -NegSingleFlonum -NonPosSingleFlonum -SingleFlonum
          -InexactRealPosZero -InexactRealNegZero -InexactRealZero -InexactRealNan -PosInexactReal -NonNegInexactReal -NegInexactReal -NonPosInexactReal -InexactReal
-         -RealZero -PosReal -NonNegReal -NegReal -NonPosReal -Real
+         -RealZero -RealZeroNoNan -PosReal -NonNegReal -NegReal -NonPosReal -Real
          -PosInfinity -NegInfinity
          -ExactImaginary -FloatImaginary -SingleFlonumImaginary -InexactImaginary -Imaginary
          -ExactNumber -ExactComplex -FloatComplex -SingleFlonumComplex -InexactComplex -Number
@@ -203,12 +203,13 @@
 (define/decl -InexactReal        (*Un -SingleFlonum -Flonum))
 
 ;; Reals
-(define/decl -RealZero   (*Un -Zero -InexactRealZero))
-(define/decl -PosReal    (*Un -PosRat -PosInexactReal))
-(define/decl -NonNegReal (*Un -NonNegRat -NonNegInexactReal))
-(define/decl -NegReal    (*Un -NegRat -NegInexactReal))
-(define/decl -NonPosReal (*Un -NonPosRat -NonPosInexactReal))
-(define/decl -Real       (*Un -Rat -InexactReal))
+(define/decl -RealZero      (*Un -Zero -InexactRealZero))
+(define/decl -RealZeroNoNan (*Un -Zero -InexactRealPosZero -InexactRealNegZero))
+(define/decl -PosReal       (*Un -PosRat -PosInexactReal))
+(define/decl -NonNegReal    (*Un -NonNegRat -NonNegInexactReal))
+(define/decl -NegReal       (*Un -NegRat -NegInexactReal))
+(define/decl -NonPosReal    (*Un -NonPosRat -NonPosInexactReal))
+(define/decl -Real          (*Un -Rat -InexactReal))
 
 ;; Complexes
 ;; We could go into _much_ more precision here.

--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -10,7 +10,8 @@
 
 (lazy-require
   ("union.rkt" (Un))
-  ("../infer/infer.rkt" (infer)))
+  ("../infer/infer.rkt" (infer))
+  ("../typecheck/tc-subst.rkt" (restrict-values)))
 
 (define subtype-cache (make-hash))
 
@@ -103,19 +104,19 @@
         (arr: t1 t2 #f #f '()))
        (subtype-seq A0
                     (subtypes* t1 s1)
-                    (subtype* s2 t2))]
+                    (subtype* (restrict-values s2 t1) t2))]
       [((arr: s1 s2 #f #f s-kws)
         (arr: t1 t2 #f #f t-kws))
        (subtype-seq A0
                     (subtypes* t1 s1)
                     (kw-subtypes* s-kws t-kws)
-                    (subtype* s2 t2))]
+                    (subtype* (restrict-values s2 t1) t2))]
       [((arr: s-dom s-rng s-rest #f s-kws)
         (arr: t-dom t-rng #f #f t-kws))
        (subtype-seq A0
                     (subtypes*/varargs t-dom s-dom s-rest)
                     (kw-subtypes* s-kws t-kws)
-                    (subtype* s-rng t-rng))]
+                    (subtype* (restrict-values s-rng t-dom) t-rng))]
       [((arr: s-dom s-rng #f #f s-kws)
         (arr: t-dom t-rng t-rest #f t-kws))
        #f]
@@ -125,7 +126,7 @@
                     (subtypes*/varargs t-dom s-dom s-rest)
                     (subtype* t-rest s-rest)
                     (kw-subtypes* s-kws t-kws)
-                    (subtype* s-rng t-rng))]
+                    (subtype* (restrict-values s-rng t-dom) t-rng))]
       ;; handle ... varargs when the bounds are the same
       [((arr: s-dom s-rng #f (cons s-drest dbound) s-kws)
         (arr: t-dom t-rng #f (cons t-drest dbound) t-kws))
@@ -133,7 +134,7 @@
                     (subtype* t-drest s-drest)
                     (subtypes* t-dom s-dom)
                     (kw-subtypes* s-kws t-kws)
-                    (subtype* s-rng t-rng))]
+                    (subtype* (restrict-values s-rng t-dom) t-rng))]
       [(_ _) #f]))
 
 ;; check subtyping of filters, so that predicates subtype correctly

--- a/typed-racket-test/unit-tests/subtype-tests.rkt
+++ b/typed-racket-test/unit-tests/subtype-tests.rkt
@@ -361,4 +361,9 @@
     (-prefab '(foo #(0)) -String)]
    [FAIL
     (-prefab '(foo #()) -String) (-prefab '(foo #(0)) (-opt -String))]
+
+   ;; Filter subtyping
+   ((make-pred-ty (list -Real) -Boolean (Un (-val 0.0) (-val 0)))
+    (make-pred-ty (list -Int) -Boolean (-val 0)))
+
    ))

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -3574,8 +3574,7 @@
          (t:-> -Nat -Boolean : (-FS (-filter (-val 0) 0) (-not-filter (-val 0) 0)))]
        [tc-e/t
          (lambda: ([x : Real]) (zero? x))
-         (t:-> -Real -Boolean : (-FS (-filter -RealZero 0)
-                                     (-not-filter (t:Un -Zero -InexactRealPosZero -InexactRealNegZero) 0)))]
+         (t:-> -Real -Boolean : (-FS (-filter -RealZeroNoNan 0) (-not-filter -RealZeroNoNan 0)))]
 
        [tc-e/t (lambda: ([x : Byte]) (positive? x))
           (t:-> -Byte -Boolean : (-FS (-filter -PosByte 0) (-filter -Zero 0)))]
@@ -3593,7 +3592,15 @@
         (t:-> -Flonum (t:Un (-val #t) -FlonumNan)
               : -true-filter)]
 
-
+       [tc-e/t
+         (lambda: ([x : Flonum]) (if (= 0 x) 1.0 x))
+         (t:-> -Flonum (t:Un -PosFlonum -NegFlonum) : -true-filter)]
+       [tc-e/t
+         (lambda: ([x : Byte]) (if (= 0 x) 1 x))
+         (t:-> -Byte -PosByte : -true-filter)]
+       [tc-e/t
+         (lambda: ([x : Flonum]) (if (= x (ann 1.0 Positive-Flonum)) x 'other))
+         (t:-> -Flonum (t:Un -PosFlonum (-val 'other)) : -true-filter)]
        )
 
   (test-suite

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -2054,7 +2054,7 @@
               (-lst -Symbol)]
         [tc-e (sequence-count zero? (inst empty-sequence Integer))
               -Nat]
-        [tc-e (sequence-filter zero? (inst empty-sequence Integer))
+        [tc-e ((inst sequence-filter Integer Zero) zero? (inst empty-sequence Integer))
               (-seq (-val 0))]
         [tc-e (sequence-add-between (inst empty-sequence Integer) 'foo)
               (-seq (t:Un -Int (-val 'foo)))]
@@ -3566,6 +3566,16 @@
        [tc-e/t
          (lambda: ([x : Real-Zero]) (or (zero? x) x))
          (t:-> -RealZero (t:Un (-val #t) -InexactRealNan) : -true-filter)]
+       [tc-e/t
+         (lambda: ([x : Positive-Integer]) (zero? x))
+         (t:-> -PosInt -Boolean : -false-filter)]
+       [tc-e/t
+         (lambda: ([x : Natural]) (zero? x))
+         (t:-> -Nat -Boolean : (-FS (-filter (-val 0) 0) (-not-filter (-val 0) 0)))]
+       [tc-e/t
+         (lambda: ([x : Real]) (zero? x))
+         (t:-> -Real -Boolean : (-FS (-filter -RealZero 0)
+                                     (-not-filter (t:Un -Zero -InexactRealPosZero -InexactRealNegZero) 0)))]
 
        [tc-e/t (lambda: ([x : Byte]) (positive? x))
           (t:-> -Byte -Boolean : (-FS (-filter -PosByte 0) (-filter -Zero 0)))]
@@ -3582,6 +3592,8 @@
        [tc-e/t (lambda: ([x : Flonum]) (or (>= +inf.f x) x))
         (t:-> -Flonum (t:Un (-val #t) -FlonumNan)
               : -true-filter)]
+
+
        )
 
   (test-suite


### PR DESCRIPTION
This PR removes a bunch of cases of = that are just restrictions that fall out from the more general cases.

First two commits are from an earlier pr but need the `RealZeroNoNan` simplification so was easier to leave them in.