### PR TITLE
[wip] add type-out provide-spec

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -2,6 +2,7 @@
 
 @begin[(require "../utils.rkt" scribble/example racket/sandbox)
        (require (for-label (only-meta-in 0 [except-in typed/racket])
+                           (only-in racket/contract contract-out)
                            (only-in racket/base)))]
 
 @(define the-eval (make-base-eval))
@@ -514,9 +515,6 @@ for function types.
     (: var4 : String -> Integer)]
 }
 
-@defform[(provide: [v t] ...)]{This declares that the @racket[v]s have
-the types @racket[t], and also provides all of the @racket[v]s.}
-
 @defform/none[#{v : t}]{ This declares that the variable @racket[v] has type
 @racket[t].  This is legal only for binding occurrences of @racket[_v].
 
@@ -676,6 +674,43 @@ Uses outside of a module top-level raise an error.
     (require 'evts)
     (sync (alarm-evt (+ 100 (current-inexact-milliseconds))))]
 }
+
+@section{Provide}
+
+@defform[(provide: [v t] ...)]{This declares that the @racket[v]s have
+the types @racket[t], and also provides all of the @racket[v]s.}
+
+@defform/subs[
+#:literals (rename struct type)
+(type-out type-out-spec ...)
+([type-out-spec
+  (id t)
+  (rename orig-id id t)
+  (struct maybe-type-vars name-spec ([f : t] ...) struct-option ...)
+  (type id t)]
+ [struct-option (code:line options)
+                #:omit-constructor])]{
+A @racket[_provide-spec] similar to @racket[contract-out] for use in @racket[provide]
+ (currently only for the same phase level as the enclosing @racket[provide] form).
+Declarations in a @racket[type-out] are visible within the module and exported to clients.
+
+The basic @racket[(id t)] form applies the type annotation @racket[t] to the identifier
+ @racket[id] and exports @racket[id].
+This has the same effect as the sequence @racket[(begin (: id t) (provide id))].
+
+The @racket[rename] form assigns @racket[orig-id] the type @racket[t] and exports
+ @racket[orig-id] under the name @racket[id].
+Within the module only @racket[orig-id] is visible, but clients may only use @racket[id].
+
+The @racket[struct] form accepts the same syntax as Typed Racket's @racket[struct] form
+ along with the @racket[#:omit-constructor] option from @racket[contract-out].
+This form defines a new structure type and exports the newly generated bindings;
+ if @racket[#:omit-constructor] is given the constructor name is not exported.
+
+The @racket[type] form defines @racket[id] as an alias for type @racket[t]
+ (using @racket[define-type]) and exports @racket[id].
+}
+
 
 @section{Other Forms}
 

--- a/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -34,6 +34,7 @@ the typed racket language.
                      def-redirect
                      define-for*-variants with-handlers: define-for/acc:-variants
                      base-for/flvector: base-for/vector -lambda -define -do -let
+                     provide-typed-vars
                      -let* -let*-values -let-values -let/cc -let/ec -letrec -letrec-values)
          (all-from-out "top-interaction.rkt")
          (all-from-out "case-lambda.rkt")
@@ -125,6 +126,7 @@ the typed racket language.
           syntax/parse/pre
           syntax/stx
           racket/list
+          racket/provide-transform
           racket/syntax
           racket/base
           (only-in "../typecheck/internal-forms.rkt" internal)
@@ -635,6 +637,59 @@ the typed racket language.
      (syntax/loc stx
        (begin (: i* t) ...
               (provide (rename-out [i* i] ...))))]))
+
+(begin-for-syntax
+  (define-syntax-class (type-out-spec stx)
+    #:attributes (type-decl* provide-spec*)
+    #:datum-literals (rename struct type)
+    (pattern [n:id t]
+     #:attr type-decl* (syntax/loc stx ((: n t)))
+     #:attr provide-spec* (syntax/loc stx (n)))
+    (pattern [rename old-n:id new-n:id t]
+     #:attr type-decl* (syntax/loc stx ((: old-n t)))
+     #:attr provide-spec* (syntax/loc stx ((rename-out (old-n new-n)))))
+    (pattern [struct n:id e* ...
+               (~or
+                (~seq #:constructor-name c-id opt-1* ... #:omit-constructor opt-2* ...)
+                (~seq #:omit-constructor opt-1* ... #:constructor-name c-id opt-2* ...))]
+     #:attr type-decl*
+            (syntax/loc stx ((-struct n e* ... #:constructor-name c-id opt-1* ... opt-2* ...)))
+     #:attr provide-spec*
+            (syntax/loc stx ((except-out (struct-out n) c-id))))
+    (pattern [struct n:id e* ... #:omit-constructor opt* ...]
+     #:attr type-decl*
+            (syntax/loc stx ((-struct n e* ... opt* ...)))
+     #:attr provide-spec*
+            (syntax/loc stx ((except-out (struct-out n) n))))
+    (pattern [struct n:id e* ...]
+     #:attr type-decl* (syntax/loc stx ((-struct n e* ...)))
+     #:attr provide-spec* (syntax/loc stx ((struct-out n))))
+    (pattern [type t e]
+     #:attr type-decl* (syntax/loc stx ((define-type-alias t e)))
+     #:attr provide-spec* (syntax/loc stx (t)))))
+
+(define-syntax provide-typed-vars
+  (make-provide-transformer
+    (λ (stx modes)
+      (for*/list ([provide-clause (in-list (syntax->list stx))]
+                  [export (in-list (expand-export provide-clause modes))])
+        export))))
+
+(define-syntax type-out
+  (make-provide-pre-transformer
+    (lambda (stx modes)
+      (syntax-parse stx
+       [(_ (~var e* (type-out-spec stx)) ...)
+        ;; Move type declarations to the toplevel
+        (for ([t* (in-list (syntax->list #'(e*.type-decl* ...)))])
+          (syntax-local-lift-module-end-declaration
+            (quasisyntax/loc stx (begin #,@t*))))
+        ;; Collect a flat list of provide specs & expand
+        (with-syntax ([(name* ...)
+                       (for*/list ([decl* (in-list (syntax->list #'(e*.provide-spec* ...)))]
+                                   [decl  (in-list (syntax->list decl*))])
+                         decl)])
+          (syntax/loc stx (provide-typed-vars name* ...)))]))))
 
 (define-syntax (declare-refinement stx)
   (syntax-parse stx

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -315,11 +315,20 @@
               (~datum prefix-all-defined) (~datum prefix-all-defined-except)
               (~datum expand)))))
 
+;; Move type declarations to the beginning of the list,
+;;  keep other declarations in the same relative order.
+;; (-> (Listof Syntax) (Listof Syntax))
+(define (lift-type-declarations form*)
+  (define (is-type-decl? form)
+    (syntax-parse form [_:type-declaration #t] [_ #f]))
+  (let*-values ([(type-decl* form*) (partition is-type-decl? form*)])
+    (append type-decl* form*)))
+
 ;; actually do the work on a module
 ;; produces prelude and post-lude syntax objects
 ;; syntax-list -> (values syntax syntax)
 (define (type-check forms0)
-  (define forms (syntax->list forms0))
+  (define forms (lift-type-declarations (syntax->list forms0)))
   (do-time "before form splitting")
   (define-values (type-aliases struct-defs stx-defs0 val-defs0 provs signature-defs)
     (filter-multiple

--- a/typed-racket-test/fail/type-out-for-syntax.rkt
+++ b/typed-racket-test/fail/type-out-for-syntax.rkt
@@ -1,0 +1,14 @@
+#lang racket/base
+
+;; type-out only works at phase 0,
+;;  because it inserts definitions at phase 0
+;   in the enclosing module
+
+(module for-stx typed/racket/base
+  (require (for-syntax typed/racket/base))
+
+  (provide
+    (for-syntax (type-out [s (-> String String)])))
+
+  (define-for-syntax (s str) ""))
+(require 'for-stx)

--- a/typed-racket-test/fail/type-out-omit-constructor-1.rkt
+++ b/typed-racket-test/fail/type-out-omit-constructor-1.rkt
@@ -1,0 +1,11 @@
+#lang racket/base
+
+;; (type-out (struct ... #:omit-constructor))
+;; Makes the struct constructor invisible
+
+(module omit-constructor typed/racket/base
+  (provide
+    (type-out (struct foo () #:omit-constructor))))
+
+(require 'omit-constructor)
+foo

--- a/typed-racket-test/fail/type-out-omit-constructor-2.rkt
+++ b/typed-racket-test/fail/type-out-omit-constructor-2.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+
+(module constr-name typed/racket/base
+  (provide (type-out
+    (struct s () #:constructor-name makes #:omit-constructor))))
+(require 'constr-name)
+makes

--- a/typed-racket-test/fail/type-out-omit-constructor-3.rkt
+++ b/typed-racket-test/fail/type-out-omit-constructor-3.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+
+(module constr-name typed/racket/base
+  (provide (type-out
+    (struct s () #:omit-constructor #:constructor-name makes))))
+(require 'constr-name)
+makes

--- a/typed-racket-test/fail/type-out-rename.rkt
+++ b/typed-racket-test/fail/type-out-rename.rkt
@@ -1,0 +1,15 @@
+#lang racket/base
+
+;; (type-out (rename ...))
+;; Does not provide original identifier
+
+(module rename typed/racket/base
+  (provide
+    (type-out (rename f g (-> Natural Natural))))
+  (define (f n)
+    (let ([n-1 (- n 1)])
+      (if (positive? n-1) (* n (f n-1)) 1))))
+
+(require 'rename)
+(f 4)
+

--- a/typed-racket-test/succeed/type-out.rkt
+++ b/typed-racket-test/succeed/type-out.rkt
@@ -1,0 +1,178 @@
+#lang racket/base
+
+;; Tests for type-out
+;; - submodules test different type-out forms, these should all compile
+
+;; -----------------------------------------------------------------------------
+;; basics / rename
+
+;; type-out a single definition
+(module single typed/racket/base
+  (provide
+    (type-out [f (-> Natural Natural)]))
+
+  (define (f n)
+    (define n-1 (- n 1))
+    (if (positive? n-1) (* n (f n-1)) 1)))
+(require 'single)
+
+;; type-out multiple definitions, along with ordinary provides
+(module multi typed/racket/base
+  (provide
+    (type-out [n Natural]
+              [fact (-> Natural Natural)])
+    fib)
+
+  (define n 12)
+
+  (define (fact n)
+    (define n-1 (- n 1))
+    (if (positive? n-1) (* n (fact n-1)) 1))
+
+  (: fib (-> Natural Natural))
+  (define (fib n)
+    (define n-1 (- n 1))
+    (define n-2 (- n 2))
+    (if (and (positive? n-1) (positive? n-2))
+      (+ (fib n-1) (fib n-2)) 1)))
+(require 'multi)
+
+;; use rename form
+(module rename typed/racket/base
+  (provide
+    (type-out
+      [rename fact g (-> Natural Natural)]))
+
+  (define (fact n)
+    (define n-1 (- n 1))
+    (if (positive? n-1) (* n (fact n-1)) 1)))
+(require 'rename)
+
+;; -----------------------------------------------------------------------------
+;; struct
+
+;; basic struct definition
+(module defstruct typed/racket/base
+  (provide
+    (type-out
+      [struct foo ([a : Natural] [b : (-> Boolean String)])]))
+  (define f foo))
+(require 'defstruct)
+
+;; compatible with struct #:type-name
+;; (but not cooperative -- need to provide new name explicitly)
+(module defstruct/type-name typed/racket/base
+  (provide
+    Bar
+    (type-out
+      [struct bar () #:type-name Bar])))
+(module defstruct/type-name-user typed/racket/base
+  (require (submod ".." defstruct/type-name))
+  (: barry Bar)
+  (define barry (bar)))
+(require 'defstruct/type-name-user)
+
+;; struct with parent
+(module struct/parent typed/racket/base
+  (provide (type-out
+    (struct bar ([x : Natural] [y : Boolean]))
+    (struct baz bar ([z : MyType]))
+  ))
+  (define-type MyType (-> Natural Boolean String)))
+(require 'struct/parent)
+
+;; struct, #:omit-constructor
+(module omit-constructor-1 typed/racket/base
+  (provide (type-out
+    (struct qux ([x : Natural] [y : Boolean]) #:omit-constructor))))
+(require 'omit-constructor-1)
+
+;; can re-order #:omit-constructor relative to other options
+(module omit-constructor-2 typed/racket/base
+  (provide (type-out
+    (struct quux () #:type-name Quux #:omit-constructor)
+    (struct quuux () #:omit-constructor #:type-name Quuux))))
+(require 'omit-constructor-2)
+
+;; -----------------------------------------------------------------------------
+;; type
+
+(module deftype typed/racket/base
+  (provide (type-out
+    (type Person (Pairof String Natural))
+    (person<? (-> Person Person Boolean))))
+  (define (person<? p1 p2)
+    (string<? (car p1) (car p2))))
+(require 'deftype)
+
+(module deftype-user typed/racket/base
+  (require (submod ".." deftype))
+  (provide person<?*)
+
+  (define-type People (Listof Person))
+
+  (: person<?* (-> People People Boolean))
+  (define (person<?* p1* p2*)
+    (for/fold : Boolean
+              ([acc #t])
+              ([p1 (in-list p1*)]
+               [p2 (in-list p2*)])
+      (and acc (person<? p1 p2)))))
+(require 'deftype-user)
+
+;; -----------------------------------------------------------------------------
+;; test compatibility with #:opaque types
+;; (to check if reordering type declarations breaks things)
+
+(module opaque-1 typed/racket/base
+  (require/typed racket/base
+   [#:opaque Str string?]
+   [string-length (-> Str Natural)])
+
+  (provide (type-out
+    (type MyTuple (Pairof String Natural))
+    (a (-> MyTuple Boolean))))
+
+  (define (a x)
+    (and (cdr x) #t)))
+(require 'opaque-1)
+
+(module opaque-2 typed/racket/base
+  (define-type MyTuple (Pairof Str Boolean))
+
+  (require/typed racket/base
+   [#:opaque Str string?]
+   [string-length (-> Str Natural)])
+
+  (define (b x)
+    #t))
+(require 'opaque-2)
+
+(module opaque-3 typed/racket/base
+  (define-type Foobar (-> Pict))
+
+  (require/typed pict
+   [#:opaque Pict pict?]
+   [blank (-> Real Real Pict)])
+
+  (provide (type-out
+    (c (-> Pict Boolean))))
+
+  (define (c x)
+    #t))
+(require 'opaque-3)
+
+;; -----------------------------------------------------------------------------
+;; compatible with #:constructor-name
+
+(module constr-name-1 typed/racket/base
+  (provide (type-out
+    (struct s () #:constructor-name makes)))
+  makes)
+(require 'constr-name-1)
+
+(module constr-name-2 typed/racket/base
+  (provide (type-out
+    (struct r () #:omit-constructor #:constructor-name maker)))
+  maker)
+(require 'constr-name-2)


### PR DESCRIPTION
(Work-in-progress because there's a bug with `(type-out (struct ...))` -- you can't use the struct inside the defining module.)

Adds initial support for a `type-out` provide spec.

Design goals:
- Behavior is a superset of `contract-out` (currently missing `#:exists` and `#:forall`)
- Look like an ML-style interface, with all type defs. and typed identifiers

Current look:

```
#lang typed/racket/base

(provide
  (type-out
    (type FullName (List String String))
    (struct person ([name : FullName] [id : Natural]))
    (get-first-name (-> FullName String))))

(define (get-first-name fn)
  (car fn))
```

Later on, I'd like to add `#:exists` & `#:forall` to bind variables across multiple type definitions, and options to export opaque types and ADTs. But I think it's better to address those separately.