### PR TITLE
fix any-wrap/c unsoundness on opaque structures

### DIFF
--- a/typed-racket-lib/typed-racket/typed-racket.rkt
+++ b/typed-racket-lib/typed-racket/typed-racket.rkt
@@ -5,6 +5,8 @@
              "standard-inits.rkt")
  ;; these need to be available to the generated code
  "typecheck/renamer.rkt" syntax/location
+ ;; this defines the inspector that structs will use
+ "utils/inspector.rkt"
  (for-syntax (submod "base-env/prims-contract.rkt" self-ctor))
  (for-syntax "utils/struct-extraction.rkt")
  (for-syntax "typecheck/renamer.rkt")
@@ -16,6 +18,13 @@
          with-type
          (for-syntax do-standard-inits))
 
+;; This sets the inspector that typed racket structs will use, so that
+;; any-wrap/c can inspect them. This allows any-wrap/c to wrap structs
+;; that are defined in typed racket, and to fail on structs that it
+;; can't wrap safely.
+;; https://github.com/racket/typed-racket/issues/379
+;; https://github.com/racket/typed-racket/pull/385
+(current-inspector new-inspector)
 
 (define-syntax-rule (drivers [name sym] ...)
   (begin

--- a/typed-racket-lib/typed-racket/utils/inspector.rkt
+++ b/typed-racket-lib/typed-racket/utils/inspector.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+
+(provide old-inspector new-inspector)
+
+;; Defines a new inspector that typed racket structs will use,
+;; and make this new inspector a sub-inspector of the old one.
+;; The old one is more powerfull than the new one, so any-wrap/c
+;; can use the old one to inspect opaque structs created by
+;; typed racket.
+(define old-inspector (current-inspector))
+(define new-inspector (make-inspector old-inspector))
+

--- a/typed-racket-test/succeed/exn-any-mutation.rkt
+++ b/typed-racket-test/succeed/exn-any-mutation.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+(module untyped racket/base
+  (provide f)
+  (define (f x) x))
+(module typed typed/racket
+  (require typed/rackunit)
+  (struct (X) s ([i : X]) #:mutable)
+  (require/typed (submod ".." untyped)
+                 [f (-> Any (s (U Integer String)))])
+  (: s1 : (s Integer))
+  (define s1 (s 42))
+  (define s2 (ann s1 Any))
+  (define s3 (f s2))
+  (check-equal? (s-i s1) 42)
+  (check-equal? (s-i s3) 42)
+  (check-exn #rx"Attempted to use a higher-order value passed as `Any`"
+             (λ () (set-s-i! s3 "hi")))
+  (check-equal? (s-i s1) 42
+                "if the previous test hadn't errored, this would be \"hi\" with type Integer")
+  )
+(require 'typed)

--- a/typed-racket-test/succeed/pr241-variation-4.rkt
+++ b/typed-racket-test/succeed/pr241-variation-4.rkt
@@ -5,6 +5,8 @@
 ;; From Issue #203
 ;;   https://github.com/racket/typed-racket/issues/203
 
-(require typed-racket/utils/any-wrap)
+(require typed-racket/utils/any-wrap
+         typed-racket/utils/inspector)
+(current-inspector new-inspector)
 (struct s ())
 (contract any-wrap/c (s) 'a 'b)


### PR DESCRIPTION
Fixes #379 

This modifies `any-wrap/c` to fail on opaque things it doesn't have an inspector for, but it defines a new inspector so that normal uses of `struct` (without a special `#:inspector` argument) create structures that `any-wrap/c` can inspect.

For example on this program:
```racket
#lang typed/racket
(struct (X) s ([i : X]) #:mutable)
(: s1 : (s Integer))
(define s1 (s 42))
(define s2 (ann s1 Any))
(define s3 (cast s2 (s (U Integer String))))
(set-s-i! s3 "unsound!")
;#<s>: contract violation
;  Attempted to use a higher-order value passed as `Any` in untyped code: #<s>
;  in: Any
;  contract from: typed-world
;  blaming: cast
;   (assuming the contract is correct)
;  at: /Users/Alex/Documents/DrRacket/any-wrap-opaque-example.rkt:6.11
(s-i s1) ; if that hadn't errored, this would produce "unsound!" with the type Integer
```
Now avoids unsoundness by producing the error shown in the comments, preventing the `"unsound!"` mutation. Before, this succeeded and allowed `(s-i s1)` to produce `"unsound!"` with the type `Integer`.