### PR TITLE
Simplify type for abs

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -665,19 +665,16 @@
 
   (define abs-cases ; used both for abs and magnitude
     (list
-     (map unop (list -Zero -One -PosByte -Byte -PosIndex -Index -PosFixnum -NonNegFixnum))
+     (-NonNegReal . -> . -NonNegReal : -true-filter : (-arg-path 0))
      ;; abs may not be closed on fixnums. (abs min-fixnum) is not a fixnum
      ((Un -PosInt -NegInt) . -> . -PosInt)
      (-Int . -> . -Nat)
      ((Un -PosRat -NegRat) . -> . -PosRat)
      (-Rat . -> . -NonNegRat)
-     (-FlonumZero . -> . -FlonumZero)
      ((Un -PosFlonum -NegFlonum) . -> . -PosFlonum)
      (-Flonum . -> . -NonNegFlonum)
-     (-SingleFlonumZero . -> . -SingleFlonumZero)
      ((Un -PosSingleFlonum -NegSingleFlonum) . -> . -PosSingleFlonum)
      (-SingleFlonum . -> . -NonNegSingleFlonum)
-     (-InexactRealZero . -> . -InexactRealZero)
      ((Un -PosInexactReal -NegInexactReal) . -> . -PosInexactReal)
      (-InexactReal . -> . -NonNegInexactReal)
      ((Un -PosReal -NegReal) . -> . -PosReal)

--- a/typed-racket-test/optimizer/tests/list.rkt
+++ b/typed-racket-test/optimizer/tests/list.rkt
@@ -1,10 +1,10 @@
 #;#;
 #<<END
-TR missed opt: list.rkt 6:0 (rest (rest l)) -- car/cdr on a potentially empty list -- caused by: 6:6 (rest l)
 TR opt: list.rkt 3:0 (first l) -- pair
 TR opt: list.rkt 4:0 (rest l) -- pair
 TR opt: list.rkt 5:0 (second l) -- pair
 TR opt: list.rkt 5:0 (second l) -- pair
+TR opt: list.rkt 6:0 (rest (rest l)) -- pair
 TR opt: list.rkt 6:6 (rest l) -- pair
 TR opt: list.rkt 7:0 (third l) -- pair
 TR opt: list.rkt 7:0 (third l) -- pair

--- a/typed-racket-test/unit-tests/metafunction-tests.rkt
+++ b/typed-racket-test/unit-tests/metafunction-tests.rkt
@@ -118,10 +118,10 @@
 
       ;; Check additional filters
       (check-equal?
-        (values->tc-results (make-Values (list (-result (-opt -Symbol) (-FS (-not-filter -String '(0 0)) -top)
+        (values->tc-results (make-Values (list (-result (-opt -String) (-FS -top (-not-filter -String '(0 0)))
                                                  (make-Path null '(0 0)))))
                             (list (make-Path null #'x)) (list -String))
-        (ret (-opt -Symbol) -false-filter (make-Path null #'x)))
+        (ret -String -true-filter (make-Path null #'x)))
 
       ;; Substitute into ranges correctly
       (check-equal?

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -444,7 +444,7 @@
         (tc-e (sinh (ann 0 Nonpositive-Integer)) -NonPosReal)
         (tc-e (angle -1) (t:Un -InexactReal -Zero))
         (tc-e (angle 2.3) -Zero)
-        (tc-e (magnitude 3/4) -PosRat)
+        (tc-e/t (magnitude 3/4) -PosRat)
         (tc-e (magnitude 3+2i) -NonNegReal)
         (tc-e (min (ann 3 Fixnum) (ann 3 Fixnum)) -Fixnum)
         (tc-e (min (ann -2 Negative-Fixnum) (ann 3 Fixnum)) -NegFixnum)
@@ -3631,6 +3631,7 @@
 
        [tc-e/t ((inst values Any) "a") -String]
        [tc-e ((inst second Any Any Any) (list "a" "b")) -String]
+       [tc-e/t (abs 4) -PosByte]
        )
 
   (test-suite

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -672,7 +672,7 @@
         [tc-e ((inst add-between Positive-Byte Symbol) '(1 2 3) 'a #:splice? #t #:before-first '(b))
               (-lst (t:Un -PosByte -Symbol))]
 
-        [tc-e (apply (plambda: (a) [x : a *] x) '(5)) (-lst -PosByte)]
+        [tc-e (apply (plambda: (a) [x : a *] x) '(5)) (unfold (-lst -PosByte))]
         [tc-e (apply append (list '(1 2 3) '(4 5 6))) (-lst -PosByte)]
 
         [tc-err ((case-lambda: [([x : Number]) x]
@@ -2686,7 +2686,7 @@
                (string-append x y))
              -String]
        [tc-e (let loop ([x "x"]) x)
-             #:ret (ret Univ -true-filter)]
+             #:ret (ret -String -true-filter)]
        [tc-e (let loop ([x : String "x"]) x)
              #:ret (ret -String -true-filter)]
        [tc-e (let/cc k "foo") -String]
@@ -3023,7 +3023,7 @@
        [tc-err
          (let ([f (lambda (x y) y)])
            (f 1 2 3))
-         #:ret (ret Univ -true-filter)]
+         #:ret (ret -PosByte -true-filter)]
 
        [tc-err
          (case-lambda
@@ -3328,7 +3328,7 @@
 
        [tc-e
          ((if (even? 4) add1 (inst values Integer)) 4)
-         -Int]
+         -PosIndex]
 
        ;; PR 14601
        [tc-err
@@ -3609,7 +3609,7 @@
        [tc-e/t (lambda: ([x : One])
                  (let ([f (lambda: [w : Any *] w)])
                    (f x "hello" #\c)))
-        (t:-> -One (-lst Univ) : -true-filter)]
+        (t:-> -One (unfold (-lst Univ)) : -true-filter)]
 
        [tc-e/t (lambda: ([x : One])
                  (let ([f (plambda: (a ...) [w : a ... a] w)])
@@ -3628,6 +3628,9 @@
        [tc-e/t
          (lambda: ([x : Byte]) (if (< 0 x) x 1))
          (t:-> -Byte -PosByte : (-FS (-filter -Byte (list 0 0)) -bot))]
+
+       [tc-e/t ((inst values Any) "a") -String]
+       [tc-e ((inst second Any Any Any) (list "a" "b")) -String]
        )
 
   (test-suite


### PR DESCRIPTION
This also contains commits for changing tc-subst so that the simplification works.

@andmkent Can you review the first, and @stamourv can you review the second?