### PR TITLE
Raise a proper contract-generation error for #380

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -343,13 +343,17 @@
             (define existing-ty-ctc (syntax-local-lift-expression
                                      (make-contract-def-rhs/from-typed existing-ty-id #f #f)))
             (define (store-existing-type existing-type)
+              (check-no-free-vars existing-type #'v)
               (cast-table-set! existing-ty-id (datum->syntax #f existing-type #'v)))
             (define (check-valid-type _)
               (define type (parse-type #'ty))
+              (check-no-free-vars type #'ty))
+            (define (check-no-free-vars type stx)
               (define vars (fv type))
               ;; If there was an error don't create another one
               (unless (or (Error? type) (null? vars))
                 (tc-error/delayed
+                 #:stx stx
                  "Type ~a could not be converted to a contract because it contains free variables."
                  type)))
             #`(#,(external-check-property #'#%expression check-valid-type)

--- a/typed-racket-test/fail/cast-tyvar.rkt
+++ b/typed-racket-test/fail/cast-tyvar.rkt
@@ -1,0 +1,11 @@
+#;
+(exn-pred exn:fail:syntax?
+          #rx"Type \\(List X\\) could not be converted to a contract"
+          #rx"contains free variables"
+          #rx"10.8")
+
+#lang typed/racket
+(: f : (All (X) (-> X X)))
+(define (f x)
+  (cast (list x) Any)
+  x)


### PR DESCRIPTION
On  `cast`s from types with free-variables, this raises a proper contract-generation type error instead of throwing an internal error. For example this program from issue #380 
```racket
#lang typed/racket
(: f : (All (X) (-> X X)))
(define (f x)
  (cast x Any)
  x)
```
Used to raise the internal error
```
. . ../../Applications/Racket/2016-06-16/Racket v6.5.0.5/share/pkgs/typed-racket-lib/typed-racket/private/type-contract.rkt:337:4: 
type->static-contract: Recursive value lookup failed. #hash() X
```
It now raises the error
```
. Type Checker: Type X could not be converted to a contract because it contains free variables.
in: x
```
With the `x` in `(cast x Any)` highlighted.