### PR TITLE
Fix github issue #205

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -330,7 +330,7 @@
   (define parent-tys (map fld-t (get-flds parent-type)))
 
   (define names (get-struct-names nm nm fld-names #f #f))
-  (define desc (struct-desc parent-tys tys null #t #f))
+  (define desc (struct-desc parent-tys tys null #f #f))
   (define sty (mk/inner-struct-type names desc parent-type))
 
   (register-sty! sty names desc)

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -43,7 +43,12 @@
 ;; setters : Listof[Id] or #f
 (struct struct-names (struct-name type-name struct-type constructor extra-constructor predicate getters setters) #:transparent)
 
-;;struct-fields: holds all the relevant information about a struct type's types
+;; struct-desc holds all the relevant information about a struct type's types
+;; parent-fields : (Listof Type)
+;; self-fields : (Listof Type)
+;; tvars : (Listof Symbol)
+;; mutable: Any
+;; proc-ty: (Option Type)
 (struct struct-desc (parent-fields self-fields tvars mutable proc-ty) #:transparent)
 
 (define (struct-desc-all-fields fields)

--- a/typed-racket-lib/typed-racket/types/remove-intersect.rkt
+++ b/typed-racket-lib/typed-racket/types/remove-intersect.rkt
@@ -88,8 +88,8 @@
          [(list (Struct: n #f flds _ _ _)
                 (StructTop: (Struct: n* #f flds* _ _ _)))
           #f]
-         [(list (and t1 (Struct: _ _ _ _ _ _))
-                (and t2 (Struct: _ _ _ _ _ _)))
+         [(list (and t1 (Struct: _ _ _ _ #f _))
+                (and t2 (Struct: _ _ _ _ #f _)))
           (or (subtype t1 t2) (subtype t2 t1))]
          [else #t])])))
 

--- a/typed-racket-test/fail/no-setters-for-built-in-structs.rkt
+++ b/typed-racket-test/fail/no-setters-for-built-in-structs.rkt
@@ -1,0 +1,8 @@
+#;
+(exn-pred #rx"missing type for top-level")
+#lang racket/load
+
+;; Test that built-in struct fields don't have types for setters
+
+(require typed/racket/base)
+set-date-second!

--- a/typed-racket-test/fail/poly-struct-mutable-parent.rkt
+++ b/typed-racket-test/fail/poly-struct-mutable-parent.rkt
@@ -1,0 +1,20 @@
+#lang typed/racket
+
+;; The call to `set-foo-x!` below should fail because the
+;; predicate filter on `bar?` has to be restrictive.
+
+(struct (A) foo ([x : A]) #:mutable)
+
+(struct (A) baz foo ())
+
+(define (f [i : Integer]) : (foo Integer)
+    (baz i))
+
+(: x (foo Integer))
+(define x (f 1))
+
+(: y Any)
+(define y x)
+
+(if (baz? y) (set-foo-x! y "foo") 2)
+(foo-x x)

--- a/typed-racket-test/succeed/gh-issue-205.rkt
+++ b/typed-racket-test/succeed/gh-issue-205.rkt
@@ -1,0 +1,14 @@
+#lang typed/racket
+
+;; A test for GH issue #205
+
+(struct (A) foo ([x : A]))
+
+(struct (A) baz foo ())
+
+(define (f [i : Integer]) : (foo Integer)
+    (baz i))
+
+(require typed/rackunit)
+
+(check-equal? (if (baz? (f 1)) 1 2) 1)


### PR DESCRIPTION
This PR fixes issue #205 and some related bugs I found, but unfortunately there is one test that doesn't pass right now.

I think that the test actually exhibits broken behavior, so I wanted a second opinion on what to do about it.

The problematic test is this one: https://github.com/racket/typed-racket/blob/master/typed-racket-test/succeed/poly-struct-parent.rkt

On my PR branch, line 25 fails to typecheck because the predicate on that line has a filter that overlaps with the `Box2` type. Unfortunately, the original behavior (that the types don't overlap) is also wrong because it makes that whole conditional branch into dead code (try adding `(+ 1 "foo")` in that cond branch). Anyone have suggestions on how to fix this test?