### PR TITLE
Reimplement init-envs.rkt

### DIFF
--- a/typed-racket-lib/info.rkt
+++ b/typed-racket-lib/info.rkt
@@ -3,7 +3,6 @@
 (define collection 'multi)
 
 (define deps '(("base" #:version "6.4.0.5")
-               "pconvert-lib"
                "source-syntax"
                "compatibility-lib" ;; to assign types
                "string-constants-lib"))

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -232,6 +232,7 @@
                    ,(and proc (type->sexp proc))
                    ,poly?
                    (quote-syntax ,pred-id))]
+    [(StructType: struct) `(make-StructType ,(type->sexp struct))]
     [(Prefab: key flds)
      `(make-Prefab (quote ,key)
                    (list ,@(map type->sexp flds)))]
@@ -312,19 +313,9 @@
                         (quote ,id)
                         ,(type->sexp ty))]
     [(Value: v) `(make-Value (quote ,v))]
-    [StructTypeTop `(make-StructTypeTop)]
-    [StructType `(make-StructType)]
-    [BoxTop `(make-BoxTop)]
-    [Weak-BoxTop `(make-Weak-BoxTop)]
-    [ChannelTop `(make-ChannelTop)]
-    [Async-ChannelTop `(make-Async-ChannelTop)]
-    [VectorTop `(make-VectorTop)]
-    [HashtableTop `(make-HashtableTop)]
-    [MPairTop `(make-MPairTop)]
-    [StructTop `(make-StructTop)]
-    [ThreadCellTop `(make-ThreadCellTop)]
-    [Prompt-TagTop `(make-Prompt-TagTop)]
-    [Continuation-Mark-KeyTop `(make-Continuation-Mark-KeyTop)]))
+    ;; Most Top types are in the predefined table, the ones here
+    ;; are not
+    [(StructTop: name) `(make-StructTop ,(type->sexp name))]))
 
 ;; Prop -> Sexp
 ;; Convert a prop to an s-expression

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -309,7 +309,7 @@
                 (list ,@(map type->sexp kws)))]
     [(Distinction: nm id ty)
      `(make-Distinction (quote ,nm)
-                        (quote-syntax ,id)
+                        (quote ,id)
                         ,(type->sexp ty))]
     [(Value: v) `(make-Value (quote ,v))]
     [StructTypeTop `(make-StructTypeTop)]

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -273,7 +273,6 @@
                     (list ,@(convert augments))
                     ,(and init-rest (type->sexp init-rest))))
      class-type]
-    [(ClassTop:) `(make-ClassTop)]
     [(Instance: ty) `(make-Instance ,(type->sexp ty))]
     [(Signature: name extends mapping)
      (define (serialize-mapping m)
@@ -286,7 +285,6 @@
      `(make-Signature (quote-syntax ,name)
                       ,serialized-extends
                       (list ,@(serialize-mapping mapping)))]
-    [(UnitTop:) `(make-UnitTop)]
     [(Unit: imports exports init-depends result)
      `(make-Unit (list ,@(map type->sexp imports))
                  (list ,@(map type->sexp exports))
@@ -354,10 +352,9 @@
 (define (path-elem->sexp pe)
   (match pe
     [(In-Predefined-Table: id) id]
-    ;; CarPE, CdrPE, SyntaxPE, ForcePE are in the table
+    ;; CarPE, CdrPE, SyntaxPE, ForcePE, FieldPE are in the table
     [(StructPE: ty idx)
-     `(make-StructPE ,(type->sexp ty) ,idx)]
-    [(FieldPE:) `(make-FieldPE)]))
+     `(make-StructPE ,(type->sexp ty) ,idx)]))
 
 (define (bound-in-this-module id)
   (let ([binding (identifier-binding id)])

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -111,6 +111,8 @@
      (int-err "Base type ~a not in predefined-type-table" n)]
     [(B: nat) `(make-B ,nat)]
     [(F: sym) `(make-F (quote ,sym))]
+    [(Pair: ty (Listof: ty))
+     `(-ne-lst ,(type->sexp ty))]
     [(Pair: left right)
      `(make-Pair ,(type->sexp left) ,(type->sexp right))]
     [(ListDots: type dbound)
@@ -120,7 +122,7 @@
     [(Vector: ty)
      `(make-Vector ,(type->sexp ty))]
     [(HeterogeneousVector: elems)
-     `(make-HeterogeneousVector (list ,@(map type->sexp elems)))]
+     `(-vec* ,@(map type->sexp elems))]
     [(Box: ty)
      `(make-Box ,(type->sexp ty))]
     [(Channel: ty)
@@ -148,11 +150,13 @@
     [(Continuation-Mark-Keyof: ty)
      `(make-Continuation-Mark-Keyof ,(type->sexp ty))]
     [(Sequence: tys)
-     `(make-Sequence (list ,@(map type->sexp tys)))]
+     `(-seq ,@(map type->sexp tys))]
     [(Syntax: ty)
      `(make-Syntax ,(type->sexp ty))]
     [(Listof: elem-ty)
      `(-lst ,(type->sexp elem-ty))]
+    [(Param: ty ty)
+     `(-Param ,(type->sexp ty))]
     [(Param: in out)
      `(make-Param ,(type->sexp in) ,(type->sexp out))]
     [(Hashtable: key val)
@@ -198,10 +202,15 @@
                    ,(object->sexp obj))]
     [(AnyValues: prop)
      `(make-AnyValues ,(prop->sexp prop))]
+    [(Union: (list (Value: vs) ...))
+     `(one-of/c ,@(for/list ([v (in-list vs)])
+                    `(quote ,v)))]
     [(Union: elems) (split-union elems)]
     [(Intersection: elems)
      `(make-Intersection (set ,@(for/list ([elem (in-immutable-set elems)])
                                   (type->sexp elem))))]
+    [(Name: stx 0 #t)
+     `(-struct-name (quote-syntax ,stx))]
     [(Name: stx args struct?)
      `(make-Name (quote-syntax ,stx) ,args ,struct?)]
     [(fld: t acc mut)

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -12,7 +12,7 @@
          (rename-in racket/private/sort [sort raw-sort])
          (rep type-rep object-rep prop-rep rep-utils free-variance)
          (for-syntax syntax/parse racket/base)
-         (types abbrev union)
+         (types abbrev union utils)
          racket/dict racket/list racket/set racket/promise
          racket/match)
 
@@ -184,6 +184,16 @@
      `(->acc (list ,@(map type->sexp dom))
              ,(type->sexp t)
              (list ,@(map path-elem->sexp pth)))]
+    [(Function: (? has-optional-args? arrs))
+     (match-define (arr: fdoms rng rest _ *kws) (first arrs))
+     (match-define (arr: ldoms _ _ _ _) (last arrs))
+     (define opts (drop ldoms (length fdoms)))
+     (define kws (map type->sexp *kws))
+     `(opt-fn (list ,@(map type->sexp fdoms))
+              (list ,@(map type->sexp opts))
+              ,(type->sexp rng)
+              ,@(if rest `(#:rest ,rest) '())
+              ,@(if (null? kws) '() `(#:kws (list ,@kws))))]
     [(Function: arrs)
      `(make-Function (list ,@(map type->sexp arrs)))]
     [(Keyword: kw ty required?)

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -447,6 +447,18 @@
       (define/with-syntax (new-defs ...) defs)
       (define/with-syntax (new-export-defs ...) export-defs)
       (define/with-syntax (new-provs ...) provs)
+      (define *env-codes
+        (list (env-init-code)
+              (talias-env-init-code)
+              (tname-env-init-code)
+              (tvariance-env-init-code)
+              (mvar-env-init-code mvar-env)
+              (signature-env-init-code)
+              (make-struct-table-code)))
+      ;; get the lifted common expressions for types which need to come first
+      (define env-codes
+        (list* (get-extra-type-definitions)
+               *env-codes))
       (values
        #`(begin
            ;; This syntax-time submodule records all the types for all
@@ -466,13 +478,7 @@
                          typed-racket/env/global-env typed-racket/env/type-alias-env
                          typed-racket/types/struct-table typed-racket/types/abbrev
                          (rename-in racket/private/sort [sort raw-sort]))
-                #,(env-init-code)
-                #,(talias-env-init-code)
-                #,(tname-env-init-code)
-                #,(tvariance-env-init-code)
-                #,(mvar-env-init-code mvar-env)
-                #,(signature-env-init-code)
-                #,(make-struct-table-code)
+                #,@env-codes
                 #,@(for/list ([a (in-list aliases)])
                      (match-define (list from to) a)
                      #`(add-alias (quote-syntax #,from) (quote-syntax #,to))))))

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -198,6 +198,8 @@
 (define/decl -Thread-CellTop (make-ThreadCellTop))
 (define/decl -Prompt-TagTop (make-Prompt-TagTop))
 (define/decl -Continuation-Mark-KeyTop (make-Continuation-Mark-KeyTop))
+(define/decl -ClassTop (make-ClassTop))
+(define/decl -UnitTop (make-UnitTop))
 (define/decl -Port (Un -Output-Port -Input-Port))
 (define/decl -SomeSystemPath (Un -Path -OtherSystemPath))
 (define/decl -Pathlike (Un -String -Path))
@@ -251,6 +253,7 @@
 (define/decl -cdr (make-CdrPE))
 (define/decl -syntax-e (make-SyntaxPE))
 (define/decl -force (make-ForcePE))
+(define/decl -field (make-FieldPE))
 
 ;; Type alias names
 (define (-struct-name name)

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -187,6 +187,7 @@
 (define Syntax-Sexp (-Sexpof Any-Syntax))
 (define Ident (-Syntax -Symbol))
 (define -HT make-Hashtable)
+(define/decl -StructTypeTop (make-StructTypeTop))
 (define/decl -BoxTop (make-BoxTop))
 (define/decl -Weak-BoxTop (make-Weak-BoxTop))
 (define/decl -ChannelTop (make-ChannelTop))

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -545,7 +545,7 @@
 
          (define (debug-printer v port write?)
            ((if write? pretty-write pretty-print)
-            (type->sexp v)
+            (syntax->datum (datum->syntax #f (type->sexp v)))
             port)))]
     [_ #'(begin)]))
 

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -540,22 +540,12 @@
     [(_ debug-printer:id)
      #:when (eq? printer-type 'debug)
      #'(begin
-         (require racket/pretty)
-         (require mzlib/pconvert)
-
-         (define (converter v basic sub)
-           (define (gen-constructor sym)
-             (string->symbol (string-append "make-" (substring (symbol->string sym) 7))))
-           (match v
-             [(? Rep? rep)
-              `(,(gen-constructor (car (vector->list (struct->vector rep))))
-                ,@(map sub (Rep-values rep)))]
-             [_ (basic v)]))
+         (require racket/pretty
+                  typed-racket/env/init-envs)
 
          (define (debug-printer v port write?)
            ((if write? pretty-write pretty-print)
-            (parameterize ((current-print-convert-hook converter))
-              (print-convert v))
+            (type->sexp v)
             port)))]
     [_ #'(begin)]))
 

--- a/typed-racket-lib/typed-racket/types/struct-table.rkt
+++ b/typed-racket-lib/typed-racket/types/struct-table.rkt
@@ -6,7 +6,8 @@
          (prefix-in c: (contract-req))
          (rep type-rep prop-rep object-rep)
          (utils tc-utils)
-         (env init-envs env-utils))
+         (env init-envs env-utils)
+         (types abbrev))
 
 (define struct-fn-table (make-free-id-table))
 

--- a/typed-racket-test/unit-tests/init-env-tests.rkt
+++ b/typed-racket-test/unit-tests/init-env-tests.rkt
@@ -2,6 +2,7 @@
 
 (require "test-utils.rkt"
          rackunit
+         (rep object-rep type-rep)
          (env init-envs)
          (types abbrev union))
 
@@ -27,5 +28,25 @@
       (check-equal?
         (convert (-mu x (-lst* Univ (-box x))))
         '(make-Mu 'x (make-Pair Univ (make-Pair (make-Box (make-F 'x)) -Null))))
+      (check-equal?
+        (convert (make-StructTypeTop))
+        '-StructTypeTop)
+      (check-equal?
+        (convert (make-BoxTop))
+        '-BoxTop)
+      (check-equal?
+        (convert (make-ClassTop))
+        '-ClassTop)
+      (check-equal?
+        (convert (make-FieldPE))
+        '-field)
+      (check-equal?
+        (convert (make-StructType (make-Struct #'foo #f null #f #f #'foo?)))
+        '(make-StructType
+          (make-Struct (quote-syntax foo) #f (list) #f #f (quote-syntax foo?))))
+      (check-equal?
+        (convert (make-StructTop (make-Struct #'foo #f null #f #f #'foo?)))
+        '(make-StructTop
+          (make-Struct (quote-syntax foo) #f (list) #f #f (quote-syntax foo?))))
     )
   ))

--- a/typed-racket-test/unit-tests/init-env-tests.rkt
+++ b/typed-racket-test/unit-tests/init-env-tests.rkt
@@ -2,7 +2,6 @@
 
 (require "test-utils.rkt"
          rackunit
-         mzlib/pconvert
          (env init-envs)
          (types abbrev union))
 
@@ -10,12 +9,7 @@
 (gen-test-main)
 
 (define (convert v)
-  (parameterize ((current-print-convert-hook converter)
-                 ;; ignore sharing in all cases
-                 (current-build-share-hook (λ (v basic sub) 'atomic))
-                 (show-sharing #f)
-                 (booleans-as-true/false #f))
-   (syntax->datum (datum->syntax #f (print-convert v)))))
+  (syntax->datum (datum->syntax #f (type->sexp v))))
 
 
 (define tests
@@ -26,10 +20,10 @@
         '(simple-> (list -String) -Symbol))
       (check-equal?
         (convert (make-pred-ty -String))
-        '(make-pred-ty (list Univ) -Boolean -String (make-Path `() (list 0 0))))
+        '(make-pred-ty (list Univ) -Boolean -String (-arg-path 0)))
       (check-equal?
         (convert (->acc (list (-lst -String)) -String (list -car)))
-        '(->acc (list (-lst -String)) -String `(,-car)))
+        '(->acc (list (-lst -String)) -String (list -car)))
       (check-equal?
         (convert (-mu x (-lst* Univ (-box x))))
         '(make-Mu 'x (make-Pair Univ (make-Pair (make-Box (make-F 'x)) -Null))))


### PR DESCRIPTION
This PR reimplements the type serialization in `init-envs.rkt` to avoid using pconvert (to avoid the library dependency and also because I think it's easier to understand without it). Also implements a few optimizations that cut a few percent off of zo sizes, up to maybe 10% on plot.

Also changes the debug printer to use the type serialization (easier to read?).