### PR TITLE
Fix type of syntax->list

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1530,7 +1530,10 @@
 [syntax-original? (-poly (a) (-> (-Syntax a) B))]
 [syntax-source-module (->opt (-Syntax Univ) [Univ] (Un (-val #f) -Path Sym -Module-Path-Index))]
 [syntax-e (-poly (a) (->acc (list (-Syntax a)) a (list -syntax-e)))]
-[syntax->list (-poly (a) (-> (-Syntax (-lst a)) (-lst a)))]
+[syntax->list (-poly (a)
+                (cl->* (-> (-Syntax (-lst a)) (-lst a))
+                       (-> (-Syntax Univ)
+                           (Un (-val #f) (-lst (-Syntax Univ))))))]
 [syntax->datum (cl->* (-> Any-Syntax -Sexp)
                       (-> (-Syntax Univ) Univ))]
 

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -1044,6 +1044,9 @@
                                                                    (Syntaxof (U 1 2 'bar)))))
                 (-Syntax (make-Hashtable (t:Un (-val 1) (-val 2) (-val 'foo))
                                          (-Syntax (t:Un (-val 1) (-val 2) (-val 'bar)))))]
+        ;; syntax->list
+        [tc-e (syntax->list #'(2 3 4)) (-lst (-Syntax -PosByte))]
+        [tc-e (syntax->list #'not-a-list) (t:Un (-val #f) (-lst (-Syntax Univ)))]
 
         ;; testing some primitives
         [tc-e (let ([app apply]


### PR DESCRIPTION
To return `(U False (Listof (Syntaxof Any)))` if it can't prove that the input is a syntax-list.

Fixes https://github.com/racket/typed-racket/issues/347
This makes the type of `syntax->list` consistent with the type `stx->list` already has.