### PR TITLE
Some little improvements on draw/gui APIs

### DIFF
--- a/typed-racket-more/typed/racket/gui/base.rkt
+++ b/typed-racket-more/typed/racket/gui/base.rkt
@@ -281,7 +281,7 @@
   (cl->* (-> (-> ManyUniv)) (-> (-> ManyUniv) -Void))]
  ;; 4.4 Global Graphics
  [flush-display (-> -Void)]
- [get-display-backing-scale (->key #:monitor -Nat #f (-opt -NonNegReal))]
+ [get-display-backing-scale (->key #:monitor -Nat #f (-opt -PosReal))]
  [get-display-count (-> -PosInt)]
  [get-display-depth (-> -Nat)]
  [get-display-left-top-inset

--- a/typed-racket-more/typed/racket/private/gui-types.rkt
+++ b/typed-racket-more/typed/racket/private/gui-types.rkt
@@ -55,14 +55,10 @@
                  (List Integer Integer Any Any)
                  (List Integer Integer Any Any Real)
                  (List (U Path-String Input-Port))
-                 (List (U Path-String Input-Port) Any)
-                 (List (U Path-String Input-Port)
-                       Any (Option (Instance Color%)))
-                 (List (U Path-String Input-Port)
-                       Any (Option (Instance Color%)) Any)
-                 (List (U Path-String Input-Port)
-                       Any (Option (Instance Color%)) Any
-                       Real)
+                 (List (U Path-String Input-Port) LoadFileKind)
+                 (List (U Path-String Input-Port) LoadFileKind (Option (Instance Color%)))
+                 (List (U Path-String Input-Port) LoadFileKind (Option (Instance Color%)) Any)
+                 (List (U Path-String Input-Port) LoadFileKind (Option (Instance Color%)) Any Real)
                  (List Bytes Integer Integer)))
    [get-argb-pixels
     (->* [Real Real Exact-Nonnegative-Integer Exact-Nonnegative-Integer Bytes]
@@ -862,8 +858,12 @@
          [swap-gl-buffers (-> Void)]
          [with-gl-context ((-> Any) [#:fail (-> Any)] -> Any)]))
 
+(define-type CursorID
+  (U 'arrow 'bullseye 'cross 'hand 'ibeam 'watch 'blank
+     'size-n/s 'size-e/w 'size-ne/sw 'size-nw/se))
+
 (define-type Cursor%
-  (Class (init [id  Symbol])
+  (Class (init [id  CursorID])
          [ok? (-> Boolean)]))
 
 (define-type Frame%


### PR DESCRIPTION
1. (get-display-backing-scale) returns (Option Positive-Real)
2. Cursor% accepts CursorID instead of Symbol
3. Bitmap% accepts LoadFileKind instead of Any

Also, there might be an internal bug.
For `(make-object bitmap% in 'png/alpha #false #false 2.0)`,
if any of the last three arguments are present, it will fail:
given: `(List Input-Port 'png/alpha Any Any Real)` in: `(#%plain-app list in (quote png/alpha) (quote #f) (quote #f) (quote 2.0))` or `(#%plain-app list in (quote png/alpha) (#%app make-color (quote 0) (quote 0) (quote 0)) (quote #f) (quote 2.0))`
