### PR TITLE
Fixup some wrong definitions; provide editor-snip%.

### DIFF
--- a/typed-racket-more/typed/racket/draw.rkt
+++ b/typed-racket-more/typed/racket/draw.rkt
@@ -140,7 +140,7 @@
          #:weight -Font-Weight #f
          #:underlined? Univ #f
          #:smoothing -Font-Smoothing #f
-         #:size-in-pizels? Univ #f
+         #:size-in-pixels? Univ #f
          #:hinting -Font-Hinting #f
          (-inst (parse-type #'Font%)))]
  [make-monochrome-bitmap

--- a/typed-racket-more/typed/racket/gui/base.rkt
+++ b/typed-racket-more/typed/racket/gui/base.rkt
@@ -81,6 +81,7 @@
             #:lock-while-reading? Univ #f
             -Input-Port)]
  ;; Editor classes
+ [editor-snip% (parse-type #'Editor-Snip%)]
  [editor-admin% (parse-type #'Editor-Admin%)]
  [editor-canvas% (parse-type #'Editor-Canvas%)]
  [editor-data% (parse-type #'Editor-Data%)]

--- a/typed-racket-more/typed/racket/private/gui-types.rkt
+++ b/typed-racket-more/typed/racket/private/gui-types.rkt
@@ -2111,7 +2111,7 @@
           ((Option (Boxof Real)) (Option (Boxof Real)) -> Void)]
          [get-file ((Option Path) -> (Option Path-String))]
          [get-filename
-          ((Option (Boxof Any)) -> (Option Path-String))]
+          (->* () ((Option (Boxof Any))) (Option Path-String))]
          [get-flattened-text (-> String)]
          [get-focus-snip (-> (Option (Instance Snip%)))]
          [get-inactive-caret-threshold (-> (U 'no-caret 'show-inactive-caret 'show-caret))]


### PR DESCRIPTION
1. Provide editor-snip% with Editor-Snip%.
       The (require/typed) way has a strange behaviour, the caret is not shown in the embedded text%.

2. Fixup the definition of (get-filename) of Editor<%>
      Its argument is optional, this affects all the untyped code that invokes it without argument, including the code inside editor-snip%.

3. Fixup a typo of (make-font). 
 