### PR TITLE
Add unsafe require/provide operations

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/unsafe.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/unsafe.scrbl
@@ -1,0 +1,30 @@
+#lang scribble/manual
+
+@begin[(require (for-label (only-meta-in 0 [except-in typed/racket for])))]
+
+@title{Unsafe Typed Racket operations}
+
+@defmodule[typed/racket/unsafe]
+
+@bold{Warning}: the operations documented in this section are @emph{unsafe},
+meaning that they can circumvent the invariants of the type system. Unless the
+@racket[#:no-optimize] language option is used, this may result in unpredictable
+behavior and may even crash Typed Racket.
+
+@defform[(require/typed/unsafe m rt-clause ...)]{
+  This form requires identifiers from the module @racket[m] with the same
+  import specifications as @racket[require/typed].
+
+  Unlike @racket[require/typed], this form is unsafe and will not generate
+  contracts that correspond to the specified types to check that the values
+  actually match their types.
+}
+
+@defform[(provide/unsafe provide-spec ...)]{
+  This form declares exports from a module with the same syntax as
+  the @racket[provide] form.
+
+  Unlike @racket[provide], this form is unsafe and Typed Racket will not generate
+  any contracts that correspond to the specified types. This means that uses of the
+  exports in other modules may circumvent the type system's invariants.
+}

--- a/typed-racket-doc/typed-racket/scribblings/ts-reference.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/ts-reference.scrbl
@@ -34,6 +34,7 @@ For a friendly introduction, see the companion manual
 @include-section["reference/no-check.scrbl"]
 @include-section["reference/typed-regions.scrbl"]
 @include-section["reference/optimization.scrbl"]
+@include-section["reference/unsafe.scrbl"]
 @include-section["reference/legacy.scrbl"]
 @include-section["reference/compatibility-languages.scrbl"]
 @include-section["reference/experimental.scrbl"]

--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -42,6 +42,15 @@
         require/typed-legacy require/typed require/typed/provide
         require-typed-struct/provide cast make-predicate define-predicate))
 
+;; unsafe operations go in this submodule
+(module* unsafe #f
+  ;; turned into a macro on the requiring side
+  (provide -require/typed/unsafe))
+
+;; used for private unsafe functionality in require macros
+;; *do not export*
+(define-syntax unsafe-kw (syntax-rules ()))
+
 (require (for-template (submod "." forms) "../utils/require-contract.rkt"
                        (submod "../typecheck/internal-forms.rkt" forms)
                        "colon.rkt"
@@ -89,7 +98,7 @@
   (pattern (nm:id parent:id)))
 
 
-(define-values (require/typed-legacy require/typed)
+(define-values (require/typed-legacy require/typed -require/typed/unsafe)
  (let ()
   (define-syntax-class opt-rename
     #:attributes (nm spec)
@@ -129,36 +138,49 @@
     (pattern [(~or (~datum opaque) #:opaque) opaque ty:id pred:id #:name-exists]
              #:with opt #'(#:name-exists)))
 
-  (define-syntax-class (clause legacy lib)
+  (define-syntax-class (clause legacy unsafe? lib)
    #:attributes (spec)
    (pattern oc:opaque-clause #:attr spec
      #`(require/opaque-type oc.ty oc.pred #,lib . oc.opt))
    (pattern (~var strc (struct-clause legacy)) #:attr spec
-     #`(require-typed-struct strc.nm (strc.body ...) strc.constructor-parts ... #,lib))
+     #`(require-typed-struct strc.nm (strc.body ...) strc.constructor-parts ...
+                             #,@(if unsafe? #'(unsafe-kw) #'())
+                             #,lib))
    (pattern sc:simple-clause #:attr spec
-     #`(require/typed #:internal sc.nm sc.ty #,lib)))
+     #`(require/typed #:internal sc.nm sc.ty #,lib
+                      #,@(if unsafe? #'(unsafe-kw) #'()))))
 
 
-  (define ((r/t-maker legacy) stx)
+  (define ((r/t-maker legacy unsafe?) stx)
     (syntax-parse stx
-      [(_ lib:expr (~var c (clause legacy #'lib)) ...)
+      [(_ lib:expr (~var c (clause legacy unsafe? #'lib)) ...)
        (when (zero? (syntax-length #'(c ...)))
          (raise-syntax-error #f "at least one specification is required" stx))
        #`(begin c.spec ...)]
-      [(_ #:internal nm:opt-rename ty lib (~optional [~seq #:struct-maker parent]) ...)
+      [(_ #:internal nm:opt-rename ty lib
+          (~optional [~seq #:struct-maker parent])
+          (~optional (~and (~seq (~literal unsafe-kw))
+                           (~bind [unsafe? #t]))
+                     #:defaults ([unsafe? #f])))
        (define/with-syntax hidden (generate-temporary #'nm.nm))
        (define/with-syntax sm (if (attribute parent)
                                   #'(#:struct-maker parent)
                                   #'()))
-       ;; define `cnt*` to be fixed up later by the module type-checking
-       (define cnt*
-         (syntax-local-lift-expression
-          (make-contract-def-rhs #'ty #f (attribute parent))))
-       (quasisyntax/loc stx
-         (begin
-           #,(internal #'(require/typed-internal hidden ty . sm))
-           #,(ignore #`(require/contract nm.spec hidden #,cnt* lib))))]))
-  (values (r/t-maker #t) (r/t-maker #f))))
+       (cond [(not (attribute unsafe?))
+              ;; define `cnt*` to be fixed up later by the module type-checking
+              (define cnt*
+                (syntax-local-lift-expression
+                 (make-contract-def-rhs #'ty #f (attribute parent))))
+              (quasisyntax/loc stx
+                (begin
+                  #,(internal #'(require/typed-internal hidden ty . sm))
+                  #,(ignore #`(require/contract nm.spec hidden #,cnt* lib))))]
+             [else
+              (quasisyntax/loc stx
+                (begin
+                  (require (only-in lib nm.spec))
+                  #,(internal #'(require/typed-internal nm.nm ty . sm))))])]))
+  (values (r/t-maker #t #f) (r/t-maker #f #f) (r/t-maker #f #t))))
 
 
 (define (require/typed/provide stx)
@@ -340,10 +362,17 @@
    (pattern (~seq #:constructor-name name:id) #:attr extra #f)
    (pattern (~seq #:extra-constructor-name name:id) #:attr extra #t))
 
+  (define-splicing-syntax-class unsafe-clause
+   (pattern (~seq) #:attr unsafe? #f)
+   (pattern (~seq (~literal unsafe-kw)) #:attr unsafe? #t))
 
   (define ((rts legacy) stx)
     (syntax-parse stx #:literals (:)
-      [(_ name:opt-parent ([fld : ty] ...) (~var input-maker (constructor-term legacy #'name.nm)) lib)
+      [(_ name:opt-parent
+          ([fld : ty] ...)
+          (~var input-maker (constructor-term legacy #'name.nm))
+          unsafe:unsafe-clause
+          lib)
        (with-syntax* ([nm #'name.nm]
                       [parent #'name.parent]
                       [hidden (generate-temporary #'name.nm)]
@@ -423,16 +452,19 @@
                          #,(ignore #'(require/contract pred hidden (any/c . c-> . boolean?) lib))
                          #,(internal #'(require/typed-internal hidden (Any -> Boolean : nm)))
                          (require/typed #:internal (maker-name real-maker) nm lib
-                                        #:struct-maker parent)
+                                        #:struct-maker parent
+                                        #,@(if (attribute unsafe.unsafe?) #'(unsafe-kw) #'()))
 
                          ;This needs to be a different identifier to meet the specifications
                          ;of struct (the id constructor shouldn't expand to it)
                          #,(if (syntax-e #'extra-maker)
-                               #'(require/typed #:internal (maker-name extra-maker) nm lib
-                                                #:struct-maker parent)
+                               #`(require/typed #:internal (maker-name extra-maker) nm lib
+                                                #:struct-maker parent
+                                                #,@(if (attribute unsafe.unsafe?) #'(unsafe-kw) #'()))
                                #'(begin))
 
-                         (require/typed lib
-                           [sel (nm -> ty)]) ...)))]))
+                         #,@(if (attribute unsafe.unsafe?)
+                                #'((require/typed #:internal sel (nm -> ty) lib unsafe-kw) ...)
+                                #'((require/typed lib [sel (nm -> ty)]) ...)))))]))
 
   (values (rts #t) (rts #f))))

--- a/typed-racket-lib/typed-racket/private/syntax-properties.rkt
+++ b/typed-racket-lib/typed-racket/private/syntax-properties.rkt
@@ -74,5 +74,6 @@
   (tr:class:local-table tr:class:local-table)
   (tr:class:name-table tr:class:name-table)
   (tr:class:def tr:class:def)
+  (unsafe-provide unsafe-provide #:mark)
   )
 

--- a/typed-racket-lib/typed-racket/typecheck/provide-handling.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/provide-handling.rkt
@@ -12,10 +12,13 @@
 
 (provide remove-provides provide? generate-prov get-alternate)
 
+;; Returns #t for safe provides. Returns #f for non-provide forms
+;; and unsafe provides for which contracts will not be generated.
 (define (provide? form)
   (syntax-parse form
     #:literal-sets (kernel-literals)
-    [(#%provide . rest) form]
+    [(~and (#%provide . rest) (~not _:unsafe-provide^))
+     form]
     [_ #f]))
 
 (define (remove-provides forms)

--- a/typed-racket-lib/typed/racket/unsafe.rkt
+++ b/typed-racket-lib/typed/racket/unsafe.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+
+;; This module provides unsafe operations for Typed Racket
+
+(provide provide/unsafe
+         require/typed/unsafe)
+
+(require (for-syntax racket/base
+                     typed-racket/private/syntax-properties
+                     (submod typed-racket/base-env/prims-contract unsafe)))
+
+(define-syntax (require/typed/unsafe stx)
+  (-require/typed/unsafe stx))
+
+(define-syntax (provide/unsafe stx)
+  (syntax-case stx ()
+    [(_ . rst)
+     (quasisyntax/loc stx
+       #,(unsafe-provide #'(provide . rst)))]))

--- a/typed-racket-test/succeed/unsafe-provide.rkt
+++ b/typed-racket-test/succeed/unsafe-provide.rkt
@@ -1,0 +1,31 @@
+#lang racket/base
+
+;; Test unsafe provide form
+
+(require racket/contract/combinator
+         racket/function)
+
+(module a typed/racket
+  (require typed/racket/unsafe)
+
+  (: f (-> String String))
+  (define (f x)
+    (string-append x "foo"))
+  (provide/unsafe f)
+  (provide/unsafe (rename-out [f g]))
+
+  (struct foo ([x : String]))
+  (provide/unsafe (struct-out foo)))
+
+(require 'a)
+
+;; UNSAFE
+;; primitive error, no blame should be raised
+(with-handlers ([(negate exn:fail:contract:blame?) void])
+  (f 3))
+
+(with-handlers ([(negate exn:fail:contract:blame?) void])
+  (g 3))
+
+(with-handlers ([(negate exn:fail:contract:blame?) void])
+  (foo-x (foo 3)))

--- a/typed-racket-test/succeed/unsafe-require.rkt
+++ b/typed-racket-test/succeed/unsafe-require.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+
+;; Test unsafe require forms
+
+(module a racket/base
+  (struct foo (x y))
+  (define a-foo (foo 1 2))
+  (provide (struct-out foo) a-foo))
+
+(module b typed/racket
+  (require/typed racket/contract/combinator [#:opaque Blame exn:fail:contract:blame?])
+  (require typed/racket/unsafe)
+  (require/typed/unsafe (submod ".." a)
+                        [#:struct foo ([x : String] [y : String])]
+                        [a-foo foo])
+
+  ;; UNSAFE
+  ;; primitive error, no blame should be raised
+  (with-handlers ([(negate exn:fail:contract:blame?) void])
+    (string-append (foo-x a-foo))))
+
+(module c typed/racket
+  (require/typed racket/contract/combinator [#:opaque Blame exn:fail:contract:blame?])
+  (require typed/racket/unsafe)
+  (require/typed/unsafe racket/base
+                        [string-append (-> String String Integer)])
+
+  ;; UNSAFE
+  (with-handlers ([(negate exn:fail:contract:blame?) void])
+    (number->string (string-append "foo" "bar"))))
+
+(require 'b 'c)


### PR DESCRIPTION
This adds a new `typed/racket/unsafe` library that is not loaded by default which provides unsafe operations. Right now it just provides `require/typed/unsafe` and `provide/unsafe`.

People have asked for a feature like this for a while (with a revived discussion on it yesterday), so here's a first attempt at it.

Design questions: should `#:opaque` clauses also be unsafe? Currently they are not in this PR, but they could be. The reason I didn't make them unsafe is because opaque types seem very pointless without the predicate check.

Other concerns:
  * should `typed/racket/unsafe` be reserved for a #lang that is unsafe instead?
  * should there be more kinds of unsafety provided?
  * is `unsafe-` prefix better?

CC @ntoronto as a potential major user.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/racket/typed-racket/126)
<!-- Reviewable:end -->
