### PR TITLE
Allow AnyValues as a return type in user code

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
@@ -16,7 +16,7 @@
 ;; special type names that are not bound to particular types
 (define-other-types
   -> ->* case-> U Rec All Opaque Vector
-  Parameterof List List* Class Object Values Instance Refinement
+  Parameterof List List* Class Object Values AnyValues Instance Refinement
   pred Struct Struct-Type Prefab Top Bot Distinction)
 
 (provide (rename-out [All ∀]

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -98,6 +98,7 @@
 (define-literal-syntax-class #:for-label Prefab)
 (define-literal-syntax-class #:for-label Values)
 (define-literal-syntax-class #:for-label values)
+(define-literal-syntax-class #:for-label AnyValues)
 (define-literal-syntax-class #:for-label Top)
 (define-literal-syntax-class #:for-label Bot)
 (define-literal-syntax-class #:for-label Distinction)
@@ -622,7 +623,7 @@
        (-Tuple (parse-types #'(tys ...)))])))
 
 ;; Syntax -> Type
-;; Parse a (Values ...) type
+;; Parse a (Values ...) or AnyValues type
 (define (parse-values-type stx)
   (parameterize ([current-orig-stx stx])
     (syntax-parse stx
@@ -644,6 +645,7 @@
                        var))]
       [((~or :Values^ :values^) tys ...)
        (-values (parse-types #'(tys ...)))]
+      [:AnyValues^ ManyUniv]
       [t
        (-values (list (parse-type #'t)))])))
 
@@ -874,6 +876,7 @@
      (ret (parse-types #'(t ...))
           (stx-map (lambda (x) -no-filter) #'(t ...))
           (stx-map (lambda (x) -no-obj) #'(t ...)))]
+    [:AnyValues^ (tc-any-results -no-filter)]
     [t (ret (parse-type #'t) -no-filter -no-obj)]))
 
 (define parse-type/id (parse/id parse-type))

--- a/typed-racket-test/succeed/pr14217.rkt
+++ b/typed-racket-test/succeed/pr14217.rkt
@@ -1,0 +1,5 @@
+#lang typed/racket
+(: foo (-> Integer AnyValues))
+(define (foo x)
+  x)
+(foo 5)

--- a/typed-racket-test/unit-tests/parse-type-tests.rkt
+++ b/typed-racket-test/unit-tests/parse-type-tests.rkt
@@ -134,6 +134,7 @@
     (-polydots (a) ((list) [a a] . ->... . N))]
    [(All (a ...) (-> (values a ...)))
     (-polydots (a) (t:-> (make-ValuesDots (list) a 'a)))]
+   [(-> Number AnyValues) (t:-> N ManyUniv)]
 
    ;; PR 14554, non-productive recursive type
    [FAIL (Rec x (All (A #:row) x))]


### PR DESCRIPTION
Two specific areas I'm unclear on and would appreciate comments about:

1) how filters should interact with AnyValues -- the representation does have a place to store one and I'm just using AnyValues with -top

2) the change in parse-tc-results (at the end of parse-type.rkt), mainly because I'm not clear on how parse-tc-results is (supposed to be) used.