### PR TITLE
Cancel marks for 'disappeared-use ids in colon macros

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/colon.rkt
+++ b/typed-racket-lib/typed-racket/base-env/colon.rkt
@@ -30,7 +30,7 @@
      #:when (eq? 'expression ctx)
      (err stx "must be used in a definition context")]
     [(: id (~and kw :) . more:omit-parens)
-     (add-disappeared-use #'kw)
+     (add-disappeared-use (syntax-local-introduce #'kw))
      (wrap stx #`(:-helper #,stx #,top-level? id more.type))]
     [(: e ...)
      (wrap stx #`(:-helper #,stx #,top-level? e ...))]))
@@ -47,7 +47,7 @@
                      (syntax-e #'i)))
      (syntax-property (syntax/loc stx (begin (quote (:-internal i ty))
                                              (#%plain-app values)))
-                      'disappeared-use #'i)]
+                      'disappeared-use (syntax-local-introduce #'i))]
     [(_ orig-stx _ i x ...)
      #:fail-unless (identifier? #'i) (err #'orig-stx "expected identifier" #'i)
      (case (syntax-length #'(x ...))


### PR DESCRIPTION
Fixes check-syntax arrows for the id and optional second :