### PR TITLE
default implementation for object/c #:stronger

### DIFF
--- a/typed-racket-lib/typed-racket/utils/opaque-object.rkt
+++ b/typed-racket-lib/typed-racket/utils/opaque-object.rkt
@@ -81,7 +81,7 @@
 (begin-for-syntax
  (define-syntax-class object/c-clause
    #:attributes (method-names method-ctcs field-names field-ctcs)
-   (pattern (field [name:id ctc:expr] ...)
+   (pattern ((~literal field) [name:id ctc:expr] ...)
             #:with field-names #'(list (quote name) ...)
             #:with field-ctcs #'(list ctc ...)
             #:with method-names #'null

--- a/typed-racket-test/succeed/opaque-object-name.rkt
+++ b/typed-racket-test/succeed/opaque-object-name.rkt
@@ -1,0 +1,52 @@
+#lang racket
+(require typed-racket/utils/opaque-object rackunit
+         (for-syntax (only-in syntax/srcloc build-source-location-list)))
+
+;; --------------------------------------------------------------------------------------------------
+
+;; object/c-opaque names should be lists:
+;; - with 'object/c-opaque as the first element
+;; - and 1 element for each member of the contract (field spec, method, ...)
+(define-syntax (test-object/c-opaque-name-shape stx)
+  (syntax-case stx ()
+   [(_ . ctc-spec*)
+    #`(begin
+        #,@(for/list ([ctc-spec (in-list (syntax-e #'ctc-spec*))])
+            #`(let ([nm (contract-name (object/c-opaque #,@ctc-spec))])
+                (with-check-info* (list (make-check-location '#,(build-source-location-list ctc-spec)))
+                  (lambda ()
+                    (check-equal? (car nm) 'object/c-opaque)
+                    (check-equal? (length nm) (+ 1 #,(length (syntax-e ctc-spec)))))))))]))
+
+(test-object/c-opaque-name-shape
+  []
+  [(field [i integer?] [j string?])]
+  [(field [k (<=/c 0)])
+   (m (->m (-> integer? integer?) zero?))]
+  [(m1 (->m (-> integer? integer?) zero?))
+   (m2 (->m boolean?))
+   (m3 (->m natural-number/c any/c))]
+  [(field [a real?] [b (-> string?)])
+   (m1 (->m (-> integer? integer?) zero?))
+   (m2 (->m boolean?))
+   (m3 (->m natural-number/c any/c))]
+)
+
+;; --------------------------------------------------------------------------------------------------
+
+(define-syntax (test-object/c-vs-opaque-name stx)
+  (syntax-case stx ()
+   [(_ . ctc-spec*)
+    #`(begin
+      #,@(for/list ([ctc-spec (in-list (syntax-e #'ctc-spec*))])
+           #`(check-not-equal?
+               (contract-name (object/c #,@ctc-spec))
+               (contract-name (object/c-opaque #,@ctc-spec)))))]))
+
+(test-object/c-vs-opaque-name
+  []
+  [(field [i integer?])
+   (f (->m string? boolean?))]
+  [(hd (->m any/c))
+   (tl (->m object?))]
+)

--- a/typed-racket-test/succeed/opaque-object-stronger.rkt
+++ b/typed-racket-test/succeed/opaque-object-stronger.rkt
@@ -1,0 +1,186 @@
+#lang racket
+(require typed-racket/utils/opaque-object)
+
+;; --------------------------------------------------------------------------------------------------
+;; test helpers
+
+(define (test-stronger? ctc-stronger ctc-weaker)
+  (unless (contract-stronger? ctc-stronger ctc-weaker)
+    (error 'pr267
+           "contract ~a is unexpectedly weaker than ~a"
+           (contract-name ctc-stronger)
+           (contract-name ctc-weaker))))
+
+(define (test-not-stronger? ctc-stronger ctc-weaker)
+  (when (contract-stronger? ctc-stronger ctc-weaker)
+    (error 'pr267
+           "contract ~a is unexpectedly stronger than ~a"
+           (contract-name ctc-stronger)
+           (contract-name ctc-weaker))))
+
+;; --------------------------------------------------------------------------------------------------
+;; stronger? tests
+
+(let () ;; object/c-opaque with the same members
+  (test-stronger?
+    (object/c-opaque)
+    (object/c-opaque))
+
+  (test-stronger?
+    (object/c-opaque
+      (field (f1 integer?))
+      (m1 (->m object? object?)))
+    (object/c-opaque
+      (field (f1 integer?))
+      (m1 (->m object? object?))))
+
+  (test-stronger?
+    (object/c-opaque
+      (m1 (->m any/c object? (-> integer? integer?))))
+    (object/c-opaque
+      (m1 (->m any/c object? (-> integer? integer?)))))
+)
+
+(let () ;; object/c-opaque with fewer members (unspecified = opaque)
+  (test-stronger?
+    (object/c-opaque)
+    (object/c-opaque
+      (field (x symbol?))))
+
+  (test-stronger?
+    (object/c-opaque
+      (field (x symbol?)))
+    (object/c-opaque
+      (field (x symbol?))
+      (y (->m none/c none/c))))
+
+  (test-stronger?
+    (object/c-opaque
+      (f (->m void? any/c)))
+    (object/c-opaque
+      (f (->m void? any/c))
+      (g (->m integer? integer? integer?))))
+
+  (test-stronger?
+    (object/c-opaque
+      (field (a integer?))
+      (c (-> real? real?)))
+    (object/c-opaque
+      (field (a integer?)
+             (b integer?))
+      (c (-> real? real?))
+      (d (-> real? real?))))
+
+)
+
+(let () ;; object/c-opaque with stronger members
+
+  (test-stronger?
+    (object/c-opaque
+      (m1 (->m any/c integer?)))
+    (object/c-opaque
+      (m1 (->m any/c any/c))))
+
+  (test-stronger?
+    (object/c-opaque
+      (m1 (->m any/c any/c)))
+    (object/c-opaque
+      (m1 (->m integer? any/c))))
+
+  (test-stronger?
+    (object/c-opaque
+      (m1 (->m any/c integer?))
+      (m2 (->m any/c (listof boolean?))))
+    (object/c-opaque
+      (m1 (->m any/c integer?))
+      (m2 (->m any/c (listof any/c)))))
+
+  (test-stronger?
+    (object/c-opaque
+      (a (->m symbol?))
+      (b (->m (between/c 2 3)))
+      (c (->m any/c (listof (char-in #\A #\B)))))
+    (object/c-opaque
+      (a (->m symbol?))
+      (b (->m (between/c 0 5)))
+      (c (->m any/c (listof (char-in #\A #\Z))))))
+)
+
+(let () ;; vs. object/c
+  (test-stronger?
+    (object/c-opaque)
+    (object/c
+      (field (a boolean?))
+      (b (->m string? any/c))))
+
+  (test-stronger?
+    (object/c-opaque
+      (field (x any/c))
+      (h (->m (-> boolean? boolean? boolean?) integer?)))
+    (object/c))
+
+  (test-stronger?
+    (object/c-opaque
+      (field (x integer?))
+      (m1 (->m any/c any/c any/c)))
+    (object/c
+      (field (x integer?))
+      (m1 (->m any/c any/c any/c))))
+
+  (test-stronger?
+    (object/c-opaque
+      (m1 (->m any/c (</c 2))))
+    (object/c
+      (field (a real?) (b boolean?))
+      (m1 (->m any/c (</c 10)))))
+)
+
+;; --------------------------------------------------------------------------------------------------
+;; not-stronger? tests
+
+(let () ;; fields must be the same for stronger?
+  (test-not-stronger?
+    (object/c-opaque
+      (field (number (</c 999))))
+    (object/c-opaque
+      (field (number (</c 1)))))
+
+  (test-not-stronger?
+    (object/c-opaque
+      (field (number (</c 1))))
+    (object/c-opaque
+      (field (number (</c 999)))))
+
+  (test-not-stronger?
+    (object/c-opaque
+      (field (a symbol?)
+             (b integer?)
+             (c (-> any/c (listof zero?)))))
+    (object/c-opaque
+      (field (a symbol?)
+             (b real?)
+             (c (-> any/c (listof exact-nonnegative-integer?))))))
+)
+
+(let () ;; an object/c is never stronger than an object/c-opaque
+  (test-not-stronger?
+    (object/c-opaque
+      (f (->m integer? integer?)))
+    (object/c
+      (f (->m any/c none/c))))
+
+  (test-not-stronger?
+    (object/c
+      (f (->m any/c none/c)))
+    (object/c-opaque
+      (f (->m integer? integer?))))
+
+  (test-not-stronger?
+    (object/c
+      (field (x integer?))
+      (m1 (->m any/c any/c any/c)))
+    (object/c-opaque
+      (field (x real?))
+      (m1 (->m any/c any/c any/c))))
+
+)

--- a/typed-racket-test/succeed/pr267-variation-0.rkt
+++ b/typed-racket-test/succeed/pr267-variation-0.rkt
@@ -1,0 +1,26 @@
+#lang racket
+
+;; Regression test for PR 267
+;;   https://github.com/racket/typed-racket/pull/267
+;; Issue reported separately as:
+;;   https://github.com/racket/racket/issues/1198
+;; becuase it was really a racket/contract issue
+;; (impersonate-vector contracts were using chaperone-contract)
+
+(define con
+  (object/c (field [a* any/c])
+   (regenerate (->m (object/c (field [a* (vectorof (object/c))]))))))
+
+(define population%
+  (class object%
+   (super-new)
+   (init-field a*)
+   (define/public (regenerate)
+    (vector-ref (get-field a* this) 0)
+    this)))
+
+(define pop
+  (contract con (new population% [a* (vector (new (class object% (super-new))))]) 'p 'n))
+
+(void (send (send pop regenerate) regenerate))
+


### PR DESCRIPTION
Fixes the included microbenchmark. This does not seem to fix the wrappers from `fsmoo` and `forth`; those contracts must not be `eq?`.
