### PR TITLE
Give correct type to `in-port` when used with custom reader

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -182,7 +182,9 @@
                 [(-HashTop) (-seq (-pair Univ Univ))]))]
   ;; in-port
   [(make-template-identifier 'in-port 'racket/private/for)
-   (->opt [(-> -Input-Port Univ) -Input-Port] (-seq Univ))]
+   (-poly (a)
+          (cl->* (-> (-seq Univ))
+                 (->opt (-> -Input-Port a) [-Input-Port] (-seq a))))]
   ;; in-input-port-bytes
   [(make-template-identifier 'in-input-port-bytes 'racket/private/for)
    (-> -Input-Port (-seq -Byte))]

--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -184,7 +184,7 @@
   [(make-template-identifier 'in-port 'racket/private/for)
    (-poly (a)
           (cl->* (-> (-seq Univ))
-                 (->opt (-> -Input-Port a) [-Input-Port] (-seq a))))]
+                 (->opt (-> -Input-Port (Un a (-val eof))) [-Input-Port] (-seq a))))]
   ;; in-input-port-bytes
   [(make-template-identifier 'in-input-port-bytes 'racket/private/for)
    (-> -Input-Port (-seq -Byte))]


### PR DESCRIPTION
Currently, `in-port` returns `(Sequenceof Any)` unconditionally, which is correct if the given read function is `read` (default value). However, `(in-port read-line)`, `(in-port read-char)`, etc. should have more specific types.