### PR TITLE
Fixes GH issue #268 “Can't provide promise for polymorphic struct”.

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -166,6 +166,7 @@
       typed-racket/utils/opaque-object
       typed-racket/utils/evt-contract
       typed-racket/utils/sealing-contract
+      typed-racket/utils/promise-not-name-contract
       racket/sequence
       racket/contract/parametric))
 

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
@@ -15,7 +15,8 @@
                        racket/async-channel
                        racket/sequence
                        racket/promise
-                       "../../utils/evt-contract.rkt")
+                       "../../utils/evt-contract.rkt"
+                       "../../utils/promise-not-name-contract.rkt")
          racket/contract
          racket/async-channel)
 
@@ -153,7 +154,7 @@
   ((set/sc (#:covariant #:chaperone)) set/c #:flat)
   ((vector/sc . (#:invariant)) vector/c #:chaperone)
   ((vectorof/sc (#:invariant)) vectorof #:chaperone)
-  ((promise/sc (#:covariant)) (λ (x) (and/c (promise/c x) (not/c promise/name?))) #:chaperone)
+  ((promise/sc (#:covariant)) promise-not-name/c #:chaperone)
   ((syntax/sc (#:covariant #:flat)) syntax/c #:flat)
   ((hash/sc (#:invariant #:flat) (#:invariant)) hash/c #:chaperone)
   ((box/sc (#:invariant)) box/c #:chaperone)

--- a/typed-racket-lib/typed-racket/utils/promise-not-name-contract.rkt
+++ b/typed-racket-lib/typed-racket/utils/promise-not-name-contract.rkt
@@ -1,0 +1,6 @@
+#lang racket/base
+
+(require racket/contract
+         racket/promise)
+(provide promise-not-name/c)
+(define (promise-not-name/c x) (and/c (promise/c x) (not/c promise/name?)))

--- a/typed-racket-test/succeed/promise-provide-generate-contract.rkt
+++ b/typed-racket-test/succeed/promise-provide-generate-contract.rkt
@@ -1,0 +1,5 @@
+#lang typed/racket
+
+(struct (A) s ([f : Any]))
+(define p (delay (s "a")))
+(provide p)


### PR DESCRIPTION
See also commit 5cd5f77 “Don't allow promises created with `delay/name` as `(Promise T)`.”.

The contracts in `typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt` should be just a single identifier, not a lambda expression, because `typed-racket-lib/typed-racket/private/type-contract.rkt` relies on that, and passes the contract name to `free-identifier=?`, which won't work on a lambda.