### PR TITLE
fixed src loc propigation for n-ary*->binary

### DIFF
--- a/typed-racket-lib/typed-racket/optimizer/extflonum.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/extflonum.rkt
@@ -42,12 +42,12 @@
   #:literal-sets (kernel-literals)
   (pattern (#%plain-app op:unary-extflonum-op t:opt-expr)
     #:do [(log-extfl-opt "unary extflonum")]
-    #:with opt #'(op.unsafe t.opt))
+    #:with opt (syntax/loc this-syntax (op.unsafe t.opt)))
   (pattern (#%plain-app op:binary-extflonum-op t1:opt-expr t2:opt-expr)
     #:do [(log-extfl-opt "binary extflonum")]
-    #:with opt #'(op.unsafe t1.opt t2.opt))
+    #:with opt (syntax/loc this-syntax (op.unsafe t1.opt t2.opt)))
 
   (pattern (#%plain-app :fx->extfl-op f:fixnum-expr)
     #:do [(log-extfl-opt "fixnum to extflonum conversion")]
-    #:with opt #'(unsafe-fx->extfl f.opt))
+    #:with opt (syntax/loc this-syntax (unsafe-fx->extfl f.opt)))
   )

--- a/typed-racket-lib/typed-racket/optimizer/fixnum.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/fixnum.rkt
@@ -142,13 +142,13 @@
     #:with opt #'(op.unsafe n.opt))
   (pattern (op:fixnum-binary-op (~between ns:fixnum-expr 2 +inf.0) ...)
     #:do [(log-fx-opt "binary fixnum")]
-    #:with opt (n-ary->binary #'op.unsafe #'(ns.opt ...)))
+    #:with opt (n-ary->binary this-syntax #'op.unsafe #'(ns.opt ...)))
   (pattern (op:fixnum-binary-comp n1:fixnum-expr n2:fixnum-expr)
     #:do [(log-fx-opt "binary fixnum comp")]
     #:with opt #'(op.unsafe n1.opt n2.opt))
   (pattern (op:fixnum-binary-comp n1:fixnum-expr n2:fixnum-expr ns:fixnum-expr ...)
     #:do [(log-fx-opt "multi fixnum comp")]
-    #:with opt (n-ary-comp->binary #'op.unsafe #'n1.opt #'n2.opt #'(ns.opt ...)))
+    #:with opt (n-ary-comp->binary this-syntax #'op.unsafe #'n1.opt #'n2.opt #'(ns.opt ...)))
 
   (pattern (op:nonzero-fixnum-binary-op n1:fixnum-expr n2:nonzero-fixnum-expr)
     #:do [(log-fx-opt "binary nonzero fixnum")]
@@ -202,7 +202,7 @@
   (pattern (op:potentially-bounded-fixnum-op (~between ns:fixnum-expr 2 +inf.0) ...)
     #:when (check-if-safe stx)
     #:do [(log-fx-opt "fixnum bounded expr")]
-    #:with opt (n-ary->binary #'op.unsafe #'(ns.opt ...)))
+    #:with opt (n-ary->binary this-syntax #'op.unsafe #'(ns.opt ...)))
   (pattern (op:potentially-bounded-nonzero-fixnum-op n1:fixnum-expr n2:nonzero-fixnum-expr)
     #:when (check-if-safe stx)
     #:do [(log-fx-opt "nonzero fixnum bounded expr")]

--- a/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
@@ -145,7 +145,7 @@
     #:with (bindings ...)
       #`(cs.bindings ... ...
          #,@(let ()
-               (define (fl-sum cs) (n-ary->binary #'unsafe-fl+ cs))
+               (define (fl-sum cs) (n-ary->binary this-syntax #'unsafe-fl+ cs))
                (list
                 #`((real-binding) #,(fl-sum #'(cs.real-binding ...)))
                 #`((imag-binding) #,(fl-sum #'(cs.imag-binding ...)))))))
@@ -161,7 +161,7 @@
     #:with (bindings ...)
       #`(cs.bindings ... ...
          #,@(let ()
-              (define (fl-subtract cs) (n-ary->binary #'unsafe-fl- cs))
+              (define (fl-subtract cs) (n-ary->binary this-syntax #'unsafe-fl- cs))
               (list
                #`((real-binding) #,(fl-subtract #'(cs.real-binding ...)))
                #`((imag-binding) #,(fl-subtract #'(cs.imag-binding ...)))))))

--- a/typed-racket-lib/typed-racket/optimizer/float.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/float.rkt
@@ -195,7 +195,7 @@
            #:with opt (n-ary->binary this-syntax #'op.unsafe #'(fs.opt ...)))
   (pattern (#%plain-app op:binary-float-comp f1:float-expr f2:float-expr)
     #:do [(log-fl-opt "binary float comp")]
-    #:with opt #'(op.unsafe f1.opt f2.opt))
+    #:with opt (syntax/loc this-syntax (op.unsafe f1.opt f2.opt)))
   (pattern (#%plain-app op:binary-float-comp
                         f1:float-expr
                         f2:float-expr
@@ -227,13 +227,13 @@
 
   (pattern (#%plain-app op:-^ f:float-expr)
     #:do [(log-fl-opt "unary float")]
-    #:with opt #'(unsafe-fl* -1.0 f.opt))
+    #:with opt (syntax/loc this-syntax (unsafe-fl* -1.0 f.opt)))
   (pattern (#%plain-app op:/^ f:float-expr)
     #:do [(log-fl-opt "unary float")]
-    #:with opt #'(unsafe-fl/ 1.0 f.opt))
+    #:with opt (syntax/loc this-syntax (unsafe-fl/ 1.0 f.opt)))
   (pattern (#%plain-app op:sqr^ f:float-expr)
     #:do [(log-fl-opt "unary float")]
-    #:with opt #'(let ([tmp f.opt]) (unsafe-fl* tmp tmp)))
+    #:with opt (syntax/loc this-syntax (let ([tmp f.opt]) (unsafe-fl* tmp tmp))))
 
   ;; we can optimize exact->inexact if we know we're giving it an Integer
   (pattern (#%plain-app op:->float^ n:int-expr)
@@ -250,19 +250,19 @@
 
   (pattern (#%plain-app op:zero?^ f:float-expr)
     #:do [(log-fl-opt "float zero?")]
-    #:with opt #'(unsafe-fl= f.opt 0.0))
+    #:with opt (syntax/loc this-syntax (unsafe-fl= f.opt 0.0)))
 
   (pattern (#%plain-app op:add1^ n:float-expr)
     #:do [(log-fl-opt "float add1")]
-    #:with opt #'(unsafe-fl+ n.opt 1.0))
+    #:with opt (syntax/loc this-syntax (unsafe-fl+ n.opt 1.0)))
   (pattern (#%plain-app op:sub1^ n:float-expr)
     #:do [(log-fl-opt "float sub1")]
-    #:with opt #'(unsafe-fl- n.opt 1.0))
+    #:with opt (syntax/loc this-syntax (unsafe-fl- n.opt 1.0)))
 
   (pattern (#%plain-app op:random-op prng:opt-expr)
     #:when (subtypeof? #'prng -Pseudo-Random-Generator)
     #:do [(log-fl-opt "float random")]
-    #:with opt #'(unsafe-flrandom prng.opt))
+    #:with opt (syntax/loc this-syntax (unsafe-flrandom prng.opt)))
   (pattern (#%plain-app op:random^) ; random with no args
     #:do [(log-fl-opt "float 0-arg random")
           ;; We introduce a reference to `current-pseudo-random-generator',
@@ -270,7 +270,7 @@
           ;; from triggering down the line (see hidden-cost.rkt), so we need
           ;; to do the logging ourselves.
           (log-optimization-info "hidden parameter (random)" #'op)]
-    #:with opt #'(unsafe-flrandom (current-pseudo-random-generator)))
+    #:with opt (syntax/loc this-syntax (unsafe-flrandom (current-pseudo-random-generator))))
 
   ;; warn about (potentially) exact real arithmetic, in general
   ;; Note: These patterns don't perform optimization. They only produce logging
@@ -278,15 +278,15 @@
   (pattern (#%plain-app op:binary-float-op n:opt-expr ...)
     #:when (maybe-exact-rational? this-syntax)
     #:do [(log-opt-info "possible exact real arith")]
-    #:with opt #'(op n.opt ...))
+    #:with opt (syntax/loc this-syntax (op n.opt ...)))
   (pattern (#%plain-app op:binary-float-comp n:opt-expr ...)
      ;; can't look at return type, since it's always bool
      #:when (andmap maybe-exact-rational? (syntax->list #'(n ...)))
      #:do [(log-opt-info "possible exact real arith")]
-     #:with opt #'(op n.opt ...))
+     #:with opt (syntax/loc this-syntax (op n.opt ...)))
   (pattern (#%plain-app op:unary-float-op n:opt-expr ...)
      #:when (maybe-exact-rational? this-syntax)
      #:do [(log-opt-info "possible exact real arith")]
-     #:with opt #'(op n.opt ...))
+     #:with opt (syntax/loc this-syntax (op n.opt ...)))
   )
 

--- a/typed-racket-lib/typed-racket/optimizer/float.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/float.rkt
@@ -192,7 +192,7 @@
                          this-syntax extra-precision-subexprs)))
                     safe-to-opt?)
            #:do [(log-fl-opt "binary float")]
-           #:with opt (n-ary->binary #'op.unsafe #'(fs.opt ...)))
+           #:with opt (n-ary->binary this-syntax #'op.unsafe #'(fs.opt ...)))
   (pattern (#%plain-app op:binary-float-comp f1:float-expr f2:float-expr)
     #:do [(log-fl-opt "binary float comp")]
     #:with opt #'(op.unsafe f1.opt f2.opt))
@@ -201,7 +201,7 @@
                         f2:float-expr
                         fs:float-expr ...)
     #:do [(log-fl-opt "multi float comp")]
-    #:with opt (n-ary-comp->binary #'op.unsafe #'f1.opt #'f2.opt #'(fs.opt ...)))
+    #:with opt (n-ary-comp->binary this-syntax #'op.unsafe #'f1.opt #'f2.opt #'(fs.opt ...)))
   (pattern (#%plain-app op:binary-float-comp args:opt-expr ...)
     ;; some args, but not all (otherwise above would have matched) are floats
     ;; mixed-type comparisons are slow and block futures


### PR DESCRIPTION
Some of the arity changes for the math operations did not properly propagate syntax source locations.