### PR TITLE
Improve type annotation of (get-backing-scale)

### DIFF
--- a/typed-racket-more/typed/racket/private/gui-types.rkt
+++ b/typed-racket-more/typed/racket/private/gui-types.rkt
@@ -68,7 +68,7 @@
     (->* [Real Real Exact-Nonnegative-Integer Exact-Nonnegative-Integer Bytes]
          [Any Any #:unscaled? Any]
          Void)]
-   [get-backing-scale (-> Nonnegative-Real)]
+   [get-backing-scale (-> Positive-Real)]
    [get-depth (-> Exact-Nonnegative-Integer)]
    [get-handle (-> Any)]
    [get-height (-> Exact-Positive-Integer)]


### PR DESCRIPTION
stay consistent with the (default-icon-backing-scale)