### PR TITLE
Remove debugging output from test case in PR 323

### DIFF
--- a/typed-racket-test/succeed/define-typed-untyped-identifier-syntax-properties.rkt
+++ b/typed-racket-test/succeed/define-typed-untyped-identifier-syntax-properties.rkt
@@ -12,12 +12,10 @@
            (for-syntax syntax/strip-context))
   
   (define-require-syntax (typed/untyped-typed stx)
-    (displayln 'typed)
     (syntax-case stx ()
       [(_ m s) (replace-context stx #'(submod m s typed))]))
   
   (define-require-syntax (typed/untyped-untyped stx)
-    (displayln 'untyped)
     (syntax-case stx ()
       [(_ m s) (replace-context stx #'(submod m s untyped))]))
   


### PR DESCRIPTION
@stamourv I saw that I had left some stale debugging output in the PR #323 you merged yesterday. I suppose you'll want to remove it, so this patch just removes the couple of `(displayln …)`. Sorry about that.