### PR TITLE
Clarification of `for/` forms

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -228,13 +228,13 @@ variants.
 @defform[(for/hash type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/hasheq type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/hasheqv type-ann-maybe (for-clause ...) expr ...+)]
-@defform[(for/vector type-ann-maybe (for-clause ...) expr ...+)]
-@defform[(for/flvector type-ann-maybe (for-clause ...) expr ...+)]
+@;defform[(for/vector type-ann-maybe (for-clause ...) expr ...+)]
+@;defform[(for/flvector type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/extflvector type-ann-maybe (for-clause ...) expr ...+)]
-@defform[(for/and type-ann-maybe (for-clause ...) expr ...+)]
+@;defform[(for/and type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/or   type-ann-maybe (for-clause ...) expr ...+)]
-@defform[(for/first type-ann-maybe (for-clause ...) expr ...+)]
-@defform[(for/last type-ann-maybe (for-clause ...) expr ...+)]
+@;defform[(for/first type-ann-maybe (for-clause ...) expr ...+)]
+@;defform[(for/last type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/sum type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/product type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/set type-ann-maybe (for-clause ...) expr ...+)]
@@ -258,6 +258,9 @@ that @racket[#:when] clauses can only appear as the last
 @racket[for-clause]. The return value of the entire form must be of
 type @racket[u]. For example, a @racket[for/list] form would be
 annotated with a @racket[Listof] type. All annotations are optional.
+
+Deliberately omitted from the above list are @racket[for/vector], @racket[for/flvector], 
+@racket[for/first], @racket[for/last], and @racket[for/and], which aren't yet supported by the typechecker.
 }
 
 @deftogether[[


### PR DESCRIPTION
Make it explicit in the docs that  `for/vector`, `for/flvector`, `for/first`, `for/last`, and `for/and` aren't yet supported by the typechecker.