### PR TITLE
fix a bug where cover+tests could call `syntax-local-introduce` when not transforming

### DIFF
--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -592,7 +592,8 @@
             (when (current-referenced-aliases)
               (define alias-box (current-referenced-aliases))
               (set-box! alias-box (cons #'id (unbox alias-box))))
-            (add-disappeared-use (syntax-local-introduce #'id))
+            (and (syntax-transforming?)
+                 (add-disappeared-use (syntax-local-introduce #'id)))
             t)]
          [else
           (parse-error #:delayed? #t (~a "type name `" (syntax-e #'id) "' is unbound"))

--- a/typed-racket-lib/typed-racket/utils/literal-syntax-class.rkt
+++ b/typed-racket-lib/typed-racket/utils/literal-syntax-class.rkt
@@ -39,4 +39,5 @@
            #:commit
            #:literal-sets ([literal-set])
            (pattern (~and op (~or pattern-literals ...))
-                    #:do [(add-disappeared-use (syntax-local-introduce #'op))]))))))
+                    #:do [(and (syntax-transforming?)
+                               (add-disappeared-use (syntax-local-introduce #'op)))]))))))


### PR DESCRIPTION
This is kind of a bad fix for florence/cover#83. But I still have no clue *how* the error mentioned there actually happens.