### PR TITLE
Support for changes mandatory-keyword expansion

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -4,6 +4,7 @@
 ;; that are expanded into by Racket macros
 (require
  "../utils/utils.rkt"
+ (only-in "../rep/type-rep.rkt" make-StructTypeTop)
  racket/promise
  string-constants/string-constant
  racket/private/kw racket/file racket/port syntax/parse racket/path
@@ -241,6 +242,12 @@
    (-> Univ Univ Univ Univ Univ)]
   [(make-template-identifier 'missing-kw 'racket/private/kw)
    (->* (list Univ) Univ Univ)]
+  [(make-template-identifier 'prop:named-keyword-procedure 'racket/private/kw)
+   -Struct-Type-Property]
+  [(make-template-identifier 'struct:keyword-procedure/arity-error 'racket/private/kw)
+   (make-StructTypeTop)]
+  [(make-template-identifier 'struct:keyword-method/arity-error 'racket/private/kw)
+   (make-StructTypeTop)]
   ;; from the expansion of `define-runtime-path`
   [(make-template-identifier 'path-of 'racket/runtime-path)
    (-> -Path -Path)]

--- a/typed-racket-lib/typed-racket/utils/lift.rkt
+++ b/typed-racket-lib/typed-racket/utils/lift.rkt
@@ -16,12 +16,12 @@
       (define stx* (local-expand/capture-lifts stx ctx stop-ids))
       (syntax-parse stx*
         #:literal-sets (kernel-literals)
-        [(begin (define-values (n) e) ... e*)
+        [(begin (define-values (n ...) e) ... e*)
          (define-values (sub-defss defs)
            (for/lists (_1 _2) ([e (in-list (syntax->list #'(e ...)))]
-                               [n (in-list (syntax->list #'(n ...)))])
+                               [ns (in-list (syntax->list #'((n ...) ...)))])
              ;; lifted expressions may re-lift, so recur
              (define-values (sub-defs e-expanded) (loop e))
-             (values sub-defs #`(define-values (#,n) #,e-expanded))))
+             (values sub-defs #`(define-values #,ns #,e-expanded))))
          (values (append (apply append sub-defss) defs) #'e*)])))
   #`(begin #,@defs #,expr))


### PR DESCRIPTION
These two commits are intended to support a revised expansion of function definitions that have mandatory keyword arguments. The first commit is a more general repair to support `syntax-local-lift-values-expression` in full. The second commit is specific to the keyword expansion.

A branch of Racket with the change to keyword expansion (plus related optimizer changes): mflatt/racket@ad230d2ca09ee45002eaa1bea24a1e8ce933e3a9 (the `mandatory-keywords` branch).