### PR TITLE
call compute-constraints instead of sc->constraints in get-max-contract-kind

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -18,6 +18,7 @@
  syntax/flatten-begin
  (only-in (types abbrev) -Bottom -Boolean)
  (static-contracts instantiate optimize structures combinators constraints)
+ (only-in (submod typed-racket/static-contracts/instantiate internals) compute-constraints)
  ;; TODO make this from contract-req
  (prefix-in c: racket/contract)
  (contract-req)
@@ -221,9 +222,7 @@
 ;; recurse into a contract finding the max
 ;; kind (e.g. flat < chaperone < impersonator)
 (define (get-max-contract-kind sc)
-    (define (get-restriction sc)
-      (sc->constraints sc get-restriction))
-    (kind-max-max (contract-restrict-value (get-restriction sc))))
+  (kind-max-max (contract-restrict-value (compute-constraints sc 'impersonator))))
 
 ;; To avoid misspellings
 (define impersonator-sym 'impersonator)

--- a/typed-racket-test/fail/sandboxed-unsafe-ops.rkt
+++ b/typed-racket-test/fail/sandboxed-unsafe-ops.rkt
@@ -7,7 +7,8 @@
 
 (require racket/sandbox)
 
-(parameterize ([sandbox-memory-limit 5000])
+;; this doesn't need a memory limit
+(parameterize ([sandbox-memory-limit #f])
   (define eval (make-evaluator 'typed/racket))
   (eval '(require typed/racket/unsafe))
 

--- a/typed-racket-test/succeed/cast-mod.rkt
+++ b/typed-racket-test/succeed/cast-mod.rkt
@@ -90,3 +90,15 @@
              (λ () (set-s-i! s4 "hello")))
   (check-equal? (s-i s1) 42))
 
+(test-case "cast on intersections involving recursive types"
+  (define-type T
+    (Rec T (U String (Listof T))))
+  (: f : (Listof T) -> Any)
+  (define (f x)
+    (if (andmap list? x)
+        (cast x Any)
+        #f))
+  (check-equal? (f (list "a" "b" "c")) #f)
+  (check-equal? (f (list (list "a") (list "b") (list "c")))
+                (list (list "a") (list "b") (list "c"))))
+


### PR DESCRIPTION
This fixes programs like:
```
#lang typed/racket
(define-type T
  (Rec T (U String (Listof T))))
(: f : (Listof T) -> Any)
(define (f x)
  (if (andmap list? x)
      (cast x Any)
      #f))
```
Where there is a `cast` from a value with an intersection type that involves recursive types that can be guarded with flat contracts.

This fixes another part of issue #375 discussed in https://github.com/racket/typed-racket/pull/381#issuecomment-230509639, which pull request #381 fell short of solving.