### PR TITLE
repairs for top-level interaction

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/colon.rkt
+++ b/typed-racket-lib/typed-racket/base-env/colon.rkt
@@ -31,7 +31,7 @@
      #:when (eq? 'expression ctx)
      (err stx "must be used in a definition context")]
     [(: id (~and kw :) . more:omit-parens)
-     (add-disappeared-use (syntax-local-introduce #'kw))
+     (add-disappeared-use #'kw)
      (wrap stx #`(:-helper #,stx #,top-level? id more.type))]
     [(: e ...)
      (wrap stx #`(:-helper #,stx #,top-level? e ...))]))
@@ -48,7 +48,7 @@
                      (syntax-e #'i)))
      (syntax-property (syntax/loc stx (begin (quote-syntax (:-internal i ty) #:local)
                                              (#%plain-app values)))
-                      'disappeared-use (syntax-local-introduce #'i))]
+                      'disappeared-use #'i)]
     [(_ orig-stx _ i x ...)
      #:fail-unless (identifier? #'i) (err #'orig-stx "expected identifier" #'i)
      (case (syntax-length #'(x ...))

--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -313,7 +313,7 @@
       [(self arg ...) (datum->syntax stx
                                      (cons (syntax-property (transfer-srcloc orig #'self)
                                                             'constructor-for
-                                                            (syntax-local-introduce #'self))
+                                                            #'self)
                                            (syntax-e (syntax (arg ...))))
                                      stx
                                      stx)]

--- a/typed-racket-lib/typed-racket/env/global-env.rkt
+++ b/typed-racket-lib/typed-racket/env/global-env.rkt
@@ -17,7 +17,8 @@
          register-types
          unregister-type
          check-all-registered-types
-         type-env-map)
+         type-env-map
+         reset-type-env!)
 
 (lazy-require ["../rep/type-rep.rkt" (Type/c? type-equal?)])
 
@@ -25,6 +26,19 @@
 ;; where id is a variable, and type is the type of the variable
 ;; if the result is a box, then the type has not actually been defined, just registered
 (define the-mapping (make-free-id-table))
+
+(define (reset-type-env!)
+  ;; Bindings can change in between top-level interactions. In particular, a binding
+  ;; introduced with `require/typed` changes after the form is evaluated. To
+  ;; accomodate shifting binding information, rebuild `the-mapping`. Otherwise,
+  ;; shifting bindngs can cause a lookup to fail, even when the table contains a
+  ;; `free-identifier=?` entry.
+  (define new-mapping (make-free-id-table))
+  (free-id-table-for-each
+   the-mapping
+   (lambda (k v)
+     (free-id-table-set! new-mapping k v)))
+  (set! the-mapping new-mapping))
 
 ;; add a single type to the mapping
 ;; identifier type -> void

--- a/typed-racket-lib/typed-racket/optimizer/sequence.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/sequence.rkt
@@ -38,7 +38,7 @@
 (define-syntax-class make-sequence
   (pattern op:id
     #:when (id-from? #'op 'make-sequence 'racket/private/for)
-    #:do [(add-disappeared-use (syntax-local-introduce #'op))]))
+    #:do [(add-disappeared-use #'op)]))
 
 (define-syntax-class sequence-opt-expr
   #:commit

--- a/typed-racket-lib/typed-racket/optimizer/unboxed-tables.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/unboxed-tables.rkt
@@ -25,8 +25,8 @@
     #:when (syntax->datum #'unboxed-info)
     #:with (real-binding imag-binding orig-binding) #'unboxed-info
     ;; we need to introduce both the binding and the use at the same time
-    #:do [(add-disappeared-use (syntax-local-introduce #'v))
-          (add-disappeared-binding (syntax-local-introduce #'orig-binding))]))
+    #:do [(add-disappeared-use #'v)
+          (add-disappeared-binding #'orig-binding)]))
 
 ;; associates the names of functions with unboxed args (and whose call sites have to
 ;; be modified) to the arguments which can be unboxed and those which have to be boxed

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -546,7 +546,7 @@
             (when (current-referenced-aliases)
               (define alias-box (current-referenced-aliases))
               (set-box! alias-box (cons #'id (unbox alias-box))))
-            (add-disappeared-use (syntax-local-introduce #'id))
+            (add-disappeared-use #'id)
             t)]
          [else
           (parse-error #:delayed? #t (~a "type name `" (syntax-e #'id) "' is unbound"))

--- a/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
@@ -51,7 +51,6 @@
       [(Empty:) (values (list) id*)]))
   ;; calculate the type, resolving aliasing and paths if necessary
   (define ty (path-type alias-path (lookup-type/lexical alias-id)))
-  
   (ret ty
        (if (overlap ty (-val #f))
            (-FS (-not-filter (-val #f) obj) (-filter (-val #f) obj))

--- a/typed-racket-lib/typed-racket/utils/literal-syntax-class.rkt
+++ b/typed-racket-lib/typed-racket/utils/literal-syntax-class.rkt
@@ -39,4 +39,4 @@
            #:commit
            #:literal-sets ([literal-set])
            (pattern (~and op (~or pattern-literals ...))
-                    #:do [(add-disappeared-use (syntax-local-introduce #'op))]))))))
+                    #:do [(add-disappeared-use #'op)]))))))

--- a/typed-racket-lib/typed-racket/utils/tc-utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/tc-utils.rkt
@@ -74,7 +74,7 @@ don't depend on any other portion of the system
     (when (and (warn-unreachable?)
                (log-level? l 'warning)
                (and (syntax-transforming?)
-                    (syntax-original? (syntax-local-introduce e)))
+                    (syntax-original? e))
                #;(and (orig-module-stx)
                       (eq? (debugf syntax-source-module e)
                            (debugf syntax-source-module (orig-module-stx))))

--- a/typed-racket-lib/typed-racket/utils/utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/utils.rkt
@@ -185,7 +185,7 @@ at least theoretically.
     [(self arg ...) (datum->syntax stx
                                    (cons (syntax-property (transfer-srcloc orig #'self)
                                                           'constructor-for
-                                                          (syntax-local-introduce #'self))
+                                                          #'self)
                                          (syntax-e (syntax (arg ...))))
                                    stx
                                    stx)]


### PR DESCRIPTION
This patch is aimed at fixing `racket/typed` at the top level.

Room for improvement: a `syntax-local-introduce` in `tc-setup` is balanced separately in `mb-core` and `ti-core`, since the balancing call needs to be after optimization.