### PR TITLE
Reimplement toplevel typechecking with trampoline macros

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/exploring-types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/exploring-types.scrbl
@@ -33,7 +33,8 @@ The following bindings are only available at the Typed Racket REPL.
   ]
 }
 
-@defform[(:print-type e)]{Prints the type of @racket[_e]. This prints the whole
+@defform[(:print-type e)]{Prints the type of @racket[_e], which must be
+an expression. This prints the whole
 type, which can sometimes be quite large.
 
 @examples[#:eval the-top-eval

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1592,6 +1592,8 @@
           -Nat
           (-opt -Integer)
           (-opt -Integer))))]
+[identifier-binding-symbol
+ (Ident . ->opt . [(Un -Int (-val #f))] -Symbol)]
 
 ;; Section 12.4
 [set!-transformer? (-> Univ B)]

--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -158,6 +158,10 @@
           (make-contract-def-rhs #'ty #f (attribute parent))))
        (quasisyntax/loc stx
          (begin
+           ;; register the identifier so that it has a binding (for top-level)
+           #,@(if (eq? (syntax-local-context) 'top-level)
+                  (list #'(define-syntaxes (hidden) (values)))
+                  null)
            #,(internal #'(require/typed-internal hidden ty . sm))
            #,(ignore #`(require/contract nm.spec hidden #,cnt* lib))))]))
   (values (r/t-maker #t) (r/t-maker #f))))

--- a/typed-racket-lib/typed-racket/base-env/prims-struct.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-struct.rkt
@@ -135,23 +135,7 @@
                                 (dtsi* (vars.vars ...) nm (fs.form ...)
                                        #:maker #,cname
                                        #,@mutable?))])
-            (if (eq? (syntax-local-context) 'top-level)
-                ;; Use `eval` at top-level to avoid an unbound id error
-                ;; from dtsi trying to look at the d-s bindings.
-                #'(begin (eval (quote-syntax d-s))
-                         ;; It is important here that the object under the
-                         ;; eval is a quasiquoted literal in order
-                         ;; for #%top-interaction to get the lexical
-                         ;; information for TR's actual #%top-interaction.
-                         ;; This effectively lets us invoke the type-checker
-                         ;; dynamically.
-                         ;;
-                         ;; The quote-syntax is also important because we want
-                         ;; the `dtsi` to have the lexical information from
-                         ;; this module. This ensures that the `dtsi` macro
-                         ;; is actually bound to its definition above.
-                         (eval `(#%top-interaction . ,(quote-syntax dtsi))))
-                #'(begin d-s dtsi))))]))
+            #'(begin d-s dtsi)))]))
    (lambda (stx)
      (syntax-parse stx
        [(_ vars:maybe-type-vars nm:struct-name/new (fs:fld-spec ...)
@@ -166,11 +150,7 @@
                                        nm.old-spec (fs.form ...)
                                        #,@mutable?
                                        #,@prefab?))])
-            ;; see comment above
-            (if (eq? (syntax-local-context) 'top-level)
-                #'(begin (eval (quote-syntax d-s))
-                         (eval `(#%top-interaction . ,(quote-syntax dtsi))))
-                #'(begin d-s dtsi))))]))))
+            #'(begin d-s dtsi)))]))))
 
 
 ;; this has to live here because it's used below

--- a/typed-racket-lib/typed-racket/core.rkt
+++ b/typed-racket-lib/typed-racket/core.rkt
@@ -54,8 +54,6 @@
                      #,(if (unbox include-extra-requires?) extra-requires #'(begin))
                      before-code ... optimized-body ... after-code ... check-syntax-help)))))))]))
 
-(define did-I-suggest-:print-type-already? #f)
-(define :print-type-message " ... [Use (:print-type <expr>) to see more.]")
 (define (ti-core stx )
   (current-type-names (init-current-type-names))
   (syntax-parse stx
@@ -69,67 +67,4 @@
      ;; TODO(endobson): Remove the call to do-standard-inits when it is no longer necessary
      ;; Cast at the top-level still needs this for some reason
      (do-standard-inits)
-     (tc-toplevel/full stx #'form
-       (λ (body2 type)
-         (with-syntax*
-          ([(optimized-body ...) (maybe-optimize #`(#,body2))]
-           ;; Transform after optimization for top-level because the flattening will
-           ;; change syntax object identity (via syntax-track-origin) which doesn't work
-           ;; for looking up types in the optimizer.
-           [(transformed-body ...)
-            (change-contract-fixups (flatten-all-begins #'(begin optimized-body ...)))])
-          (define ty-str
-            (match type
-              ;; 'no-type means the form is not an expression and
-              ;; has no meaningful type to print
-              ['no-type #f]
-              ;; don't print results of type void
-              [(tc-result1: (== -Void type-equal?)) #f]
-              ;; don't print results of unknown type
-              [(tc-any-results: f) #f]
-              [(tc-result1: t f o)
-               ;; Don't display the whole types at the REPL. Some case-lambda types
-               ;; are just too large to print.
-               ;; Also, to avoid showing too precise types, we generalize types
-               ;; before printing them.
-               (define tc (cleanup-type t))
-               (define tg (generalize tc))
-               (format "- : ~a~a~a\n"
-                       (pretty-format-type tg #:indent 4)
-                       (cond [(equal? tc tg) ""]
-                             [else (format " [more precisely: ~a]" tc)])
-                       (cond [(equal? tc t) ""]
-                             [did-I-suggest-:print-type-already? " ..."]
-                             [else (set! did-I-suggest-:print-type-already? #t)
-                                   :print-type-message]))]
-              [(tc-results: t)
-               (define tcs (map cleanup-type t))
-               (define tgs (map generalize tcs))
-               (define tgs-val (make-Values (map -result tgs)))
-               (define formatted (pretty-format-type tgs-val #:indent 4))
-               (define indented? (regexp-match? #rx"\n" formatted))
-               (format "- : ~a~a~a\n"
-                       formatted
-                       (cond [(andmap equal? tgs tcs) ""]
-                             [indented?
-                              (format "\n[more precisely: ~a]"
-                                      (pretty-format-type (make-Values (map -result tcs))
-                                                          #:indent 17))]
-                             [else (format " [more precisely: ~a]" (cons 'Values tcs))])
-                       ;; did any get pruned?
-                       (cond [(andmap equal? t tcs) ""]
-                             [did-I-suggest-:print-type-already? " ..."]
-                             [else (set! did-I-suggest-:print-type-already? #t)
-                                   :print-type-message]))]
-              [x (int-err "bad type result: ~a" x)]))
-          (if (and ty-str
-                   (not (null? (syntax-e #'(transformed-body ...)))))
-              (with-syntax ([(transformed-body ... transformed-last)
-                             #'(transformed-body ...)])
-                #`(begin #,(if (unbox include-extra-requires?)
-                               extra-requires
-                               #'(begin))
-                         #,(arm #'(begin transformed-body ...))
-                         (begin0 #,(arm #'transformed-last)
-                           (display '#,ty-str))))
-              (arm #'(begin transformed-body ...))))))]))
+     (tc-toplevel/full stx #'form)]))

--- a/typed-racket-lib/typed-racket/typecheck/toplevel-trampoline.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/toplevel-trampoline.rkt
@@ -1,0 +1,173 @@
+#lang racket/base
+
+;; This module implements Typed Racket's trampolining top-level
+;; typechecking. The entrypoint is the function provided below, which
+;; sets up the trampoline.
+;;
+;; Subsequently, the macros forms defined in the submodule at the bottom
+;; take over and keep head local-expanding until `begin` forms are exhausted,
+;; at which point the syntax can be fully-expanded and checked normally.
+
+(require "../utils/utils.rkt"
+         syntax/parse
+         (private syntax-properties)
+         (for-template racket/base))
+
+(provide tc-toplevel-start)
+
+;; entrypoint for typechecking a top-level interaction
+;; this is defined in this module (instead of tc-top-level.rkt) in
+;; order to avoid cyclic dependency issues
+;; syntax -> syntax
+(define (tc-toplevel-start stx)
+  (syntax-parse stx
+    #:literal-sets (kernel-literals)
+    ;; Don't open up `begin`s that are supposed to be ignored
+    [(~and (begin e ... e-last)
+           (~not (~or _:ignore^ _:ignore-some^)))
+     #'(begin (tc-toplevel-trampoline e) ...
+              (tc-toplevel-trampoline/report e-last))]))
+
+(module trampolines racket/base
+  (require "../utils/utils.rkt"
+           (for-syntax racket/base
+                       racket/match
+                       syntax/kerncase
+                       syntax/parse
+                       syntax/stx
+                       (rep type-rep)
+                       (optimizer optimizer)
+                       (types utils abbrev printer generalize)
+                       (typecheck tc-toplevel tc-app-helper)
+                       (private type-contract syntax-properties)
+                       (utils disarm lift utils timing tc-utils arm)))
+
+  (provide tc-toplevel-trampoline
+           tc-toplevel-trampoline/report)
+
+  (define-for-syntax (maybe-optimize body)
+    ;; do we optimize?
+    (if (optimize?)
+        (begin
+          (do-time "Starting optimizer")
+          (begin0 (stx-map optimize-top body)
+            (do-time "Optimized")))
+        body))
+
+  (define-for-syntax (trampoline-core stx report? kont)
+    (syntax-parse stx
+      [(_ e)
+       (define head-expanded
+         (disarm*
+          (local-expand/capture* #'e 'top-level (kernel-form-identifier-list))))
+       (syntax-parse head-expanded
+         #:literal-sets (kernel-literals)
+         [(begin (define-values (n) _) ... (~or _:ignore^ _:ignore-some^))
+          #'e]
+         ;; keep trampolining on begins
+         [(begin (define-values (n) e-rhs) ... (begin e ... e-last))
+          #`(begin (tc-toplevel-trampoline (define-values (n) e-rhs)) ...
+                   (tc-toplevel-trampoline e) ...
+                   #,(if report?
+                         #'(tc-toplevel-trampoline/report e-last)
+                         #'(tc-toplevel-trampoline e-last)))]
+         [_
+          (define fully-expanded
+            ;; a non-begin form can still cause lifts, so still have to catch them
+            (disarm* (local-expand/capture* #'e 'top-level (list #'module*))))
+          ;; Unlike the `begin` cases, we probably don't need to trampoline back
+          ;; to the top-level because we're not catching lifts from macros at the
+          ;; top-level context but instead from expression context.
+          (parameterize ([expanded-module-stx fully-expanded])
+            (syntax-parse fully-expanded
+              #:literal-sets (kernel-literals)
+              [(begin form ...)
+               (define forms (syntax->list #'(form ...)))
+               (define result
+                 (for/last ([form (in-list forms)])
+                   (tc-toplevel-form form)))
+               ;; Transform after optimization for top-level because the flattening
+               ;; will change syntax object identity (via syntax-track-origin) which
+               ;; doesn't work for looking up types in the optimizer.
+               (define new-stx
+                 (apply append
+                        (for/list ([form (in-list forms)])
+                          (change-contract-fixups (maybe-optimize (list form))))))
+               (kont new-stx result)]))])]))
+
+  ;; Trampoline that continues the typechecking process.
+  (define-syntax (tc-toplevel-trampoline stx)
+    (trampoline-core
+     stx #f
+     (λ (new-stx result)
+       (arm
+        (if (unbox include-extra-requires?)
+            #`(begin #,extra-requires #,@new-stx)
+            #`(begin #,@new-stx))))))
+
+  (begin-for-syntax
+    (define did-I-suggest-:print-type-already? #f)
+    (define :print-type-message " ... [Use (:print-type <expr>) to see more.]"))
+
+  ;; Trampoline that continues the typechecking process and reports the type
+  ;; information to the user.
+  (define-syntax (tc-toplevel-trampoline/report stx)
+    (trampoline-core
+     stx #t
+     (λ (new-stx result)
+       (define ty-str
+         (match result
+           ;; 'no-type means the form is not an expression and
+           ;; has no meaningful type to print
+           ['no-type #f]
+           ;; don't print results of type void
+           [(tc-result1: (== -Void type-equal?)) #f]
+           ;; don't print results of unknown type
+           [(tc-any-results: f) #f]
+           [(tc-result1: t f o)
+            ;; Don't display the whole types at the REPL. Some case-lambda types
+            ;; are just too large to print.
+            ;; Also, to avoid showing too precise types, we generalize types
+            ;; before printing them.
+            (define tc (cleanup-type t))
+            (define tg (generalize tc))
+            (format "- : ~a~a~a\n"
+                    (pretty-format-type tg #:indent 4)
+                    (cond [(equal? tc tg) ""]
+                          [else (format " [more precisely: ~a]" tc)])
+                    (cond [(equal? tc t) ""]
+                          [did-I-suggest-:print-type-already? " ..."]
+                          [else (set! did-I-suggest-:print-type-already? #t)
+                                :print-type-message]))]
+           [(tc-results: t)
+            (define tcs (map cleanup-type t))
+            (define tgs (map generalize tcs))
+            (define tgs-val (make-Values (map -result tgs)))
+            (define formatted (pretty-format-type tgs-val #:indent 4))
+            (define indented? (regexp-match? #rx"\n" formatted))
+            (format "- : ~a~a~a\n"
+                    formatted
+                    (cond [(andmap equal? tgs tcs) ""]
+                          [indented?
+                           (format "\n[more precisely: ~a]"
+                                   (pretty-format-type (make-Values (map -result tcs))
+                                                       #:indent 17))]
+                          [else (format " [more precisely: ~a]" (cons 'Values tcs))])
+                    ;; did any get pruned?
+                    (cond [(andmap equal? t tcs) ""]
+                          [did-I-suggest-:print-type-already? " ..."]
+                          [else (set! did-I-suggest-:print-type-already? #t)
+                                :print-type-message]))]
+           [x (int-err "bad type result: ~a" x)]))
+       (define with-printing
+        (with-syntax ([(e ... e-last) new-stx])
+          (if ty-str
+              #`(begin e ...
+                       (begin0 e-last (display '#,ty-str)))
+              #'(begin e ... e-last))))
+       (arm
+        (if (unbox include-extra-requires?)
+            #`(begin #,extra-requires #,with-printing)
+            with-printing))))))
+
+(require (for-template (submod "." trampolines)))

--- a/typed-racket-lib/typed-racket/utils/lift.rkt
+++ b/typed-racket-lib/typed-racket/utils/lift.rkt
@@ -15,7 +15,7 @@
     (let loop ([stx stx])
       (define stx* (local-expand/capture-lifts stx ctx stop-ids))
       (syntax-parse stx*
-        #:literals (begin define-values)
+        #:literal-sets (kernel-literals)
         [(begin (define-values (n) e) ... e*)
          (define-values (sub-defss defs)
            (for/lists (_1 _2) ([e (in-list (syntax->list #'(e ...)))]

--- a/typed-racket-test/unit-tests/interactive-tests.rkt
+++ b/typed-racket-test/unit-tests/interactive-tests.rkt
@@ -152,10 +152,6 @@
       (:print-type))
     (test-form-exn #rx"exactly one argument"
       (:print-type 1 2))
-    (test-form (regexp-quote "has no type")
-      (:print-type (begin (begin))))
-    (test-form (regexp-quote "has no type")
-      (:print-type (require racket/format)))
 
     (test-form (regexp-quote "(-> 4 Zero Zero)")
       (:query-type/args * 4 0))


### PR DESCRIPTION
This pull request reimplements top-level typechecking. This new approach fixes the PR13747 regression due to the new expander and lets us eliminate hacks used to support the top-level. It is an alternative to PR #172.

One slight backwards incompatibility is that I changed `:print-type` and related functions to only work on expressions and not definitions or other top-level only constructs such as `require/typed`. I doubt people ever use `:print-type` on anything but expressions, so this seems ok.

I'll squash most of these commits before pushing.