### PR TITLE
no objects for mutated private class fields

### DIFF
--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -119,9 +119,13 @@
 (define/decl -no-obj (make-NoObject))
 (define/decl -empty-obj (make-Empty))
 (define (-id-path id)
-  (if (is-var-mutated? id)
-      -empty-obj
-      (make-Path null id)))
+  (cond
+    [(identifier? id)
+     (if (is-var-mutated? id)
+         -empty-obj
+         (make-Path null id))]
+    [else
+     (make-Path null id)]))
 (define (-arg-path arg [depth 0])
   (make-Path null (list depth arg)))
 (define (-acc-path path-elems o)
@@ -233,10 +237,12 @@
   (->* doms rng))
 
 (define (->acc dom rng path #:var [var (list 0 0)])
-  (make-Function (list (make-arr* dom rng
-                                  #:filters (-FS (-not-filter (-val #f) (make-Path path var))
-                                                 (-filter (-val #f) (make-Path path var)))
-                                  #:object (make-Path path var)))))
+  (define obj (-acc-path path (-id-path var)))
+  (make-Function
+   (list (make-arr* dom rng
+                    #:filters (-FS (-not-filter (-val #f) obj)
+                                   (-filter (-val #f) obj))
+                    #:object obj))))
 
 (define (cl->* . args)
   (define (funty-arities f)

--- a/typed-racket-test/unit-tests/class-tests.rkt
+++ b/typed-racket-test/unit-tests/class-tests.rkt
@@ -2021,4 +2021,21 @@
                  (define/public (m)
                    (if (string? x) (string-append x "bar") "baz"))))
              (error "foo"))
-           #:msg #rx"expected: String.*given: \\(U String 'obfuscate\\)"]))
+           #:msg #rx"expected: String.*given: \\(U String 'obfuscate\\)"]
+   ;; tests that we are not creating objects for mutable private fields
+   [tc-e (let ()
+           (class object%
+             (super-new)
+             (: bsp-trees (U #f Integer))
+             (define bsp-trees #f)
+             (: m (-> Any))
+             (define (m) (set! bsp-trees 5))
+             
+             (: sync-bsp-trees (-> Integer))
+             (define/private (sync-bsp-trees)
+               (let ([bsp-trees-val bsp-trees])
+                 (cond
+                   [bsp-trees-val  bsp-trees-val]
+                   [else 5]))))
+           (void))
+         -Void]))


### PR DESCRIPTION
still need to double check and test real quick... but this should fix the bug let-aliasing helped expose by discovering mutated private fields were getting objects created for them.