### PR TITLE
Memoize the Un constructor for unions

### DIFF
--- a/typed-racket-lib/typed-racket/types/union.rkt
+++ b/typed-racket-lib/typed-racket/types/union.rkt
@@ -49,11 +49,16 @@
 ;; Normalizes representation by sorting types.
 ;; Type * -> Type
 ;; The input types can overlap and be union types
+(define Un-cache (make-weak-hash))
 (define Un
   (case-lambda 
     [() -Bottom]
     [(t) t]
     [args 
-     (define ts (foldr merge '()
-                       (remove-dups (sort (append-map flat args) type<?))))
-     (make-union* ts)]))
+     (cond [(hash-ref Un-cache args #f)]
+           [else
+            (define ts (foldr merge '()
+                              (remove-dups (sort (append-map flat args) type<?))))
+            (define type (make-union* ts))
+            (hash-set! Un-cache args type)
+            type])]))


### PR DESCRIPTION
This commit seems to help cut down typechecking time. I tried compiling the math library and also `new-metrics.rkt` with/without the commit and saw about a 10% speedup.

Can someone else try to confirm the speedup?