### PR TITLE
implement sc->constraints for recursive-sc

### DIFF
--- a/typed-racket-lib/typed-racket/static-contracts/structures.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/structures.rkt
@@ -105,7 +105,7 @@
   ;; Takes a static contract and returns the corresponding contract.
   ;; The function argument should be used for sub parts of the static contract.
   [sc->contract sc f]
-  ;; sc->constraints: static-contract? (static-contract? -> constraint-set?) -> constraint-set?
+  ;; sc->constraints: static-contract? (static-contract? -> contract-restrict?) -> contract-restrict?
   ;; Takes a static contract and computes the constraint set for a static contract.
   ;; The function argument should be used for sub parts of the static contract.
   [sc->constraints sc f]
@@ -139,7 +139,9 @@
                [(recursive-sc names values body)
                 (for-each (λ (v) (f v 'covariant)) values)
                 (f body 'covariant)
-                (void)]))]
+                (void)]))
+           (define (sc->constraints v f)
+             (simple-contract-restrict 'impersonator))]
         #:methods gen:custom-write [(define write-proc recursive-sc-write-proc)])
 
 ;; A use of a contract bound by recursive-sc


### PR DESCRIPTION
This pull requests implements the `sc->constraints` generic method for the `recursive-sc` struct.

This changes the error in the `wrap` package mentioned in issue #375 here (https://github.com/racket/typed-racket/issues/375#issuecomment-228580196),

From this:
```
. . ../../../../../../../../../../Applications/Racket/2016-06-16/Racket v6.5.0.5/collects/racket/private/generic.rkt:488:0: 
sc->constraints: not implemented for
(recursive-sc
 (list #<syntax scan1681546> #<syntax scan1681547> #<syntax scan1681548>)
 (list (or/sc2 (list (simple-contract #<syntax:/Applications/Racket/2016-06-16/Racket v6.5.0.5/share/pkgs/typed-racket-lib/typed-racket/private/type-contract.rkt...
```
To this:
```
. Type Checker: Type (U Null (Pairof JsObject (∩ JsList (Listof HashTableTop)))) could not be converted to a contract: 
Intersection type contract contains more than 1 non-flat contract: (∩ JsList (Listof HashTableTop)) in: items-js
```