### PR TITLE
guide: change 1st sentence

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/ts-guide.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/ts-guide.scrbl
@@ -12,9 +12,9 @@
 
 @section-index["typechecking" "typechecker" "typecheck"]
 
-Typed Racket is a family of languages, each of which enforce
-that programs written in the language obey a type system that ensures
-the absence of many common errors.  This guide is intended for programmers familiar
+Typed Racket is Racket's gradually-typed sister language which
+lets you add statically-checked type annotations to your programs.
+This guide is intended for programmers familiar
 with Racket.  For an introduction to Racket, see @(other-manual '(lib "scribblings/guide/guide.scrbl")).
 
 For the precise details, also see


### PR DESCRIPTION
Calling Typed Racket "a family of languages" doesn't sound correct. This PR suggests replacing that sentence with one from the github readme.

Another idea: use the docs "Typed Racket is a sister language of Racket with a static type-checker".