### PR TITLE
fix type of non-empty-string?

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -177,7 +177,7 @@
            #:repeat? Univ #f
            -String)]
 
-[non-empty-string? (make-pred-ty -String)]
+[non-empty-string? (asym-pred Univ -Boolean (-PS (-is-type 0 -String) -tt))]
 [string-contains? (-> -String -String -Boolean)]
 [string-prefix? (-> -String -String -Boolean)]
 [string-suffix? (-> -String -String -Boolean)]

--- a/typed-racket-test/succeed/gh-issue-426.rkt
+++ b/typed-racket-test/succeed/gh-issue-426.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket
+
+;; Test for Github issue #426
+;; https://github.com/racket/typed-racket/issues/426
+
+(require racket/string typed/rackunit)
+
+(check-equal? (non-empty-string? "foo")            #true)
+(check-equal? (non-empty-string? "")               #false)
+(check-equal? (if (non-empty-string? "foo") 'A 'B) 'A)
+(check-equal? (if (non-empty-string? "")    'A 'B) 'B)
+


### PR DESCRIPTION
If `(non-empty-string? v)` returns true, that implies that `v` is a string, but if it returns false, that doesn't imply anything about the type of `v`.

Fixes https://github.com/racket/typed-racket/issues/426