### PR TITLE
Fix contracts for structs with the same name (PR 15330)

### DIFF
--- a/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
@@ -32,24 +32,24 @@
 
 ;; check equality of two syntax objects by structural traversal
 ;; where identifiers are compared by free-identifier=?
-(define (stx-equal? s1 s2 recur)
+;;
+;; Note: does not handle cycles but there shouldn't be any
+(define (stx-equal? s1 s2)
   (cond [(and (identifier? s1) (identifier? s2))
          (free-identifier=? s1 s2)]
         [else
          (define d1 (if (syntax? s1) (syntax-e s1) s1))
          (define d2 (if (syntax? s2) (syntax-e s2) s2))
-         (equal?/recur d1 d2
-                       (λ (x y) (stx-equal? x y recur)))]))
+         (equal?/recur d1 d2 stx-equal?)]))
 
 (struct simple-contract static-contract (syntax kind name)
         #:transparent
         #:methods gen:equal+hash
          [(define (equal-proc s1 s2 recur)
             (and ;; have to make sure identifiers are compared by free-id=?
-                 ;; because of struct predicates
+                 ;; because of struct predicates, opaque, etc.
                  (stx-equal? (simple-contract-syntax s1)
-                             (simple-contract-syntax s2)
-                             recur)
+                             (simple-contract-syntax s2))
                  (recur (simple-contract-kind s1)
                         (simple-contract-kind s2))
                  (recur (simple-contract-name s1)

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
@@ -33,14 +33,13 @@
 ;; check equality of two syntax objects by structural traversal
 ;; where identifiers are compared by free-identifier=?
 (define (stx-equal? s1 s2 recur)
-  (define d1 (if (syntax? s1) (syntax-e s1) s1))
-  (define d2 (if (syntax? s2) (syntax-e s2) s2))
   (cond [(and (identifier? s1) (identifier? s2))
          (free-identifier=? s1 s2)]
-        [(and (pair? d1) (pair? d2))
-         (and (stx-equal? (car d1) (car d2) recur)
-              (stx-equal? (cdr d1) (cdr d2) recur))]
-        [else (recur d1 d2)]))
+        [else
+         (define d1 (if (syntax? s1) (syntax-e s1) s1))
+         (define d2 (if (syntax? s2) (syntax-e s2) s2))
+         (equal?/recur d1 d2
+                       (λ (x y) (stx-equal? x y recur)))]))
 
 (struct simple-contract static-contract (syntax kind name)
         #:transparent

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
@@ -38,9 +38,9 @@
   (cond [(and (identifier? s1) (identifier? s2))
          (free-identifier=? s1 s2)]
         [else
-         (define d1 (if (syntax? s1) (syntax-e s1) s1))
-         (define d2 (if (syntax? s2) (syntax-e s2) s2))
-         (equal?/recur d1 d2 stx-equal?)]))
+         (if (and (syntax? s1) (syntax? s2))
+             (equal?/recur (syntax-e s1) (syntax-e s2) stx-equal?)
+             (equal?/recur s1 s2 stx-equal?))]))
 
 (struct simple-contract static-contract (syntax kind name)
         #:transparent

--- a/typed-racket-test/succeed/pr15330.rkt
+++ b/typed-racket-test/succeed/pr15330.rkt
@@ -1,0 +1,22 @@
+#lang racket/base
+
+;; Test for PR 15330
+;;
+;; Make sure struct contracts with the same name bound in different
+;; places will work correctly
+
+(module base typed/racket/base
+ 
+  (provide (struct-out Record))
+  (struct Record ([id : Integer]) #:transparent))
+
+(module yy typed/racket/base
+ 
+  (require (prefix-in roles: (submod ".." base)))
+  (provide (struct-out Record))
+  (struct Record ([subrec : roles:Record]) #:transparent))
+
+(require (prefix-in role: 'yy)
+         (prefix-in roles: 'base))
+         
+(role:Record-subrec (role:Record (roles:Record 0)))

--- a/typed-racket-test/unit-tests/static-contract-equality-tests.rkt
+++ b/typed-racket-test/unit-tests/static-contract-equality-tests.rkt
@@ -1,0 +1,27 @@
+#lang racket/base
+
+;; Tests for equality predicates on static contract values
+
+(require rackunit
+         typed-racket/static-contracts/combinators)
+
+;; these should be equal for optimizations to kick in
+(check-equal? (flat/sc #'(quote 3)) (flat/sc #'(quote 3)))
+(check-equal? (flat/sc #'(lambda (x) (integer? x)))
+              (flat/sc #'(lambda (x) (integer? x))))
+
+(define (make-stx id)
+  #`(lambda (x) (#,id x)))
+(define foo-stx-1 (make-stx #'foo?))
+(define foo-stx-2 (make-stx #'foo?))
+
+(parameterize ([current-namespace (make-base-namespace)])
+  (eval #'(struct foo (x)))
+  (define foo-stx-3 (make-stx (expand #'foo?)))
+  (define foo-stx-4 (make-stx (expand #'foo?)))
+
+  (check-equal? (flat/sc foo-stx-1) (flat/sc foo-stx-2))
+  (check-equal? (flat/sc foo-stx-3) (flat/sc foo-stx-4))
+
+  ;; these shouldn't be equal because bindings are different
+  (check-not-equal? (flat/sc foo-stx-1) (flat/sc foo-stx-3)))


### PR DESCRIPTION
This is a fix intended to go into the TR release for PR 15330.

There are several ways to fix this. The one I chose was changing the equality to traverse syntax objects by structure, comparing leaves by free-id=? for identifiers and equal? otherwise.

Another option would be to add an (optional) value to these static contracts that is used for equality checking. Then we could stuff the struct predicate identifier in there for struct contracts.

Yet another is to compile struct contracts specially, avoiding using `flat/sc`.

Any opinions on which approach is best?