### PR TITLE
Fix GH issue #271

### DIFF
--- a/typed-racket-test/fail/gh-issue-271.rkt
+++ b/typed-racket-test/fail/gh-issue-271.rkt
@@ -1,0 +1,13 @@
+#;
+(exn-pred #rx"could not be converted")
+#lang racket/load
+
+;; Tests that p? cannot be generated
+
+(require typed/racket)
+
+(define-predicate p? (All (A) (Listof A)))
+
+(let ()
+  (: x (U (Listof Integer) Integer)) (define x '(1 2 3))
+  (if (p? x) 0 (add1 x)))


### PR DESCRIPTION
Propagate syntax properties when opening up begins at the top-level so that ignore properties will get transferred.