### PR TITLE
Fix require/typed and similar macros in some module* or #lang contexts

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/def-export.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/def-export.rkt
@@ -9,8 +9,4 @@
 (define-syntax (def-export stx)
   (syntax-parse stx
     [(def-export export-id:identifier id:identifier cnt-id:identifier)
-     #'(define-syntax export-id
-         (let ([c #'cnt-id])
-           (if (unbox typed-context?)
-               (renamer #'id c)
-               (renamer c))))]))
+     #'(define-syntax export-id (typed-renaming #'id #'cnt-id))]))

--- a/typed-racket-lib/typed-racket/typecheck/def-export.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/def-export.rkt
@@ -9,7 +9,5 @@
 (define-syntax (def-export stx)
   (syntax-parse stx
     [(def-export export-id:identifier id:identifier cnt-id:identifier)
-     (with-syntax ([(indirection) (generate-temporaries (list 1))])
-       #'(begin
-           (define-syntax indirection (typed-indirection #'id))
-           (define-syntax export-id (typed-renaming #'indirection #'cnt-id))))]))
+     #'(define-syntax export-id (typed-renaming (syntax-property #'id 'not-free-identifier=? #t)
+                                                (syntax-property #'cnt-id 'not-free-identifier=? #t)))]))

--- a/typed-racket-lib/typed-racket/typecheck/def-export.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/def-export.rkt
@@ -9,4 +9,7 @@
 (define-syntax (def-export stx)
   (syntax-parse stx
     [(def-export export-id:identifier id:identifier cnt-id:identifier)
-     #'(define-syntax export-id (typed-renaming #'id #'cnt-id))]))
+     (with-syntax ([(indirection) (generate-temporaries (list 1))])
+       #'(begin
+           (define-syntax indirection (typed-indirection #'id))
+           (define-syntax export-id (typed-renaming #'indirection #'cnt-id))))]))

--- a/typed-racket-lib/typed-racket/typecheck/provide-handling.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/provide-handling.rkt
@@ -10,7 +10,7 @@
          (for-syntax racket/base)
          (for-template racket/base "def-export.rkt"))
 
-(provide remove-provides provide? generate-prov get-alternate)
+(provide remove-provides provide? generate-prov)
 
 (define (provide? form)
   (syntax-parse form

--- a/typed-racket-lib/typed-racket/typecheck/renamer.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/renamer.rkt
@@ -1,21 +1,11 @@
 #lang racket/base
 
-(provide renamer get-alternate un-rename)
+(provide renamer un-rename)
 
 ;; target : identifier
 ;; alternate : identifier
 (define-struct typed-renaming (target alternate)
   #:property prop:rename-transformer 0)
-
-;; identifier -> identifier
-;; get the alternate field of the renaming, if it exists
-(define (get-alternate id)
-  (define-values (v new-id) (syntax-local-value/immediate id (λ _ (values #f #f))))
-  (cond [(typed-renaming? v)
-         (typed-renaming-alternate v)]
-        [(rename-transformer? v)
-         (get-alternate (rename-transformer-target v))]
-        [else id]))
 
 (define (renamer id [alt #f])
   (if alt

--- a/typed-racket-lib/typed-racket/typecheck/renamer.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/renamer.rkt
@@ -1,47 +1,17 @@
 #lang racket/base
 
-(require typed-racket/utils/tc-utils
-         (for-template racket/base))
+(require typed-racket/utils/tc-utils)
 
-(provide typed-indirection typed-renaming un-rename)
+(provide typed-renaming un-rename)
 
-;; FIXME: use `make-variable-like-transformer` to abstract this pattern once
-;;        it gets an option to supply a function instead of syntax to operate
-;;        on the identifier.
-(define (rename obj stx)
-  (cond ;; Protect against the case that the renamed identifier is
-        ;; the only expression in the module, in which case expansion
-        ;; will happen before the #%module-begin of TR sets the typed
-        ;; context flag.
-        [(eq? (syntax-local-context) 'module-begin)
-         #`(#%expression #,stx)]
-        [(identifier? stx)
-         (if (unbox typed-context?)
-             (typed-renaming-target obj)
-             (typed-renaming-alternate obj))]
-        [else
-         (datum->syntax stx
-                        (cons (rename obj (car (syntax-e stx)))
-                              (cdr (syntax-e stx)))
-                        stx
-                        stx)]))
-
-;; this sets up a second indirection that just informs TR that there
-;; was a renaming established that can be checked by
-;; syntax-local-value/immediate
-(define-struct rename-indirect (target)
-  #:property prop:rename-transformer 0)
-
-(define (typed-indirection id)
-  (rename-indirect (syntax-property id 'not-free-identifier=? #t)))
-
+;; target : identifier
+;; alternate : identifier
 (define-struct typed-renaming (target alternate)
-  #:property prop:syntax-local-value
+  #:property prop:rename-transformer
   (λ (obj)
     (if (unbox typed-context?)
         (typed-renaming-target obj)
-        (typed-renaming-alternate obj)))
-  #:property prop:set!-transformer rename)
+        (typed-renaming-alternate obj))))
 
 ;; Undo renaming for type lookup.
 ;; Used because of macros that mark the identifier used as the binding such as
@@ -51,7 +21,7 @@
 (define (un-rename id)
   (if (syntax-transforming?)
       (let-values (((binding new-id) (syntax-local-value/immediate id (lambda () (values #f #f)))))
-        (if (rename-indirect? binding)
+        (if (typed-renaming? binding)
             new-id
             id))
       id))

--- a/typed-racket-test/succeed/gh-issue-163-1.rkt
+++ b/typed-racket-test/succeed/gh-issue-163-1.rkt
@@ -1,0 +1,18 @@
+#lang typed/racket
+
+;; Test for GH issue 163
+
+(: bar (case→ (→ 'a True) (→ 'b False)))
+(define (bar x) (if (eq? x 'a) #t #f))
+
+(module m typed/racket
+  (: foo (case→ (→ 'a True) (→ 'b False)))
+  (define (foo x) (if (eq? x 'a) #t #f))
+
+  (provide foo))
+
+(require 'm)
+
+(module+ test
+  (define b bar)
+  (define f foo))

--- a/typed-racket-test/succeed/gh-issue-163-2.rkt
+++ b/typed-racket-test/succeed/gh-issue-163-2.rkt
@@ -1,0 +1,9 @@
+#lang racket
+
+(module m typed/racket/base
+  (define x 1)
+  (provide x))
+
+(module n typed/racket/base
+  (require (submod ".." m))
+  (module* a #f x))

--- a/typed-racket-test/succeed/gh-issue-181.rkt
+++ b/typed-racket-test/succeed/gh-issue-181.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket
+
+;; Test case for GH issue #181
+
+(module m1 typed/racket
+  (provide bar)
+  (define-syntax-rule (bar) 42))
+
+(module m2 typed/racket
+  (require typed/racket
+           (submod ".." m1))
+  (provide (all-from-out typed/racket)
+           bar))
+
+(module m3 (submod ".." m2)
+  (bar))

--- a/typed-racket-test/succeed/require-typed-on-typed-module.rkt
+++ b/typed-racket-test/succeed/require-typed-on-typed-module.rkt
@@ -1,0 +1,11 @@
+#lang racket/base
+
+(module a typed/racket
+  (require/typed racket/base [values (-> String String)])
+  (provide values))
+
+(module b typed/racket
+  (require/typed (submod ".." a) [values (-> String Any)])
+  values)
+
+(require 'b)


### PR DESCRIPTION
This closes several bugs related to the typed context flag. In addition to the issues mentioned in the commit message, this should also fix a problem with `with-typed` and requires from other typed modules. (I'll add a test for that later)

This PR relies on a PR that's pending for Racket itself: https://github.com/plt/racket/pull/1020