### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/typed-racket-lib/info.rkt
+++ b/typed-racket-lib/info.rkt
@@ -5,7 +5,6 @@
 (define deps '(("base" #:version "6.2.0.2")
                "pconvert-lib"
                "unstable-contract-lib"
-               "unstable-list-lib"
                "source-syntax"
                "compatibility-lib" ;; to assign types
                "string-constants-lib"))

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -25,7 +25,7 @@
          (for-syntax
            racket/base
            syntax/parse)
-         unstable/sequence unstable/list unstable/hash
+         unstable/sequence unstable/hash
          racket/list)
 
 (import dmap^ constraints^)
@@ -261,7 +261,7 @@
     ;; One is null-end the other is uniform-end
     [((seq ss (null-end))
       (seq ts (uniform-end t-rest)))
-     (cgen/list context ss (extend ss ts t-rest))]
+     (cgen/list context ss (list-extend ss ts t-rest))]
     [((seq ss (uniform-end s-rest))
       (seq ts (null-end)))
      #f]
@@ -270,7 +270,7 @@
       (seq ts (uniform-end t-rest)))
      (cgen/list context
                 (cons s-rest ss)
-                (cons t-rest (extend ss ts t-rest)))]
+                (cons t-rest (list-extend ss ts t-rest)))]
     ;; dotted below, nothing above
     [((seq ss (dotted-end dty dbound))
       (seq ts (null-end)))
@@ -358,7 +358,7 @@
         (% cset-meet
            (cgen/list context ss (if (positive? length-delta)
                                      (drop-right ts length-delta)
-                                     (extend ss ts t-rest)))
+                                     (list-extend ss ts t-rest)))
            (% move-vars+rest-to-dmap
               (% cset-meet
                  (cgen/list (context-add context #:bounds (list new-bound) #:vars vars #:indices (list new-bound))
@@ -851,7 +851,7 @@
 
 ;; like infer, but T-var is the vararg type:
 (define (infer/vararg X Y S T T-var R [expected #f])
-  (define new-T (if T-var (extend S T T-var) T))
+  (define new-T (if T-var (list-extend S T T-var) T))
   (and ((length S) . >= . (length T))
        (infer X Y S new-T R expected)))
 

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -25,8 +25,8 @@
          (for-syntax
            racket/base
            syntax/parse)
-         unstable/sequence unstable/hash
-         racket/list)
+         unstable/sequence
+         racket/hash racket/list)
 
 (import dmap^ constraints^)
 (export infer^)

--- a/typed-racket-lib/typed-racket/optimizer/sequence.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/sequence.rkt
@@ -2,7 +2,7 @@
 
 (require syntax/parse
          racket/match
-         unstable/function
+         racket/function
          syntax/parse/experimental/specialize
          (for-template racket/base racket/unsafe/ops)
          "../utils/utils.rkt" "../utils/tc-utils.rkt"

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -17,7 +17,6 @@
          racket/promise
          racket/format
          racket/match
-         (only-in unstable/list check-duplicate)
          "parse-classes.rkt"
          (for-label
            (except-in racket/base case-lambda)

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -689,10 +689,10 @@
   (define merged-augments (merge-clause super-augments augments))
 
   ;; make sure augments and methods are disjoint
-  (define maybe-dup-method (check-duplicate (dict-keys merged-methods)))
+  (define maybe-dup-method (check-duplicates (dict-keys merged-methods)))
   (when maybe-dup-method
     (parse-error "duplicate method name" "name" maybe-dup-method))
-  (define maybe-dup-augment (check-duplicate (dict-keys merged-augments)))
+  (define maybe-dup-augment (check-duplicates (dict-keys merged-augments)))
   (when maybe-dup-augment
     (parse-error "duplicate augmentable method name"
                  "name" maybe-dup-augment))

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -642,7 +642,7 @@
          (for/list ([t arrs])
            (match t
              [(arr: dom _ _ _ _) (length dom)])))
-       (define maybe-dup (check-duplicate arities))
+       (define maybe-dup (check-duplicates arities))
        (when maybe-dup
          (fail #:reason (~a "function type has two cases of arity " maybe-dup)))
        (if (= (length arrs) 1)

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -15,7 +15,6 @@
  racket/match racket/syntax racket/list
  racket/format
  racket/dict
- unstable/list
  syntax/flatten-begin
  (only-in (types abbrev) -Bottom)
  (static-contracts instantiate optimize structures combinators)

--- a/typed-racket-lib/typed-racket/typecheck/provide-handling.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/provide-handling.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 (require "../utils/utils.rkt"
-         unstable/list unstable/sequence syntax/id-table racket/dict racket/syntax
+         unstable/sequence syntax/id-table racket/dict racket/syntax
          racket/struct-info racket/match syntax/parse
          (only-in (private type-contract) include-extra-requires?)
          (private syntax-properties)
@@ -90,11 +90,11 @@
     (define type-is-constructor? #t) ;Conservative estimate (provide/contract does the same)
     (match-define (list type-desc constr pred (list accs ...) muts super) (extract-struct-info si))
     (define-values (defns export-defns new-ids aliases)
-      (map/values 4
-                  (lambda (e) (if (identifier? e)
-                                  (mk e)
-                                  (mk-ignored-quad e)))
-                  (list* type-desc pred super accs)))
+      (for/lists (defns export-defns new-ids aliases)
+        ([e (in-list (list* type-desc pred super accs))])
+        (if (identifier? e)
+            (mk e)
+            (mk-ignored-quad e))))
     ;; Here, we recursively handle all of the identifiers referenced
     ;; in this static struct info.
     (define-values (constr-defn constr-export-defn constr-new-id constr-aliases)

--- a/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 (require "../utils/utils.rkt"
-         racket/match unstable/list unstable/sequence racket/set racket/list
+         racket/match unstable/sequence racket/set racket/list
          (only-in racket/list make-list)
          (contract-req)
          (typecheck check-below tc-subst tc-metafunctions)
@@ -119,8 +119,8 @@
                   (format "Wrong number of arguments - Expected ~a, but got ~a\n\n" (length (car doms)) (length arg-tys))
                   "")
               (append
-               (for/list ([dom-t (in-list (extend arg-tys (car doms) #f))]
-                          [arg-t (in-list (extend (car doms) arg-tys #f))]
+               (for/list ([dom-t (in-list (list-extend arg-tys (car doms) #f))]
+                          [arg-t (in-list (list-extend (car doms) arg-tys #f))]
                           [i (in-naturals 1)])
                          (let ([dom-t (or dom-t "-none-")]
                                [arg-t (or arg-t "-none-")])

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
@@ -4,7 +4,7 @@
          "signatures.rkt"
          "utils.rkt"
          syntax/parse racket/match
-         unstable/list syntax/stx
+         syntax/stx
          unstable/sequence
          (typecheck signatures tc-funapp)
          (types abbrev utils)
@@ -44,9 +44,9 @@
         [(tc-result1: (and t Poly?))
          (tc-expr/check #'quo (ret Univ))
          (tc/funapp #'op #'(quo arg)
-                    (instantiate-poly t (extend (list Univ Univ)
-                                                (stx-map type-annotation #'(i ...))
-                                                Univ))
+                    (instantiate-poly t (list-extend (list Univ Univ)
+                                                     (stx-map type-annotation #'(i ...))
+                                                     Univ))
                     (list (ret Univ) (single-value #'arg))
                     expected)]))
   ;; special-case for not - flip the filters

--- a/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
@@ -2,7 +2,6 @@
 
 (require (rename-in "../utils/utils.rkt" [infer infer-in]))
 (require racket/match racket/list
-         (only-in unstable/list list-update)
          (for-syntax racket/base syntax/parse)
          (contract-req)
          (infer-in infer)

--- a/typed-racket-lib/typed-racket/typecheck/tc-literal.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-literal.rkt
@@ -9,7 +9,7 @@
          (only-in (infer infer) restrict)
          (utils stxclass-util)
          syntax/parse
-         unstable/function
+         racket/function
          unstable/sequence
          racket/extflonum)
 

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -2,7 +2,7 @@
 
 (require (rename-in "../utils/utils.rkt" [infer r:infer])
          racket/syntax syntax/parse syntax/stx syntax/id-table
-         racket/list unstable/list racket/dict racket/match unstable/sequence
+         racket/list racket/dict racket/match unstable/sequence
          (prefix-in c: (contract-req))
          (rep type-rep)
          (types utils abbrev type-table struct-table)
@@ -26,6 +26,10 @@
  [tc-toplevel-form (syntax? . c:-> . c:any/c)])
 
 (define-logger online-check-syntax)
+
+(define (filter-multiple l . fs)
+  (apply values
+         (map (lambda (f) (filter f l)) fs)))
 
 (define unann-defs (make-free-id-table))
 
@@ -542,4 +546,3 @@
      (tc-toplevel/pass1.5 form)
      (begin0 (tc-toplevel/pass2 form #f)
              (report-all-errors))]))
-

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -9,7 +9,7 @@
          racket/match
          racket/function
          racket/undefined
-         unstable/function
+         racket/function
 
          (prefix-in c: (contract-req))
          (rename-in (rep type-rep filter-rep object-rep)

--- a/typed-racket-lib/typed-racket/types/classes.rkt
+++ b/typed-racket-lib/typed-racket/types/classes.rkt
@@ -14,7 +14,6 @@
          racket/match
          syntax/parse
          syntax/stx
-         (only-in unstable/list check-duplicate)
          (only-in unstable/sequence in-syntax)
          (for-template (base-env class-clauses)))
 

--- a/typed-racket-lib/typed-racket/types/classes.rkt
+++ b/typed-racket-lib/typed-racket/types/classes.rkt
@@ -60,14 +60,14 @@
             #:attr all-init-names (append (attribute init-field-names)
                                           (attribute init-names))
             #:fail-when
-            (check-duplicate (attribute all-init-names))
+            (check-duplicates (attribute all-init-names))
             "duplicate init or init-field clause"
             #:fail-when
-            (check-duplicate (attribute all-field-names))
+            (check-duplicates (attribute all-field-names))
             "duplicate field or init-field clause"
             #:fail-when
-            (check-duplicate (append (attribute method-names)
-                                     (attribute augment-names)))
+            (check-duplicates (append (attribute method-names)
+                                      (attribute augment-names)))
             "duplicate method or augmentable method clause"
             #:attr constraints
             (list (attribute all-init-names)
@@ -115,14 +115,14 @@
                                 (attribute augments)
                                 (attribute init-rest))
            #:fail-when
-           (check-duplicate (map first (attribute inits)))
+           (check-duplicates (map first (attribute inits)))
            "duplicate init or init-field clause"
            #:fail-when
-           (check-duplicate (map first (attribute fields)))
+           (check-duplicates (map first (attribute fields)))
            "duplicate field or init-field clause"
            #:fail-when
-           (check-duplicate (map first (append (attribute methods)
-                                               (attribute augments))))
+           (check-duplicates (map first (append (attribute methods)
+                                                (attribute augments))))
            "duplicate method or augmentable method clause"))
 
 ;; Type -> RowConstraint
@@ -228,16 +228,16 @@
                                  (parse-type (attribute init-rest-type)))
            #:with implements #'(implements-id ...)
            #:fail-when
-           (check-duplicate (map first (attribute inits)))
+           (check-duplicates (map first (attribute inits)))
            "duplicate init or init-field clause"
            #:fail-when
-           (check-duplicate (map first (attribute fields)))
+           (check-duplicates (map first (attribute fields)))
            "duplicate field or init-field clause"
            #:fail-when
-           (check-duplicate (map first (attribute methods)))
+           (check-duplicates (map first (attribute methods)))
            "duplicate method clause"
            #:fail-when
-           (check-duplicate (map first (attribute augments)))
+           (check-duplicates (map first (attribute augments)))
            "duplicate augment clause"))
 
 ;; Stx Stx Listof<Boolean> (Stx -> Type) -> Listof<(List Symbol Type Boolean)>

--- a/typed-racket-lib/typed-racket/types/numeric-tower.rkt
+++ b/typed-racket-lib/typed-racket/types/numeric-tower.rkt
@@ -4,7 +4,7 @@
          (rename-in (types numeric-predicates base-abbrev)
                     [simple-Un *Un])
          (rename-in (rep type-rep) [make-Base make-Base*])
-         unstable/function
+         racket/function
          racket/extflonum
          ;; For base type contracts
          (for-template racket/base racket/contract/base racket/extflonum (types numeric-predicates)))

--- a/typed-racket-lib/typed-racket/utils/utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/utils.rkt
@@ -17,7 +17,9 @@ at least theoretically.
  ;; logging
  show-input?
  ;; provide macros
- rep utils typecheck infer env private types static-contracts)
+ rep utils typecheck infer env private types static-contracts
+ ;; misc
+ list-extend)
 
 (define optimize? (make-parameter #t))
 (define-for-syntax enable-contracts? (and (getenv "PLT_TR_CONTRACTS") #t))
@@ -200,3 +202,8 @@ at least theoretically.
                       (self-ctor-transformer (struct-info-self-ctor-id ins) stx))
           #:property prop:struct-info (λ (x) (extract-struct-info (struct-info-self-ctor-info x))))
   struct-info-self-ctor))
+
+;; Listof[A] Listof[B] B -> Listof[B]
+;; pads out t to be as long as s
+(define (list-extend s t extra)
+  (append t (build-list (max 0 (- (length s) (length t))) (lambda _ extra))))

--- a/typed-racket-test/info.rkt
+++ b/typed-racket-test/info.rkt
@@ -13,8 +13,7 @@
                "racket-index"
                "pconvert-lib"
                "compatibility-lib"
-               "unstable-flonum-lib"
-               "unstable-list-lib"))
+               "unstable-flonum-lib"))
 (define build-deps '("scheme-lib"
                      "base"
                      "racket-benchmarks"

--- a/typed-racket-test/unit-tests/tooltip-tests.rkt
+++ b/typed-racket-test/unit-tests/tooltip-tests.rkt
@@ -5,9 +5,9 @@
 ;; certain types are recorded at the right locations.
 
 (require "test-utils.rkt"
+         racket/list
          racket/match
          rackunit
-         unstable/list
          (for-syntax racket/base))
 
 (provide tests)

--- a/typed-racket-test/unit-tests/tooltip-tests.rkt
+++ b/typed-racket-test/unit-tests/tooltip-tests.rkt
@@ -85,7 +85,7 @@
     (for/list ([tooltip (in-list tooltips)])
       (match-define (vector _ start end _) tooltip)
       (list start end)))
-  (if (check-duplicate locations)
+  (if (check-duplicates locations)
       'duplicate-tooltips
       #t))
 


### PR DESCRIPTION
Depends on Racket PR #972, which moves most of its contents to core libraries.

Moves a few `unstable/list` functions to TR itself.
