### PR TITLE
Allow the types created for structs to be specified manually instead of always generating them from the struct name

### DIFF
--- a/typed-racket-lib/info.rkt
+++ b/typed-racket-lib/info.rkt
@@ -12,4 +12,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.3")
+(define version "1.4")

--- a/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
@@ -89,10 +89,10 @@
 
 
 (define-syntax-class define-typed-struct-body
-  #:attributes (name mutable prefab type-only maker extra-maker nm
+  #:attributes (name type-name mutable prefab type-only maker extra-maker nm
                 (tvars 1) (fields 1) (types 1))
   (pattern ((~optional (tvars:id ...) #:defaults (((tvars 1) null)))
-            nm:struct-name ([fields:id : types:expr] ...) options:dtsi-fields)
+            nm:struct-name type-name:id ([fields:id : types:expr] ...) options:dtsi-fields)
            #:attr name #'nm.nm
            #:attr mutable (attribute options.mutable)
            #:attr prefab (attribute options.prefab)
@@ -151,7 +151,7 @@
   [typed-struct
     (define-typed-struct-internal . :define-typed-struct-body)]
   [typed-struct/exec
-    (define-typed-struct/exec-internal nm ([fields:id : types] ...) proc-type)]
+    (define-typed-struct/exec-internal nm type-name ([fields:id : types] ...) proc-type)]
   [typed-require
     (require/typed-internal name type)]
   [typed-require/struct

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -52,8 +52,7 @@
 (define (name-of-struct stx)
   (syntax-parse stx
     [(~or t:typed-struct t:typed-struct/exec)
-     #:with nm/par:parent #'t.nm
-     #'nm/par.name]))
+     #'t.type-name]))
 
 
 ;; parse name field of struct, determining whether a parent struct was specified
@@ -81,7 +80,7 @@
 ;; and optional constructor name
 ;; all have syntax loc of name
 ;; identifier listof[identifier] Option[identifier] -> struct-names
-(define (get-struct-names nm flds maker* extra-maker)
+(define (get-struct-names type-name nm flds maker* extra-maker)
   (define (split l)
     (let loop ([l l] [getters '()] [setters '()])
       (if (null? l)
@@ -90,7 +89,7 @@
   (match (build-struct-names nm flds #f #f nm #:constructor-name maker*)
     [(list sty maker pred getters/setters ...)
      (let-values ([(getters setters) (split getters/setters)])
-       (struct-names nm sty maker extra-maker pred getters setters))]))
+       (struct-names type-name sty maker extra-maker pred getters setters))]))
 
 ;; gets the fields of the parent type, if they exist
 ;; Option[Struct-Ty] -> Listof[Type]
@@ -246,7 +245,7 @@
 ;; tc/struct : Listof[identifier] (U identifier (list identifier identifier))
 ;;             Listof[identifier] Listof[syntax]
 ;;             -> void
-(define (tc/struct vars nm/par fld-names tys
+(define (tc/struct vars nm/par type-name fld-names tys
                    #:proc-ty [proc-ty #f]
                    #:maker [maker #f]
                    #:extra-maker [extra-maker #f]
@@ -262,7 +261,7 @@
   (define types
     ;; add the type parameters of this structure to the tvar env
     (extend-tvars tvars
-      (parameterize ([current-poly-struct `#s(poly ,nm ,new-tvars)])
+      (parameterize ([current-poly-struct `#s(poly ,type-name ,new-tvars)])
         ;; parse the field types
         (map parse-type tys))))
   ;; instantiate the parent if necessary, with new-tvars
@@ -277,7 +276,7 @@
   ;; create the actual structure type, and the types of the fields
   ;; that the outside world will see
   ;; then register it
-  (define names (get-struct-names nm fld-names maker extra-maker))
+  (define names (get-struct-names type-name nm fld-names maker extra-maker))
 
   (cond [prefab?
          (define-values (parent-key parent-fields)
@@ -322,7 +321,7 @@
     (and parent (resolve-name (make-Name parent 0 #t))))
   (define parent-tys (map fld-t (get-flds parent-type)))
 
-  (define names (get-struct-names nm fld-names #f #f))
+  (define names (get-struct-names nm nm fld-names #f #f))
   (define desc (struct-desc parent-tys tys null #t #f))
   (define sty (mk/inner-struct-type names desc parent-type))
 

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -36,14 +36,16 @@
   (parameterize ([current-orig-stx form])
     (syntax-parse form
       [t:typed-struct
-       (tc/struct (attribute t.tvars) #'t.nm (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
+       (tc/struct (attribute t.tvars) #'t.nm #'t.type-name
+                  (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
                   #:mutable (attribute t.mutable)
                   #:maker (attribute t.maker)
                   #:extra-maker (attribute t.extra-maker)
                   #:type-only (attribute t.type-only)
                   #:prefab? (attribute t.prefab))]
       [t:typed-struct/exec
-       (tc/struct null #'t.nm (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
+       (tc/struct null #'t.nm #'t.type-name
+                  (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
                   #:proc-ty #'t.proc-type)])))
 
 (define (type-vars-of-struct form)

--- a/typed-racket-test/succeed/require-typed-struct-custom-type.rkt
+++ b/typed-racket-test/succeed/require-typed-struct-custom-type.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket/base
+
+(require/typed
+ net/url-structs
+ [#:struct path/param
+           ([path : (U String 'up 'same)]
+            [param : (Listof String)])
+           #:type-name Path/Param])
+
+(ann (path/param "path" null) Path/Param)

--- a/typed-racket-test/succeed/struct-custom-type.rkt
+++ b/typed-racket-test/succeed/struct-custom-type.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base
+
+(struct (A) s ([f : A]) #:type-name S)
+
+(define si : (S String) (s "foo"))
+(ann (s-f si) String)
+
+(define-struct/exec exec ()
+  [(λ (e x) (add1 x)) : (Exec Real -> Real)]
+  #:type-name Exec)
+
+((ann (exec) Exec) 3)


### PR DESCRIPTION
This change affects all the struct definition forms as well as `#:struct` clauses in `require/typed`. It's something I've been wanting to change for a while, but I've only now gotten around to doing it. The change is simple and can probably best be explained in code.

```racket
(struct [point : Point] ([x : Real] [y : Real]))
```

This creates a struct called `point`, but the *type* generated for it is `Point`. The change to `require/typed` is the same.

```racket
(require/typed
 net/url-structs
 [#:struct [path/param : Path/Param]
           ([path : (U String 'up 'same)]
            [param : (Listof String)])])
```

Capitalization is, unsurprisingly, the main motivator behind this change, which lets both naming conventions be satisfied without needing any type aliases.