### PR TITLE
Fix types for assoc and member + tests for these

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -640,7 +640,10 @@
 
 [assq  (-poly (a b) (Univ (-lst (-pair a b)) . -> . (-opt (-pair a b))))]
 [assv  (-poly (a b) (Univ (-lst (-pair a b)) . -> . (-opt (-pair a b))))]
-[assoc (-poly (a b) (Univ (-lst (-pair a b)) . -> . (-opt (-pair a b))))]
+[assoc (-poly (a b c)
+              (cl->* (Univ (-lst (-pair a b)) . -> . (-opt (-pair a b)))
+                     (c (-lst (-pair a b)) (-> c a Univ)
+                        . -> . (-opt (-pair a b)))))]
 [assf  (-poly (a b) ((a . -> . Univ) (-lst (-pair a b))
                      . -> . (-opt (-pair a b))))]
 

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -632,9 +632,9 @@
 [memq (-poly (a) (-> Univ (-lst a) (-opt (-ne-lst a))))]
 [memv (-poly (a) (-> Univ (-lst a) (-opt (-ne-lst a))))]
 [memf (-poly (a) ((a . -> . Univ) (-lst a) . -> . (-opt (-ne-lst a))))]
-[member (-poly (a)
+[member (-poly (a b)
           (cl->* (Univ (-lst a) . -> . (-opt (-ne-lst a)))
-                 (Univ (-lst a) (-> a a Univ)
+                 (b (-lst a) (-> b a Univ)
                        . -> . (-opt (-ne-lst a)))))]
 [findf (-poly (a) ((a . -> . B) (-lst a) . -> . (-opt a)))]
 

--- a/typed-racket-test/succeed/assoc-with-is-equal-argument.rkt
+++ b/typed-racket-test/succeed/assoc-with-is-equal-argument.rkt
@@ -1,0 +1,28 @@
+#lang typed/racket
+
+(require typed/rackunit)
+
+;; Test that (assoc v lst is-equal?) always passes v as the first argument to
+;; is-equal? . If this is not the case, the type for the is-equal? argument
+;; should be (→ (U a c) (U a c) Any) instead of (→ c a Any).
+(let ([needle : Integer
+              ;; Use a random needle to prevent some optimizations (but not all)
+              (floor (inexact->exact (* (random) 200)))])
+  (assoc3 needle
+          (ann (map (λ ([x : Integer]) (cons x (format "~a" x))) (range 1000))
+               (Listof (Pairof Integer String)))
+          (λ ([x : Integer] [y : Integer])
+            ;; Check the needle is always the first argument
+            (check-equal? x needle)
+            ;; Check y = needle implies x = needle
+            (check-true (or (not (= y needle)) (= x needle)))
+            (= x y))))
+
+;; Test that the third is-equal? argument is taken into account. If it is taken
+;; into account, it will return '("c" . 2). If it isn't, it will return
+;; '("x" . 4) instead.
+(check-equal? (assoc "x"
+                     '(("bb" . 1) ("c" . 2) ("ddd" . 3) ("x" . 4))
+                     (lambda ([s1 : String] [s2 : String])
+                       (= (string-length s1) (string-length s2))))
+              '("c" . 2))

--- a/typed-racket-test/succeed/assoc-with-is-equal-argument.rkt
+++ b/typed-racket-test/succeed/assoc-with-is-equal-argument.rkt
@@ -8,15 +8,15 @@
 (let ([needle : Integer
               ;; Use a random needle to prevent some optimizations (but not all)
               (floor (inexact->exact (* (random) 200)))])
-  (assoc3 needle
-          (ann (map (λ ([x : Integer]) (cons x (format "~a" x))) (range 1000))
-               (Listof (Pairof Integer String)))
-          (λ ([x : Integer] [y : Integer])
-            ;; Check the needle is always the first argument
-            (check-equal? x needle)
-            ;; Check y = needle implies x = needle
-            (check-true (or (not (= y needle)) (= x needle)))
-            (= x y))))
+  (assoc needle
+         (ann (map (λ ([x : Integer]) (cons x (format "~a" x))) (range 1000))
+              (Listof (Pairof Integer String)))
+         (λ ([x : Integer] [y : Integer])
+           ;; Check the needle is always the first argument
+           (check-equal? x needle)
+           ;; Check y = needle implies x = needle
+           (check-true (or (not (= y needle)) (= x needle)))
+           (= x y))))
 
 ;; Test that the third is-equal? argument is taken into account. If it is taken
 ;; into account, it will return '("c" . 2). If it isn't, it will return

--- a/typed-racket-test/succeed/member-with-is-equal-argument.rkt
+++ b/typed-racket-test/succeed/member-with-is-equal-argument.rkt
@@ -1,0 +1,30 @@
+#lang typed/racket
+
+(require typed/rackunit)
+
+;; Test that (member v lst is-equal?) always passes v as the first argument to
+;; is-equal? . If this is not the case, the type for the is-equal? argument
+;; should be (→ (U a b) (U a b) Any) instead of (→ b a Any).
+
+(let ([needle : Integer
+              ;; Use a random needle to prevent some optimizations (but not all)
+              (floor (inexact->exact (* (random) 200)))])
+  (member needle
+          (range 1000)
+          (λ ([x : Integer] [y : Integer])
+            ;; Check the needle is always the first argument
+            (check-equal? x needle)
+            ;; Check y = needle implies x = needle
+            (check-true (or (not (= y needle)) (= x needle)))
+            (= x y))))
+
+;; Test that the third is-equal? argument is taken into account. If it is taken
+;; into account, it will return '("c" "ddd" "x"). If it isn't, it will return
+;; '("x") instead.
+(check-equal? (member "x"
+                      '("bb" "c" "ddd" "x")
+                      (lambda ([s1 : String] [s2 : String])
+                        (= (string-length s1) (string-length s2))))
+              '("c" "ddd" "x"))
+
+(check-equal? (member "x" '("bb" "c" "ddd" "x")) '("x"))

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -2374,13 +2374,15 @@
        ;; The result type shouldn't be widened to include that type though.
        [tc-e (member 3
                      '(a b c)
-                     (lambda: ([s1 : (U Number Symbol String)] [s2 : String])
-                       (= (string-length (format "~a" s1)) (string-length s2))))
+                     (lambda: ([s1 : (U Number Symbol String)] [s2 : Symbol])
+                       (= (string-length (format "~a" s1))
+                          (string-length (symbol->string s2)))))
              (t:Un (-val #f) (-lst (one-of/c 'a 'b 'c)))]
        [tc-e (assoc 3
                     '((a . #(a)) (b . #(b)) (c . #(c)))
                     (lambda: ([s1 : (U Number Symbol String)] [s2 : String])
-                      (= (string-length (format "~a" s1)) (string-length s2))))
+                      (= (string-length (format "~a" s1))
+                         (string-length (symbol->string s2)))))
              (t:Un (-val #f) (-pair (one-of/c 'a 'b 'c) (-vec -Symbol)))]
        ;; Reject `member` when needle not included in is-equal?'s argument type:
        [tc-err (member (ann 123 Number)

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -2370,47 +2370,6 @@
        [tc-e (vector-memq 3 #(a b c)) (t:Un (-val #f) -Index)]
        [tc-e (vector-memv 3 #(a b c)) (t:Un (-val #f) -Index)]
        [tc-e (vector-member 3 #(a b c)) (t:Un (-val #f) -Index)]
-       ;; Test that (member v lst is-equal?) always passes v as the first
-       ;; argument to is-equal? . If this is not the case, the type for the
-       ;; is-equal? argument should be (→ (U a b) (U a b) Any) instead of
-       ;; (→ b a Any).
-       ;; We use a random needle to prevent some of optimization (but not all):
-       (let ([needle : Integer (floor (inexact->exact (* (random) 200)))])
-         (member needle
-                 (range 1000)
-                 (λ ([x : Integer] [y : Integer])
-                   ;; Check the needle is always the first argument
-                   (check-equal? x needle)
-                   ;; Check y = needle implies x = needle
-                   (check-true (or (not (= y needle)) (= x needle)))
-                   (= x y))))
-       ;; Test that (assoc v lst is-equal?) always passes v as the first
-       ;; argument to is-equal? . If this is not the case, the type for the
-       ;; is-equal? argument should be (→ (U a c) (U a c) Any) instead of
-       ;; (→ c a Any).
-       ;; We use a random needle to prevent some of optimization (but not all):
-       (let ([needle : Integer (floor (inexact->exact (* (random) 200)))])
-         (assoc3 needle
-                 (ann (map (λ ([x : Integer]) (cons x (format "~a" x))) (range 1000))
-                      (Listof (Pairof Integer String)))
-                 (λ ([x : Integer] [y : Integer])
-                   ;; Check the needle is always the first argument
-                   (check-equal? x needle)
-                   ;; Check y = needle implies x = needle
-                   (check-true (or (not (= y needle)) (= x needle)))
-                   (= x y))))
-       ;; Test output of member with third is-equal? argument:
-       (check-equal? (member "x"
-                             '("bb" "c" "ddd" "x")
-                             (lambda ([s1 : String] [s2 : String])
-                               (= (string-length s1) (string-length s2))))
-                     '("c" "ddd" "x"))
-       ;; Test output of assoc with third is-equal? argument:
-       (check-equal? (assoc "x"
-                            '(("bb" . 1) ("c" . 2) ("ddd" . 3) ("x" . 4))
-                            (lambda ([s1 : String] [s2 : String])
-                              (= (string-length s1) (string-length s2))))
-                     '("c" . 2))
        ;; Test `member` with needle not included in is-equal?'s argument type:
        [tc-err (member (ann 123 Number)
                        '("bb" "c" "ddd")

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -2370,12 +2370,24 @@
        [tc-e (vector-memq 3 #(a b c)) (t:Un (-val #f) -Index)]
        [tc-e (vector-memv 3 #(a b c)) (t:Un (-val #f) -Index)]
        [tc-e (vector-member 3 #(a b c)) (t:Un (-val #f) -Index)]
-       ;; Test `member` with needle not included in is-equal?'s argument type:
+       ;; Allow needle to be a subtype of the first argument of is-equal?
+       ;; The result type shouldn't be widened to include that type though.
+       [tc-e (member 3
+                     '(a b c)
+                     (lambda: ([s1 : (U Number Symbol String)] [s2 : String])
+                       (= (string-length (format "~a" s1)) (string-length s2))))
+             (t:Un (-val #f) (-lst (one-of/c 'a 'b 'c)))]
+       [tc-e (assoc 3
+                    '((a . #(a)) (b . #(b)) (c . #(c)))
+                    (lambda: ([s1 : (U Number Symbol String)] [s2 : String])
+                      (= (string-length (format "~a" s1)) (string-length s2))))
+             (t:Un (-val #f) (-pair (one-of/c 'a 'b 'c) (-vec -Symbol)))]
+       ;; Reject `member` when needle not included in is-equal?'s argument type:
        [tc-err (member (ann 123 Number)
                        '("bb" "c" "ddd")
                        (lambda ([s1 : String] [s2 : String])
                          (= (string-length s1) (string-length s2))))]
-       ;; Test `assoc` with needle not included in is-equal?'s argument type:
+       ;; Reject `assoc` when needle not included in is-equal?'s argument type:
        [tc-err (assoc (ann 123 Number)
                       '(("bb" . 123) ("c" . 123) ("ddd" . 123))
                        (lambda ([s1 : String] [s2 : String])


### PR DESCRIPTION
Fixes github issue #223: “(member) has wrong type, exploiting the hole causes segfault”

* Fixes the type declaration for `member` so that it has the correct type for the third `is-equal?` argument.
* Changes the type declaration for `assoc` so that it accepts a third `is-equal?` argument
* Adds some tests to check the validity of the hypothesis about `member` and `assoc` always giving the needle as the first argument to the provided `is-equal?` function.
* Adds some tests to check that the typechecker correctly rejects `(member 123 '("bb" "c" "ddd") equal-length)`, where equal-length takes two strings, and the same for assoc.

----

I think it would be nice to also test that, the infered type arguments for `member` and `assoc` are correct  in the following code, but I don't know how to test the infered type arguments with `tc-e` and friends.

* For `member`, `a = (U 'a 'b 'c)` and `b = (U Number Symbol String)`, and not some wider type for `b`.
* For `assoc`, `a = (U 'a 'b 'c)` and `b = (Vectorof Symbol)` (I'm unsure about the `b`) and `c = (U Number Symbol String)`, and not some wider type for `c`.

```racket
       [tc-e (member 3
                     '(a b c)
                     (lambda: ([s1 : (U Number Symbol String)] [s2 : String])
                       (= (string-length (format "~a" s1)) (string-length s2))))
             (t:Un (-val #f) (-lst (one-of/c 'a 'b 'c)))]
       [tc-e (assoc 3
                    '((a . #(a)) (b . #(b)) (c . #(c)))
                    (lambda: ([s1 : (U Number Symbol String)] [s2 : String])
                      (= (string-length (format "~a" s1)) (string-length s2))))
             (t:Un (-val #f) (-pair (one-of/c 'a 'b 'c) (-vec -Symbol)))]
```