### PR TITLE
Follow TR error message conventions, as suggested by samth in PR #250 .

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
@@ -8,7 +8,7 @@
      #'(begin (define-syntax nm
                 (lambda (stx)
                   (raise-syntax-error 'type-check
-                                      (format "type name ~a used out of context in ~a"
+                                      (format "type name used out of context\n  type: ~a\n  in: ~a"
                                               (syntax->datum (if (stx-pair? stx)
                                                                  (stx-car stx)
                                                                  stx))

--- a/typed-racket-lib/typed-racket/base-env/extra-env-lang.rkt
+++ b/typed-racket-lib/typed-racket/base-env/extra-env-lang.rkt
@@ -52,7 +52,7 @@
                                    ;;        lift out to utility module maybe
                                    (define-syntax (type stx)
                                      (raise-syntax-error 'type-check
-                                                         (format "type name ~a used out of context in ~a"
+                                                         (format "type name used out of context\n  type: ~a\n  in: ~a"
                                                                  (syntax->datum (if (stx-pair? stx)
                                                                                     (stx-car stx)
                                                                                     stx))

--- a/typed-racket-lib/typed-racket/base-env/prims-struct.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-struct.rkt
@@ -235,7 +235,7 @@
        #'(lambda (stx)
            (raise-syntax-error
             'type-check
-            (format "type name ~a used out of context in ~a"
+            (format "type name used out of context\n  type: ~a\n in: ~a"
                     (syntax->datum (if (stx-pair? stx) (stx-car stx) stx))
                     (syntax->datum stx))
             stx

--- a/typed-racket-lib/typed-racket/base-env/type-env-lang.rkt
+++ b/typed-racket-lib/typed-racket/base-env/type-env-lang.rkt
@@ -10,7 +10,7 @@
           (define-syntax (nm stx)
             (raise-syntax-error
              'type-check
-             (format "type name ~a used out of context in ~a"
+             (format "type name used out of context\n  type: ~a\n  in: ~a"
                      (syntax->datum (if (stx-pair? stx) (stx-car stx) stx))
                      (syntax->datum stx))
              stx

--- a/typed-racket-test/fail/pr13209.rkt
+++ b/typed-racket-test/fail/pr13209.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred #rx"arguments for structure type constructor")
+(exn-pred #rx"wrong number of arguments to structure type constructor")
 #lang typed/racket
 
 ;; Test for PR 13209

--- a/typed-racket-test/fail/recursive-type-application.rkt
+++ b/typed-racket-test/fail/recursive-type-application.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred #rx"does not match the given number:")
+(exn-pred #rx"wrong number of arguments to polymorphic type")
 #lang typed/racket
 
 ;; Check bad arity for recursive invocation of Foo


### PR DESCRIPTION
I finally got around to change how arguments and other pieces of information are printed in TR's error messages, to follow the [error message conventions](http://docs.racket-lang.org/reference/exns.html?q=raise-arg#%28part._err-msg-conventions%29), as suggested by @samth [in PR #250](https://github.com/racket/typed-racket/pull/250#issuecomment-158788270).

One thing worth noting: The `(Poly-unsafe: n _)` and `(Name: name-id num-args #f)` now both give the same `wrong number of arguments to polymorphic type` error, as I couldn't find a meaningful difference for when they occur, from a user's perspective (it seems the former occurs in recursive applications, and the latter in non-recursive applications, but I'm not 100% sure). If the messages should make a distinction, please tell me what's the difference between the two cases, and I'll adjust the error messages.