### PR TITLE
optimize `(-> Any Bool)` contract

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -72,6 +72,7 @@
          racket/struct-info
          syntax/struct
          syntax/location
+         (for-template "../utils/any-wrap.rkt")
          "../utils/tc-utils.rkt"
          "../private/syntax-properties.rkt"
          "../typecheck/internal-forms.rkt"
@@ -467,7 +468,7 @@
                                   si))
 
                          (dtsi* () spec ([fld : ty] ...) #:maker maker-name #:type-only)
-                         #,(ignore #'(require/contract pred hidden (any/c . c-> . boolean?) lib))
+                         #,(ignore #'(require/contract pred hidden (or/c struct-predicate-procedure?/c (c-> any-wrap/c boolean?)) lib))
                          #,(internal #'(require/typed-internal hidden (Any -> Boolean : nm)))
                          (require/typed #:internal (maker-name real-maker) nm lib
                                         #:struct-maker parent

--- a/typed-racket-lib/typed-racket/utils/any-wrap.rkt
+++ b/typed-racket-lib/typed-racket/utils/any-wrap.rkt
@@ -120,4 +120,10 @@
    #:projection (λ (blame) (λ (val) (((val-first-projection blame) val) #f)))
    #:val-first-projection val-first-projection))
 
-(provide any-wrap/c)
+;; Contract for "safe" struct predicate procedures.
+;; We can trust that these obey the type (-> Any Boolean).
+(define (struct-predicate-procedure?/c x)
+  (and (struct-predicate-procedure? x)
+       (not (impersonator? x))))
+
+(provide any-wrap/c struct-predicate-procedure?/c)

--- a/typed-racket-test/succeed/pr226-variation-1.rkt
+++ b/typed-racket-test/succeed/pr226-variation-1.rkt
@@ -1,0 +1,18 @@
+#lang typed/racket
+
+;; Struct predicates should not be wrapped in a contract
+;;  when they cross a typed/untyped boundary.
+;; We know they're safe! Don't suffer the indirection cost.
+
+(module untyped racket
+  (struct s ())
+  (provide (struct-out s)))
+
+(require/typed 'untyped
+  [#:struct s ()])
+
+(require/typed racket/contract/base
+  [has-contract? (-> Any Boolean)])
+
+(when (has-contract? s?)
+  (error 'pr226 "safe struct predicate was wrapped in a contract"))

--- a/typed-racket-test/succeed/pr226-variation-2.rkt
+++ b/typed-racket-test/succeed/pr226-variation-2.rkt
@@ -1,0 +1,20 @@
+#lang typed/racket
+
+;; Chaperoned struct predicates must be wrapped in a contract.
+;; (Even though `struct-predicate-procedure?` will return
+;;  true for these values)
+
+(module untyped racket
+  (struct s ())
+  (define s?? (chaperone-procedure s? (lambda (x) (x) x)))
+  ;; provide enough names to trick #:struct
+  (provide s struct:s (rename-out [s?? s?])))
+
+(require/typed 'untyped
+  [#:struct s ()])
+
+(define (fail-if-called)
+  (error 'pr226 "Untyped code invoked a higher-order value passed as 'Any'"))
+
+(with-handlers ([exn:fail:contract? (lambda (e) 'success)])
+  (s? fail-if-called))

--- a/typed-racket-test/succeed/pr226-variation-3.rkt
+++ b/typed-racket-test/succeed/pr226-variation-3.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket
+
+;; Untyped should not be able to pass arbitrary code in
+;;  in place of a struct predicate.
+
+(module untyped racket
+  (struct s ())
+  (define (s?? x)
+    (when (box? x)
+      (set-box! x (void)))
+    #t)
+  (provide s struct:s (rename-out [s?? s?])))
+
+(require/typed 'untyped
+  [#:struct s ()])
+
+(: suitcase (Boxof '$$$))
+(define suitcase (box '$$$))
+
+(with-handlers ([exn:fail:contract? (lambda (x) (void))])
+  (s? suitcase)
+  (void))
+
+(unless (and (eq? '$$$ (unbox suitcase)))
+  (error 'pr226 "THEY SLIPPED US A RINGER"))


### PR DESCRIPTION
Compile `(-> Any Bool)` types to an `(or/c struct-predicate-procedure? (-> any/c boolean?))` contract.
This avoids a great many indirections when using a struct (constructor, predicate, accessor ...) across a typed/untyped boundary.