### PR TITLE
add (and/c vector? any-wrap/c) -like contracts

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -343,7 +343,7 @@
             (define existing-ty-ctc (syntax-local-lift-expression
                                      (make-contract-def-rhs/from-typed existing-ty-id #f #f)))
             (define (store-existing-type existing-type)
-              (cast-table-set! existing-ty-id existing-type))
+              (cast-table-set! existing-ty-id (datum->syntax #f existing-type #'v)))
             (define (check-valid-type _)
               (define type (parse-type #'ty))
               (define vars (fv type))

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -346,7 +346,7 @@
 
       (define (only-untyped sc)
         (if (from-typed? typed-side)
-            (fail #:reason "contract generation not supported for this type")
+            (and/sc sc any-wrap/sc)
             sc))
       (cached-match sc-cache type typed-side
         ;; Applications of implicit recursive type aliases

--- a/typed-racket-test/succeed/cast-mod.rkt
+++ b/typed-racket-test/succeed/cast-mod.rkt
@@ -44,31 +44,49 @@
   (: b1 : (Boxof Integer))
   (define b1 (box 42))
   (define b2 (cast b1 (Boxof String)))
+  (define b3 (ann b1 BoxTop))
+  (define b4 (cast b3 (Boxof (U Integer String))))
   (check-equal? (unbox b1) 42)
+  (check-equal? (unbox b4) 42)
   (check-exn #rx"expected: Integer\n *given: \"hi\""
              (λ () (set-box! b2 "hi")))
   (check-equal? (unbox b1) 42
-                "if the previous test hadn't errored, this would be \"hi\" with type Integer"))
+                "if the previous test hadn't errored, this would be \"hi\" with type Integer")
+  (check-exn #rx"Attempted to use a higher-order value passed as `Any`"
+             (λ () (set-box! b4 "hello")))
+  (check-equal? (unbox b1) 42))
 
 (test-case "cast on mutable vectors"
   (: v1 : (Vectorof Integer))
   (define v1 (vector 42))
   (define v2 (cast v1 (Vectorof String)))
+  (define v3 (ann v1 VectorTop))
+  (define v4 (cast v3 (Vectorof (U Integer String))))
   (check-equal? (vector-ref v1 0) 42)
+  (check-equal? (vector-ref v4 0) 42)
   (check-exn #rx"expected: Integer\n *given: \"hi\""
              (λ () (vector-set! v2 0 "hi")))
   (check-equal? (vector-ref v1 0) 42
-                "if the previous test hadn't errored, this would be \"hi\" with type Integer"))
+                "if the previous test hadn't errored, this would be \"hi\" with type Integer")
+  (check-exn #rx"Attempted to use a higher-order value passed as `Any`"
+             (λ () (vector-set! v4 0 "hello")))
+  (check-equal? (vector-ref v1 0) 42))
 
 ;; Struct definitions need to be at the module level for some reason.
-(struct (X) s ([i : X]) #:mutable)
+(struct (X) s ([i : X]) #:mutable #:transparent)
 (test-case "cast on mutable structs"
   (: s1 : (s Integer))
   (define s1 (s 42))
   (define s2 (cast s1 (s String)))
+  (define s3 (ann s1 Any))
+  (define s4 (cast s3 (s (U Integer String))))
   (check-equal? (s-i s1) 42)
+  (check-equal? (s-i s4) 42)
   (check-exn #rx"expected: Integer\n *given: \"hi\""
              (λ () (set-s-i! s2 "hi")))
   (check-equal? (s-i s1) 42
-                "if the previous test hadn't errored, this would be \"hi\" with type Integer"))
+                "if the previous test hadn't errored, this would be \"hi\" with type Integer")
+  (check-exn #rx"Attempted to use a higher-order value passed as `Any`"
+             (λ () (set-s-i! s4 "hello")))
+  (check-equal? (s-i s1) 42))
 


### PR DESCRIPTION
For `VectorTop`, `HashTableTop`, etc. going from typed to untyped.

This fixes examples like
```racket
#lang typed/racket
(define v (ann (vector 1) VectorTop))
(cast v Any)
```
To generate `(and/c vector? any-wrap/c)` contracts instead of raising a compile-time contract-generation error. This reduces some of the backwards-incompatibility from the `cast` soundness fix.

This fixes some of the problems in https://github.com/racket/typed-racket/issues/375, although parts of ~~both measures-with-dimensions and~~ `wrap` are still failing for other reasons.