### PR TITLE
suppress error of unsupported (extflvector)

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -3,7 +3,8 @@
 @begin[(require "../utils.rkt"
                 "numeric-tower-pict.rkt"
                 scribble/example
-                racket/sandbox)
+                racket/sandbox
+                racket/extflonum)
        (require (for-label (only-meta-in 0 [except-in typed/racket for])
                            racket/async-channel))]
 
@@ -372,7 +373,9 @@ corresponding to @racket[trest], where @racket[bound]
 @defidform[FlVector]{An @rtech{flvector}.
   @ex[(flvector 1.0 2.0 3.0)]}
 @defidform[ExtFlVector]{An @rtech{extflvector}.
-  @ex[(extflvector 1.0t0 2.0t0 3.0t0)]}
+  @(if (extflonum-available?)
+       @ex[(extflvector 1.0t0 2.0t0 3.0t0)]
+       @ex[(eval:error (extflvector 1.0t0 2.0t0 3.0t0))])}
 @defidform[FxVector]{An @rtech{fxvector}.
   @ex[(fxvector 1 2 3)]}
 


### PR DESCRIPTION
building failed on solaris/illumos based system due to unsupported feature.

also, `scribble/examples` should handle this automatically. 