### PR TITLE
Merge `print-syntax?` and `show-input?` parameters into just the `print-syntax?` parameter

### DIFF
--- a/typed-racket-lib/typed-racket/tc-setup.rkt
+++ b/typed-racket-lib/typed-racket/tc-setup.rkt
@@ -53,7 +53,7 @@
                    [disappeared-use-todo      null]
                    [disappeared-bindings-todo null])
       (define fully-expanded-stx (disarm* (do-expand stx expand-ctxt (list #'module*))))
-      (when (show-input?)
+      (when (print-syntax?)
         (pretty-print (syntax->datum fully-expanded-stx)))
       (do-time "Local Expand Done")
       (let ([exprs (syntax->list (syntax-local-introduce fully-expanded-stx))])

--- a/typed-racket-lib/typed-racket/utils/utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/utils.rkt
@@ -14,8 +14,6 @@ at least theoretically.
  optimize?
  ;; timing
  start-timing do-time
- ;; logging
- show-input?
  ;; provide macros
  rep utils typecheck infer env private types static-contracts
  ;; misc
@@ -32,8 +30,6 @@ at least theoretically.
                                          (require racket/contract/region))))
       (syntax-rules () [(_) (begin)])))
 (do-contract-req)
-
-(define show-input? (make-parameter #f))
 
 ;; fancy require syntax
 (define-syntax (define-requirer stx)


### PR DESCRIPTION
It seems that both of these parameters had the intent of printing expanded syntax before typechecking. This pull request merges the behavior into the `print-syntax?` parameter, allowing expanded syntax to be printed based on a single flag in tc-setup.rkt