### PR TITLE
extend define-new-subtype to polymorphic types

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-struct.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-struct.rkt
@@ -205,5 +205,14 @@
            #,(ignore
               #'(define constructor (lambda (x) x)))
            #,(internal (syntax/loc stx
-                         (unsafe-:-internal constructor (-> rep-ty ty)))))])))
+                         (unsafe-:-internal constructor (-> rep-ty ty)))))]
+      [(define-new-subtype (ty:id arg:id ...) (constructor:id rep-ty:expr))
+       #:with gen-id (generate-temporary #'ty)
+       #`(begin
+           (define-type-alias (ty arg ...) (Distinction ty gen-id rep-ty))
+           #,(ignore
+              #'(define constructor (lambda (x) x)))
+           #,(internal (syntax/loc stx
+                         (unsafe-:-internal constructor (All (arg ...) (-> rep-ty (ty arg ...)))))))]
+      )))
 

--- a/typed-racket-lib/typed-racket/base-env/prims-struct.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-struct.rkt
@@ -205,5 +205,5 @@
            #,(ignore
               #'(define constructor (lambda (x) x)))
            #,(internal (syntax/loc stx
-                         (define-new-subtype-internal ty (constructor rep-ty) #:gen-id gen-id))))])))
+                         (unsafe-:-internal constructor (-> rep-ty ty)))))])))
 

--- a/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
@@ -21,7 +21,6 @@
   internal
 
   type-alias
-  new-subtype-def
   type-refinement
   typed-struct
   typed-struct/exec
@@ -29,12 +28,12 @@
   typed-require/struct
   predicate-assertion
   type-declaration
+  unsafe-type-declaration
   typed-define-signature
   typed-define-values/invoke-unit
   typecheck-failure
 
   type-alias?
-  new-subtype-def?
   typed-struct?
   typed-struct/exec?
   typed-define-signature?
@@ -63,6 +62,7 @@
                   assert-predicate-internal
                   declare-refinement-internal
                   :-internal
+                  unsafe-:-internal
                   typecheck-fail-internal
                   define-signature-internal
                   define-values/invoke-unit-internal))
@@ -141,8 +141,6 @@
 (define-internal-classes
   [type-alias
     (define-type-alias-internal name type args)]
-  [new-subtype-def
-    (define-new-subtype-internal name (constructor rep-type) #:gen-id gen-id)]
   [type-refinement
     (declare-refinement-internal predicate)]
   [typed-struct
@@ -157,6 +155,8 @@
     (assert-predicate-internal type predicate)]
   [type-declaration
     (:-internal id:identifier type)]
+  [unsafe-type-declaration
+    (unsafe-:-internal id:identifier type)]
   ;; the check field indicates whether this signature is being 
   ;; required from an untyped context in which case the super
   ;; value is ignored and information about parent signatures

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -71,8 +71,10 @@
        (list)]
 
       ;; define-new-subtype
-      [form:new-subtype-def
-       (handle-define-new-subtype/pass1 #'form)]
+      [form:unsafe-type-declaration
+       ;; (unsafe-:-internal id type)
+       (register-type #'form.id (parse-type #'form.type))
+       (list)]
 
       ;; declare-refinement
       ;; FIXME - this sucks and should die
@@ -581,14 +583,4 @@
   (tc-toplevel/pass1.5 form)
   (begin0 (tc-toplevel/pass2 form #f)
           (report-all-errors)))
-
-;; handle-define-new-subtype/pass1 : Syntax -> Empty
-(define (handle-define-new-subtype/pass1 form)
-  (syntax-parse form
-    [form:new-subtype-def
-     ;; (define-new-subtype-internal name (constructor rep-type) #:gen-id gen-id)
-     (define ty (parse-type (attribute form.name)))
-     (define rep-ty (parse-type (attribute form.rep-type)))
-     (register-type (attribute form.constructor) (-> rep-ty ty))
-     (list)]))
 

--- a/typed-racket-test/succeed/define-new-subtype-poly.rkt
+++ b/typed-racket-test/succeed/define-new-subtype-poly.rkt
@@ -1,0 +1,13 @@
+#lang typed/racket/base
+
+(define-new-subtype (Meters a) (meters a))
+
+(: m+ : (case-> [(Meters Real) (Meters Real) -> (Meters Real)]
+                [(Meters Number) (Meters Number) -> (Meters Number)]))
+(define (m+ a b)
+  (meters (+ a b)))
+
+(define x1 (m+ (meters 1) (meters 2)))
+(ann x1 (Meters Real))
+(define x2 (m+ (meters (ann 1 Number)) (meters 2)))
+(ann x2 (Meters Number))


### PR DESCRIPTION
So for example

``` racket
(define-new-subtype (Meters a) (meters a))
```

To allow `(Meters Real)`, `(Meters Number)`, or even `(Meters (Vectorof Real))`.
