### PR TITLE
Simplified bad syntax error reporting for let (changes c8f02eb by samth)

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -203,7 +203,7 @@ the typed racket language.
   (let ([mk (lambda (form)
               (lambda (stx)
                 (syntax-parse stx
-                  #:context (datum->syntax stx `(,form) stx stx)
+                  #:context (list (syntax-e form) stx)
                   [(_ (bs:optionally-annotated-binding ...) . body)
                    (quasisyntax/loc stx (#,form (bs.binding ...) . body))])))])
     (values (mk #'let) (mk #'let*) (mk #'letrec))))

--- a/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -203,10 +203,9 @@ the typed racket language.
   (let ([mk (lambda (form)
               (lambda (stx)
                 (syntax-parse stx
+                  #:context (datum->syntax stx `(,form) stx stx)
                   [(_ (bs:optionally-annotated-binding ...) . body)
-                   (quasisyntax/loc stx (#,form (bs.binding ...) . body))]
-                  [(_) (raise-syntax-error (syntax-e form) "bad syntax: expected more forms"
-                                           (datum->syntax stx `(,form) stx stx))])))])
+                   (quasisyntax/loc stx (#,form (bs.binding ...) . body))])))])
     (values (mk #'let) (mk #'let*) (mk #'letrec))))
 
 (define-syntaxes (-let-values -let*-values -letrec-values)


### PR DESCRIPTION
Changed the c8f02eb commit by samth, which fixed srcloc for syntax errors in `let`, to achieve the same thing but with slightly more readable code. Following our discussion on IRC last week:

```
<georges-duperon> samth: thanks for the let srcloc fix.
<georges-duperon> samth: Just curious, wouldn't #:context (datum->syntax stx `(,form) stx stx) have been enough, instead of having a custom raise-syntax-error as well?
<samth> georges-duperon: try it out, if it works submit a PR
```

It seems to work on my copy of racket.