### PR TITLE
add unsafe-reprovide

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/unsafe.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/unsafe.scrbl
@@ -39,6 +39,10 @@ behavior and may even crash Typed Racket.
   This form declares exports from a module with the same syntax as
   the @racket[provide] form.
 
+  @margin-note{@racket[unsafe-provide] only prevents contract generation for
+   identifiers defined in the same module as the unsafe provide.
+   See docs for @racket[unsafe-reprovide].}
+
   Unlike @racket[provide], this form is unsafe and Typed Racket will not generate
   any contracts that correspond to the specified types. This means that uses of the
   exports in other modules may circumvent the type system's invariants.
@@ -77,6 +81,42 @@ behavior and may even crash Typed Racket.
   Like @racket[require/typed/provide] except that this form is unsafe and will not generate
   contracts that correspond to the specified types to check that the values
   actually match their types.
+}
+
+@defform[(unsafe-reprovide id ...)]{
+  The current implementation of @racket[unsafe-provide] can only prevent contract
+   generation for identifiers defined in the same module as the @racket[unsafe-provide] statement.
+  If a typed module imports another typed module's provides and tries to re-provide them unsafely,
+   the re-provided identifiers will still be protected with contracts.
+
+  @examples[#:eval (make-base-eval)
+    (module t typed/racket/base
+      (require math/array typed/racket/unsafe)
+      (unsafe-provide array-ref))
+
+    (require 't racket/contract)
+    (has-contract? array-ref)
+  ]
+
+  One way to work around this limitation is to re-define the typed identifiers
+   before re-providing them.
+  The @racket[unsafe-reprovide] form is a shorthand for re-defining and unsafely
+   providing a sequence of identifiers.
+  Replacing the above @racket[unsafe-provide] with an @racket[unsafe-reprovide]
+   is semantically equivalent to the following:
+
+  @examples[#:eval (make-base-eval)
+    (module t typed/racket/base
+      (require math/array typed/racket/unsafe)
+      (define array-ref1 array-ref)
+      (unsafe-provide (rename-out [array-ref1 array-ref])))
+
+    (require 't racket/contract)
+    (has-contract? array-ref)
+  ]
+
+  @; BG TODO
+  @history[#:added "1.6"]
 }
 
 @close-eval[eval]

--- a/typed-racket-lib/typed-racket/core.rkt
+++ b/typed-racket-lib/typed-racket/core.rkt
@@ -37,7 +37,7 @@
              (;; pmb = #%plain-module-begin
               [(pmb . body2) new-mod]
               ;; perform the provide transformation from [Culpepper 07]
-              [transformed-body (begin0 (remove-provides #'body2) (do-time "Removed provides"))]
+              [transformed-body (begin0 (remove-provides #'body2) (check-unsafe-reprovides #'body2) (do-time "Removed provides"))]
               ;; add the real definitions of contracts on requires
               [transformed-body
                (begin0 (change-contract-fixups (syntax->list #'transformed-body))

--- a/typed-racket-lib/typed/racket/unsafe.rkt
+++ b/typed-racket-lib/typed/racket/unsafe.rkt
@@ -3,6 +3,7 @@
 ;; This module provides unsafe operations for Typed Racket
 
 (provide (protect-out unsafe-provide
+                      unsafe-reprovide
                       unsafe-require/typed
                       unsafe-require/typed/provide))
 
@@ -46,3 +47,17 @@
      #'(begin (unsafe-require/typed lib clause)
               (provide t pred)
               (unsafe-require/typed/provide lib other-clause ...))]))
+
+(define-syntax (unsafe-reprovide stx)
+  (syntax-case stx ()
+   [(_ nm* ...)
+    (with-syntax ([(nm+* ...)
+                   (for/list ((nm (in-list (syntax-e #'(nm* ...)))))
+                     (unless (identifier? nm)
+                       (raise-syntax-error 'unsafe-reprovide "expected identifier" stx nm))
+                     (gensym (syntax-e nm)))])
+      (syntax/loc stx
+        (begin
+          (define nm+* nm*)
+          ...
+          (unsafe-provide (rename-out [nm+* nm*] ...)))))]))

--- a/typed-racket-test/succeed/unsafe-provide-warning.rkt
+++ b/typed-racket-test/succeed/unsafe-provide-warning.rkt
@@ -1,0 +1,22 @@
+#lang racket/base
+
+;; Compiling a module that calls `unsafe-provide` on an identifier
+;;  defined outside the current module (i.e. an imported identifier)
+;;  should print a warning to the `current-error-port`
+
+(define p (open-output-string))
+(parameterize ([current-error-port p])
+  (void (compile
+    #'(module test typed/racket/base
+        (module a typed/racket/base
+          (define -a 1)
+          (provide -a))
+        (require 'a typed/racket/unsafe)
+        (define b 2)
+        (unsafe-provide -a b (rename-out [-a c]))))))
+
+(define msg (begin0 (get-output-string p) (close-output-port p)))
+(define expected-error "unsafe-provide:[^\n]*-a[^\n]*\n")
+
+(unless (regexp-match (string-append expected-error expected-error) msg)
+  (error 'unsafe-provide "Expected warning about re-provided identifier"))

--- a/typed-racket-test/succeed/unsafe-reprovide-syntax-error.rkt
+++ b/typed-racket-test/succeed/unsafe-reprovide-syntax-error.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket
+
+(require typed/racket/unsafe)
+
+(with-handlers ([exn:fail:syntax? (lambda (exn) (void))])
+  (eval #'(unsafe-reprovide 4))
+  (error 'unsafe-reprovide "expected syntax error"))

--- a/typed-racket-test/succeed/unsafe-reprovide.rkt
+++ b/typed-racket-test/succeed/unsafe-reprovide.rkt
@@ -1,0 +1,45 @@
+#lang racket/base
+
+;; Test `unsafe-reprovide` form,
+;;  compare to `unsafe-provide`
+
+(module source typed/racket
+  (: v (-> Natural Natural))
+  (define (v x)
+    (add1 x))
+
+  (provide v))
+
+;; -----------------------------------------------------------------------------
+
+(module adaptor-1 typed/racket
+  (require (submod ".." source)
+           typed/racket/unsafe)
+  (unsafe-provide v))
+
+(module adaptor-2 typed/racket
+  (require (submod ".." source)
+           typed/racket/unsafe)
+  (unsafe-reprovide v))
+
+(module adaptor-3 typed/racket
+  (require (prefix-in source: (submod ".." source))
+           typed/racket/unsafe)
+  (define v source:v)
+  (unsafe-provide v))
+
+;; -----------------------------------------------------------------------------
+
+(require
+  (prefix-in s: (submod "." source))
+  (prefix-in a1: (submod "." adaptor-1))
+  (prefix-in a2: (submod "." adaptor-2))
+  (prefix-in a3: (submod "." adaptor-3))
+  (only-in racket/contract has-contract?)
+  rackunit)
+
+(check-true (has-contract? s:v))
+(check-true (has-contract? a1:v))
+
+(check-false (has-contract? a2:v))
+(check-false (has-contract? a3:v))


### PR DESCRIPTION
- adds note to documentation for `unsafe-provide`,
  that only identifiers defined in the current module can get contracts removed
- explains Sam's work-around
- adds `unsafe-reprovide` shorthand for re-defining & re-(unsafe-)providing

plus 2 tests for `unsafe-reprovide`
