### PR TITLE
Fix typo in generated contract for Nonpositive-Integer

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -788,7 +788,7 @@
   (define positive-integer/sc (numeric/sc Positive-Integer (and/c exact-integer? positive?)))
   (define natural/sc (numeric/sc Natural exact-nonnegative-integer?))
   (define negative-integer/sc (numeric/sc Negative-Integer (and/c exact-integer? negative?)))
-  (define nonpositive-integer/sc (numeric/sc Nonpositive-Integer (and/c exact-integer? nonpostive?)))
+  (define nonpositive-integer/sc (numeric/sc Nonpositive-Integer (and/c exact-integer? nonpositive?)))
   (define integer/sc (numeric/sc Integer exact-integer?))
   (define positive-rational/sc (numeric/sc Positive-Rational (and/c t:exact-rational? positive?)))
   (define nonnegative-rational/sc (numeric/sc Nonnegative-Rational (and/c t:exact-rational? nonnegative?)))

--- a/typed-racket-test/succeed/integer-contracts.rkt
+++ b/typed-racket-test/succeed/integer-contracts.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket/base
+
+(cast 2 Integer)
+(cast 2 Positive-Integer)
+(cast -2 Negative-Integer)
+(cast 2 Nonnegative-Integer)
+(cast -2 Nonpositive-Integer)


### PR DESCRIPTION
In the contract for `Nonpositive-Integer`, `nonpositive?` was misspelled as `nonpostive?`, creating an unbound identifier error when a contract needed to be generated.