### PR TITLE
Add type docs & net/url type fixes

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -4,14 +4,21 @@
        (require (for-label (only-meta-in 0 [except-in typed/racket for])
                            (only-in racket/base for)
                            racket/list srfi/14 net/url
-                           version/check))]
+                           version/check
+                           ;; Specific libraries wrapped for TR:
+                           file/gif
+                           net/http-client
+                           net/url-structs
+                           net/url
+                           openssl
+                           json))]
 
 
 @title{Libraries Provided With Typed Racket}
 
 The @racketmodname[typed/racket] language corresponds to the
 @racketmodname[racket] language---that is, any identifier provided
-by @racketmodname[racket], such as @racket[modulo] is available by default in
+by @racketmodname[racket], such as @racket[modulo], is available by default in
 @racketmodname[typed/racket].
 
 @racketmod[typed/racket
@@ -47,22 +54,60 @@ The following libraries are included with Typed Racket in the
 @(define-syntax-rule @defmodule/incl[name]
    @defmodule[name #:no-declare])
 
+@(define-syntax-rule (deftype name . parts)
+   (defidform #:kind "type" name . parts))
+
+@;; framework and mred left out until support for classes
+@;; is more complete
 @defmodule/incl[typed/file/gif]
+@deftype[GIF-Stream]{
+  Describe a GIF stream, as produced by @racket[gif-start]
+  and accepted by the other functions from @racketmodname[file/gif].
+}
+@deftype[GIF-Colormap]{
+  Type alias for a list of three-element (R,G,B) vectors representing an image.
+}
+
 @defmodule/incl[typed/file/md5]
 @defmodule/incl[typed/file/tar]
 @defmodule/incl[typed/framework]
 @defmodule/incl[typed/json]
+
+@deftype[JSExpr]{
+  Describes a @tech["jsexpr" #:doc '(lib "json/json.scrbl")].
+}
+
 @defmodule/incl[typed/mred/mred]
 @defmodule/incl[typed/net/base64]
 @defmodule/incl[typed/net/cgi]
 @defmodule/incl[typed/net/cookie]
+
+@deftype[Cookie]{
+  Describes an HTTP cookie as implemented by @racketmodname[net/cookie].
+}
+
 @defmodule/incl[typed/net/dns]
 @defmodule/incl[typed/net/ftp]
+
+@deftype[FTP-Connection]{
+  Describes an open FTP connection.
+}
+
 @defmodule/incl[typed/net/gifwrite]
 @defmodule/incl[typed/net/git-checkout]
 @defmodule/incl[typed/net/head]
 @defmodule/incl[typed/net/http-client]
+
+@deftype[HTTP-Connection]{
+  Describes an HTTP connection, corresponding to @racket[http-conn?].
+}
+
 @defmodule/incl[typed/net/imap]
+
+@deftype[IMAP-Connection]{
+  Describes an IMAP connection.
+}
+
 @defmodule/incl[typed/net/mime]
 @defmodule/incl[typed/net/nntp]
 @defmodule/incl[typed/net/pop3]
@@ -73,10 +118,56 @@ The following libraries are included with Typed Racket in the
 @defmodule/incl[typed/net/uri-codec]
 @defmodule/incl[typed/net/url-connect]
 @defmodule/incl[typed/net/url-structs]
+
+@deftype[Path/Param]{
+  Describes the @racket[path/param] struct from @racketmodname[net/url-structs].
+}
+@deftype[URL]{
+  Describes an @racket[url] struct from @racketmodname[net/url-structs].
+}
+
 @defmodule/incl[typed/net/url]
+In addition to defining the following types, this module also provides the
+@racket[HTTP-Connection] type defined by @racketmodname[typed/net/http-client],
+and the @racket[URL] and @racket[Path/Param] types from
+@racketmodname[typed/net/url-structs].
+
+@deftype[URL-Exception]{
+  Describes exceptions raised by URL-related functions; corresponds
+  to @racket[url-exception?].
+}
+@deftype[PortT]{
+  Describes the functions @racket[head-pure-port], @racket[delete-pure-port],
+  @racket[get-impure-port], @racket[head-impure-port], and
+  @racket[delete-impure-port].
+}
+@deftype[PortT/Bytes]{
+  Like @racket[PortT], but describes the functions that make POST and PUT
+  requests, which require an additional byte-string argument for POST or PUT
+  data.
+}
+
+@defmodule/incl[typed/openssl]
+
+@deftype[SSL-Protocol]{
+  Describes an SSL protocol, defined as
+  @racket[(U 'auto 'sslv2-or-v3 'sslv2 'sslv3 'tls 'tls11 'tls12)].
+}
+@deftogether[(@deftype[SSL-Server-Context]
+              @deftype[SSL-Client-Context])]{
+  Describes an OpenSSL server or client context.
+}
+@deftype[SSL-Context]{Supertype of OpenSSL server and client contexts.}
+@deftype[SSL-Listener]{
+  Describes an SSL listener, as produced by @racket[ssl-listen].
+}
+@deftype[SSL-Verify-Source]{
+  Describes a verification source usable by @racket[ssl-load-verify-source!]
+  and the @racket[ssl-default-verify-sources] parameter.
+}
+
 @defmodule/incl[typed/openssl/md5]
 @defmodule/incl[typed/openssl/sha1]
-@defmodule/incl[typed/openssl]
 @defmodule/incl[typed/pict]
 @defmodule[typed/racket/async-channel #:no-declare @history[#:added "1.1"]]
 @defmodule/incl[typed/racket/date]
@@ -90,7 +181,21 @@ The following libraries are included with Typed Racket in the
 @defmodule/incl[typed/rackunit/text-ui]
 @defmodule/incl[typed/rackunit]
 @defmodule/incl[typed/srfi/14]
+
+@deftype[Char-Set]{
+  Describes a character set usable by the @racketmodname[srfi/14] functions.
+}
+@deftype[Cursor]{
+  Describes a cursor for iterating over character sets.
+}
+
 @defmodule/incl[typed/srfi/19]
+
+@deftogether[(@defidform[#:kind "type" Time]
+              @defidform[#:kind "type" Date])]{
+  Describes an SRFI 19 time or date structure.
+}
+
 @defmodule/incl[typed/syntax/stx]
 @defmodule/incl[typed/web-server/configuration/responders]
 @defmodule/incl[typed/web-server/http]

--- a/typed-racket-more/typed/net/url.rkt
+++ b/typed-racket-more/typed/net/url.rkt
@@ -7,15 +7,18 @@
 ;; opaque types
 (require/typed/provide
  net/url
- [#:opaque URL-Exception url-exception?]
- [#:opaque HTTP-Connection http-connection?])
+ [#:opaque URL-Exception url-exception?])
 
+(require (only-in typed/net/http-client
+                  HTTP-Connection
+                  [http-conn? http-connection?]))
+(provide HTTP-Connection http-connection?)
 
 ;; convenience type aliases
 ;; PortT/String is unused, but was provided by earlier versions of this module, so it's included here
 (define-type PortT ([URL] [(Listof String)] . ->* . Input-Port))
-(define-type PortT/String ([URL] [String (Listof String)] . ->* . Input-Port))
-(define-type PortT/Bytes ([URL] [Bytes (Listof String)] . ->* . Input-Port))
+(define-type PortT/String ([URL String] [(Listof String)] . ->* . Input-Port))
+(define-type PortT/Bytes ([URL Bytes] [(Listof String)] . ->* . Input-Port))
 (provide PortT PortT/String PortT/Bytes)
 
 (require/typed/provide


### PR DESCRIPTION
This includes documentation for the types exported by most of the wrapper libraries, and two minor changes to the types exported by typed/net/url.