### PR TITLE
Make TR's contract generation interact better with contract system optimizations

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -111,7 +111,7 @@
                     (λ (#:reason [reason #f]) (set! failure-reason reason))))
   (syntax-parse stx
     #:literal-sets (kernel-literals)
-    [(define-values ctc-id _)
+    [(define-values (ctc-id) _)
      ;; no need for ignore, the optimizer doesn't run on this code
      (cond [failure-reason
             #`(define-syntax (#,untyped-id stx)
@@ -123,7 +123,7 @@
            [else
             (match-define (list defs ctc) result)
             #`(begin #,@defs
-                     (define ctc-id #,ctc)
+                     (define-values (ctc-id) #,ctc)
                      (define-module-boundary-contract #,untyped-id
                        #,orig-id ctc-id
                        #:pos-source #,blame-id

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -529,8 +529,8 @@
            ;; indirection here (see the implementation in
            ;; provide-handling.rkt).
            ;;
-           ;; First, we generate a macro that expands to a
-           ;; `local-require` of the contracted identifier in the
+           ;; First, we generate a macro that lifts a
+           ;; `require` of the contracted identifier in the
            ;; #%contract-defs submodule:
            ;;    (define-syntax con-f (mk-redirect f))
            ;;
@@ -542,7 +542,7 @@
            ;; because it's important for `export-f` to be a
            ;; rename-transformer (making things like
            ;; `syntax-local-value` work right), but `con-f` can't be,
-           ;; since it expands to a `local-require`.
+           ;; since it lifts a `require`
            new-export-defs ...
 
            ;; Finally, we do the export:

--- a/typed-racket-lib/typed-racket/utils/redirect-contract.rkt
+++ b/typed-racket-lib/typed-racket/utils/redirect-contract.rkt
@@ -31,9 +31,9 @@
       (with-syntax ([mp (collapse-module-path-index
                          contract-defs-submod-modidx)]
                     [i (datum->syntax id (syntax-e id) stx stx)])
-        #`(let ()
-            (local-require (only-in mp [#,(datum->syntax #'mp (syntax-e #'i)) i]))
-            i))]
+        (syntax-local-lift-require
+         #`(rename mp i #,(datum->syntax #'mp (syntax-e #'i)))
+         #'i))]
      [else
       (datum->syntax stx
                      (cons (redirect (car (syntax-e stx)))


### PR DESCRIPTION
This fixes a performance regression in TR from v6.1.1 to v6.2 that @rfindler discovered.

The regression is due to a combination of two problems. One is some overaggressive definition lifting by the contract generation pass. The other is due to the expansion of contract definition submodule redirection macros.

You can observe the problem by running `typed-racket-test/performance/function-contract.rkt`. In v6.1.1 it should take about 90ms. HEAD is about 270ms. This PR should bring it back down to around 90ms.

There's a problem though, which is that it fails two tests because of something weird with the top-level.

Here's a minimal interaction showing the problem:

````
-> (module a typed/racket
     (: x (Boxof Integer)) (define x (box 3))
     (provide x))
-> (require 'a)
-> (set-box! x "foo")
-> x
; x: broke its own contract
;   promised: Integer
;   produced: "foo"
;   in: (box/c Integer)
;   contract from: a
;   blaming: a
;    (assuming the contract is correct)
;   at: readline-input:3.14
; [,bt for context]
````

For some reason the `x` in the `set-box!` doesn't have a contract, but the `x` later does. This only seems to happen for the top-level, and it also doesn't seem to trigger if the contracted variable is used as the head form of an expression.

Any ideas? Is there something wrong with my use of `syntax-local-lift-require` in commit c26e5dc7199ed142e2ab85804fdee0324923557b?