### PR TITLE
Allow cpointer predicates as struct predicates.

### DIFF
--- a/typed-racket-lib/typed-racket/utils/any-wrap.rkt
+++ b/typed-racket-lib/typed-racket/utils/any-wrap.rkt
@@ -6,6 +6,7 @@
          racket/set
          racket/undefined
          (only-in racket/async-channel async-channel?)
+         (only-in ffi/unsafe cpointer-predicate-procedure?)
          (only-in racket/future future? fsemaphore?)
          (only-in racket/pretty pretty-print-style-table?)
          (only-in racket/udp udp?)
@@ -209,7 +210,8 @@
 ;; Contract for "safe" struct predicate procedures.
 ;; We can trust that these obey the type (-> Any Boolean).
 (define (struct-predicate-procedure?/c x)
-  (and (struct-predicate-procedure? x)
+  (and (or (struct-predicate-procedure? x)
+           (cpointer-predicate-procedure? x))
        (not (impersonator? x))))
 
 (provide any-wrap/c struct-predicate-procedure?/c)


### PR DESCRIPTION
Fixes the math library failure here:

http://drdr.racket-lang.org/35897/racket/share/pkgs/math-lib/math/private/bigfloat/bigfloat-hurwitz-zeta.rkt

Relies on racket/racket#1368.

Relevant to #385.