### PR TITLE
Have optimizer ignore code more consistently

### DIFF
--- a/typed-racket-lib/typed-racket/optimizer/hidden-costs.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/hidden-costs.rkt
@@ -4,7 +4,7 @@
          (for-template racket/base)
          "../utils/utils.rkt"
          (optimizer utils logging)
-         (types abbrev struct-table))
+         (types abbrev numeric-tower struct-table))
 
 (provide hidden-cost-log-expr)
 
@@ -64,4 +64,12 @@
     #:when (not (or (subtypeof? #'pattern-arg -Regexp)
                     (subtypeof? #'pattern-arg -Byte-Regexp)))
     #:do [(log-optimization-info "non-regexp pattern" #'pattern-arg)]
-    #:with opt (syntax/loc this-syntax (op pattern-arg.opt args.opt ...))))
+    #:with opt (syntax/loc this-syntax (op pattern-arg.opt args.opt ...)))
+
+  ;; vectors of floats can be replaced with flvectors in most cases
+  ;; need to deconstruct to not infinite loop
+  (pattern (#%plain-app es ...)
+    #:when (subtypeof? this-syntax (-vec -Flonum))
+    #:with (es*:opt-expr ...) #'(es ...)
+    #:do [(log-optimization-info "vector of floats" this-syntax)]
+    #:with opt (syntax/loc this-syntax (es*.opt ...))))

--- a/typed-racket-lib/typed-racket/optimizer/optimizer.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/optimizer.rkt
@@ -24,9 +24,9 @@
   (pattern opt:ignore-table^)
 
   ;; Can't optimize the body of this code because it isn't typechecked
-  (pattern (~and _:kw-lambda^
-             ((~and op let-values)
-              ([(i:id) e-rhs:opt-expr]) e-body:expr ...))
+  (pattern (~and (~or _:kw-lambda^ _:opt-lambda^)
+                 ((~and op let-values)
+                  ([(i:id) e-rhs:opt-expr]) e-body:expr ...))
            #:with opt (quasisyntax/loc/origin this-syntax #'op
                         (op ([(i) e-rhs.opt]) e-body ...)))
 

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-keywords.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-keywords.rkt
@@ -6,7 +6,7 @@
          "utils.rkt"
          syntax/parse syntax/stx racket/match racket/set
          (typecheck signatures tc-app-helper tc-funapp tc-metafunctions)
-         (types abbrev utils substitute subtype)
+         (types abbrev utils substitute subtype type-table)
          (rep type-rep)
          (utils tc-utils)
          (r:infer infer)
@@ -35,6 +35,7 @@
     ;; If #t, then the contract system has inserted an extra argument which we
     ;; need to ignore
     #:attr boundary-ctc? (contract-neg-party-property #'fn)
+    #:do [(for-each register-ignored! (syntax->list #'form))] ; no type info, so can't optimize
     #:with pos-args (if (attribute boundary-ctc?)
                         (stx-cdr #'*pos-args)
                         #'*pos-args)

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
@@ -7,7 +7,7 @@
          syntax/stx
          racket/sequence
          (typecheck signatures tc-funapp)
-         (types abbrev utils)
+         (types abbrev type-table utils)
          (private type-annotation)
          (rep type-rep filter-rep)
          (utils tc-utils)
@@ -26,6 +26,7 @@
   ;; parameterize
   (pattern (extend-parameterization pmz (~seq params args) ...)
     (begin
+      (register-ignored! #'pmz)
       (for ([param (in-syntax #'(params ...))]
             [arg (in-syntax #'(args ...))])
         (match (single-value param)

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -117,6 +117,7 @@
       ;; definitions lifted from contracts should be ignored
       [(define-values (lifted) expr)
        #:when (contract-lifted-property #'expr)
+       #:do [(register-ignored! #'expr)]
        (list)]
       
       ;; register types of variables defined by define-values/invoke-unit forms
@@ -177,6 +178,7 @@
       ;; definitions lifted from contracts should be ignored
       [(define-values (lifted) expr)
        #:when (contract-lifted-property #'expr)
+       #:do [(register-ignored! #'expr)]
        (list)]
 
       [(define-values (var ...) expr)
@@ -235,6 +237,7 @@
                [expected-type (in-list (map cdr (signature->bindings import-sig)))])
            (define lexical-type (lookup-type/lexical member))
            (check-below lexical-type expected-type)))
+       (register-ignored! #'dviu)
        'no-type]
       ;; these forms we have been instructed to ignore
       [stx:ignore^
@@ -256,6 +259,7 @@
       ;; definitions lifted from contracts should be ignored
       [(define-values (lifted) expr)
        #:when (contract-lifted-property #'expr)
+       #:do [(register-ignored! #'expr)]
        'no-type]
 
       ;; definitions just need to typecheck their bodies

--- a/typed-racket-test/optimizer/missed-optimizations/float-vector.rkt
+++ b/typed-racket-test/optimizer/missed-optimizations/float-vector.rkt
@@ -1,0 +1,3 @@
+#lang typed/racket
+
+(vector 3.2 3.4)

--- a/typed-racket-test/optimizer/missed-optimizations/float-vector.rkt
+++ b/typed-racket-test/optimizer/missed-optimizations/float-vector.rkt
@@ -1,3 +1,13 @@
+#;#;
+#<<END
+TR info: float-vector.rkt 2:0 (vector 3.2 3.4) -- vector of floats
+END
+#<<END
+'#(3.2 3.4)
+
+END
+
 #lang typed/racket
+#reader typed-racket-test/optimizer/reset-port
 
 (vector 3.2 3.4)

--- a/typed-racket-test/optimizer/missed-optimizations/pair.rkt
+++ b/typed-racket-test/optimizer/missed-optimizations/pair.rkt
@@ -1,5 +1,6 @@
 #;#;
 #<<END
+TR info: pair.rkt 29:17 (mcar (quote ())) -- vector of floats
 TR missed opt: pair.rkt 12:16 (cdr (cdr (cdr (cdr (list 1 2 3))))) -- car/cdr on a potentially empty list -- caused by: 12:21 (cdr (cdr (cdr (list 1 2 3))))
 TR missed opt: pair.rkt 15:0 (mcar (values (ann (mlist 1) (MListof Byte)))) -- car/cdr on a potentially empty list -- caused by: 15:6 (values (ann (mlist 1) (MListof Byte)))
 TR missed opt: pair.rkt 17:0 (mcdr (values (ann (mlist 1) (MListof Byte)))) -- car/cdr on a potentially empty list -- caused by: 17:6 (values (ann (mlist 1) (MListof Byte)))

--- a/typed-racket-test/optimizer/missed-optimizations/precision-loss.rkt
+++ b/typed-racket-test/optimizer/missed-optimizations/precision-loss.rkt
@@ -1,6 +1,7 @@
 #;#;
 #<<END
 TR info: precision-loss.rkt 10:3 (- 3/4) -- possible exact real arith
+TR info: precision-loss.rkt 12:31 (assert (+ 1/4 3/4) exact-integer?) -- vector of floats
 TR info: precision-loss.rkt 12:39 (+ 1/4 3/4) -- possible exact real arith
 TR info: precision-loss.rkt 18:0 (* (* (r 3/4) 2/3) (car (list (* 2.0 (* (r 3/4) 2/3)))) 2.0) -- possible exact real arith
 TR info: precision-loss.rkt 18:3 (* (r 3/4) 2/3) -- possible exact real arith

--- a/typed-racket-test/optimizer/tests/both-if-branches-dead.rkt
+++ b/typed-racket-test/optimizer/tests/both-if-branches-dead.rkt
@@ -1,5 +1,6 @@
 #;#;
 #<<END
+TR info: both-if-branches-dead.rkt 3:6 (k (void)) -- vector of floats
 TR opt: both-if-branches-dead.rkt 4:6 12 -- dead then branch
 TR opt: both-if-branches-dead.rkt 5:6 (* 3 4) -- dead else branch
 END

--- a/typed-racket-test/optimizer/tests/dead-substructs.rkt
+++ b/typed-racket-test/optimizer/tests/dead-substructs.rkt
@@ -1,5 +1,6 @@
 #;#;
 #<<END
+TR info: dead-substructs.rkt 13:14 (error "eh?") -- vector of floats
 TR info: dead-substructs.rkt 15:4 make-child1 -- struct constructor
 TR info: dead-substructs.rkt 16:4 make-child2 -- struct constructor
 END

--- a/typed-racket-test/optimizer/tests/float-promotion.rkt
+++ b/typed-racket-test/optimizer/tests/float-promotion.rkt
@@ -1,5 +1,6 @@
 #;#;
 #<<END
+TR info: float-promotion.rkt 2:3 (assert (modulo 1 2) exact-positive-integer?) -- vector of floats
 TR opt: float-promotion.rkt 2:0 (+ (assert (modulo 1 2) exact-positive-integer?) 2.0) -- binary float
 TR opt: float-promotion.rkt 2:11 (modulo 1 2) -- binary nonzero fixnum
 TR opt: float-promotion.rkt 3:0 (+ (expt 100 100) 2.0) -- binary float

--- a/typed-racket-test/optimizer/tests/float-real.rkt
+++ b/typed-racket-test/optimizer/tests/float-real.rkt
@@ -1,6 +1,7 @@
 #;#;
 #<<END
 TR info: float-real.rkt 3:15 (* (ann 2 Integer) 3.2) -- possible exact real arith
+TR info: float-real.rkt 3:7 (assert (* (ann 2 Integer) 3.2) positive?) -- vector of floats
 TR info: float-real.rkt 4:0 (* 2.3 (* (ann 2 Integer) 3.1)) -- possible exact real arith
 TR info: float-real.rkt 4:7 (* (ann 2 Integer) 3.1) -- possible exact real arith
 TR missed opt: float-real.rkt 3:15 (* (ann 2 Integer) 3.2) -- all args float-arg-expr, result not Float -- caused by: 3:23 2

--- a/typed-racket-test/optimizer/tests/invalid-fxquotient.rkt
+++ b/typed-racket-test/optimizer/tests/invalid-fxquotient.rkt
@@ -1,5 +1,6 @@
 #;#;
 #<<END
+TR info: invalid-fxquotient.rkt 2:41 (assert (- (expt 2 30)) fixnum?) -- vector of floats
 TR info: invalid-fxquotient.rkt 5:14 (fxquotient 3 0) -- non-optimized fixnum op
 TR missed opt: invalid-fxquotient.rkt 3:21 (quotient fixnum-min -1) -- out of fixnum range
 END

--- a/typed-racket-test/optimizer/tests/opt-arg.rkt
+++ b/typed-racket-test/optimizer/tests/opt-arg.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base
+
+;; The optimizer now looks at all expressions regardless of shape (to log
+;; all expressions with type (Vectorof Float) as candidates for uses of
+;; flvectors).
+;; This revealed that, previously, the optimizer did not skip the generated
+;; body of optional arg function definitions (which is not typechecked, and so
+;; should be skipped). It did for kw arg functions, but not optional.
+;; This is now fixed, and this test is to guard against regressions.
+
+(define (slicef-at [force? #f])
+  #f)

--- a/typed-racket-test/optimizer/tests/opt-arg.rkt
+++ b/typed-racket-test/optimizer/tests/opt-arg.rkt
@@ -1,4 +1,10 @@
+#;#;
+#<<END
+END
+""
+
 #lang typed/racket/base
+#reader typed-racket-test/optimizer/reset-port
 
 ;; The optimizer now looks at all expressions regardless of shape (to log
 ;; all expressions with type (Vectorof Float) as candidates for uses of

--- a/typed-racket-test/optimizer/tests/opt-arg.rkt
+++ b/typed-racket-test/optimizer/tests/opt-arg.rkt
@@ -10,3 +10,10 @@
 
 (define (slicef-at [force? #f])
   #f)
+
+
+;; Similar issue, with static call sites for keyword argument functions.
+(define (validate-txexpr-element #:context [txexpr-context #f])
+  #f)
+(define (validate-txexpr x)
+  (validate-txexpr-element #:context x))

--- a/typed-racket-test/optimizer/tests/sqrt-segfault.rkt
+++ b/typed-racket-test/optimizer/tests/sqrt-segfault.rkt
@@ -1,5 +1,6 @@
 #;#;
 #<<END
+TR info: sqrt-segfault.rkt 10:14 (assert (* dist2 (sqrt dist2)) flonum?) -- vector of floats
 TR missed opt: sqrt-segfault.rkt 10:31 (sqrt dist2) -- unexpected complex type
 TR opt: sqrt-segfault.rkt 8:14 (- 0.0 0.0) -- binary float
 TR opt: sqrt-segfault.rkt 9:14 (* dx dx) -- binary float

--- a/typed-racket-test/optimizer/tests/vector-bounds-check.rkt
+++ b/typed-racket-test/optimizer/tests/vector-bounds-check.rkt
@@ -1,5 +1,9 @@
 #;#;
 #<<END
+TR info: vector-bounds-check.rkt 11:6 (error "make-my-flvector should only be called once!") -- vector of floats
+TR info: vector-bounds-check.rkt 15:12 (make-my-vector) -- vector of floats
+TR info: vector-bounds-check.rkt 6:6 (error "make-my-vector should only be called once!") -- vector of floats
+TR info: vector-bounds-check.rkt 8:7 (vector 1.0 2.0 3.0) -- vector of floats
 TR opt: vector-bounds-check.rkt 15:0 (vector-ref (make-my-vector) 0) -- vector partial bounds checking elimination
 TR opt: vector-bounds-check.rkt 16:0 (flvector-ref (make-my-flvector) (ann 0 Fixnum)) -- flvector partial bounds checking elimination
 END

--- a/typed-racket-test/optimizer/tests/vector-sum.rkt
+++ b/typed-racket-test/optimizer/tests/vector-sum.rkt
@@ -1,5 +1,6 @@
 #;#;
 #<<END
+TR info: vector-sum.rkt 7:30 (make-vector l 0.0) -- vector of floats
 TR opt: vector-sum.rkt 10:2 (for: ((i : Nonnegative-Fixnum (in-range l))) (vector-set! v i (sin (exact->inexact i)))) -- binary fixnum comp
 TR opt: vector-sum.rkt 10:2 (for: ((i : Nonnegative-Fixnum (in-range l))) (vector-set! v i (sin (exact->inexact i)))) -- dead else branch
 TR opt: vector-sum.rkt 10:2 (for: ((i : Nonnegative-Fixnum (in-range l))) (vector-set! v i (sin (exact->inexact i)))) -- dead else branch

--- a/typed-racket-test/succeed/gui-lang.rkt
+++ b/typed-racket-test/succeed/gui-lang.rkt
@@ -5,4 +5,4 @@
 (define (f #{x : Integer}) (add1 x))
 (f 3)
 
-(make-object bitmap% 300 300)
+(make-object bitmap% (+ 300 300) 300)


### PR DESCRIPTION
The optimizer relied implicitly on the following invariant: all expressions either have a type in the type table, or an entry in the ignore table.
With the added missed optimization logging in the second commit, the optimizer now relies on that invariant explicitly, which turns all the instances where it didn't hold into errors.
This PR restores that invariant everywhere.

This also requires a change to the contract system (https://github.com/racket/racket/pull/1093), since TR relies on it to ignore contract-related code, and the contract system was not always marking the relevant code.

I'm not very happy with the solution in the 3rd commit, so any feedback on how to improve it is welcome.