### PR TITLE
Make M/Listof expanders not add new pattern vars

### DIFF
--- a/typed-racket-lib/typed-racket/types/match-expanders.rkt
+++ b/typed-racket-lib/typed-racket/types/match-expanders.rkt
@@ -17,7 +17,7 @@
 (define-match-expander Listof:
   (lambda (stx)
     (syntax-parse stx
-      [(_ elem-pat (~optional var-pat #:defaults ([var-pat #'var])))
+      [(_ elem-pat (~optional var-pat #:defaults ([var-pat #'_])))
        ;; Note: in practice it's unlikely that the second pattern will ever come up
        ;;       because the sequence number for '() will be low and the union will
        ;;       be sorted by sequence number. As a paranoid precaution, however,
@@ -49,7 +49,7 @@
 (define-match-expander MListof:
   (lambda (stx)
     (syntax-parse stx
-      [(_ elem-pat (~optional var-pat #:defaults ([var-pat #'var])))
+      [(_ elem-pat (~optional var-pat #:defaults ([var-pat #'_])))
        ;; see note above
        #'(or (Mu: var-pat (Union: (list (Value: '()) (MPair: elem-pat (F: var-pat)))))
              (Mu: var-pat (Union: (list (MPair: elem-pat (F: var-pat)) (Value: '())))))])))

--- a/typed-racket-test/succeed/list-expanders.rkt
+++ b/typed-racket-test/succeed/list-expanders.rkt
@@ -1,0 +1,19 @@
+#lang racket
+(require rackunit
+         typed-racket/types/match-expanders
+         typed-racket/types/abbrev
+         typed-racket/types/base-abbrev)
+
+(test-case
+ "Listof: can appear in or patterns"
+ (define list-base-type
+   (match (make-Listof Univ)
+     [(or (Listof: t) t) t]))
+ (check-equal? list-base-type Univ))
+
+(test-case
+ "MListof: can appear in or patterns"
+ (define mlist-base-type
+   (match (-mlst Univ)
+     [(or (MListof: t) t) t]))
+ (check-equal? mlist-base-type Univ))


### PR DESCRIPTION
To reproduce, see the snippet below where match complains about `var` not being bound in all branches of the pattern.

``` racket
#lang racket
(require typed-racket/types/match-expanders)

(match #f
  [(or (Listof: _) _) #t])
```
