### PR TITLE
add typed/file/glob

### DIFF
--- a/typed-racket-more/typed/file/glob.rkt
+++ b/typed-racket-more/typed/file/glob.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base
+
+(require typed/racket/unsafe)
+
+(define-type Glob (U Path-String (Sequenceof Path-String)))
+
+(unsafe-require/typed file/glob
+  [glob (->* [Glob] [#:capture-dotfiles? Boolean] (Listof Path-String))]
+  [in-glob (->* [Glob] [#:capture-dotfiles? Boolean] (Sequenceof Path-String))]
+  [glob-match? (->* [Glob Path-String] [#:capture-dotfiles? Boolean] Boolean)]
+  [glob-capture-dotfiles? (Parameterof Boolean)])
+
+(unsafe-provide glob
+                in-glob
+                glob-match?
+                glob-capture-dotfiles?)

--- a/typed-racket-more/typed/file/glob.rkt
+++ b/typed-racket-more/typed/file/glob.rkt
@@ -10,7 +10,7 @@
   [glob-match? (->* [Glob Path-String] [#:capture-dotfiles? Boolean] Boolean)]
   [glob-capture-dotfiles? (Parameterof Boolean)])
 
-(unsafe-provide glob
-                in-glob
-                glob-match?
-                glob-capture-dotfiles?)
+(provide glob
+         in-glob
+         glob-match?
+         glob-capture-dotfiles?)


### PR DESCRIPTION
Typed interface to `file/glob`.

This PR is "ready to go", but if we leave it open I'll try to add types + tests for the other `file/*` libraries by the end of the month.

(Otherwise I'll still try to add those, just in a different PR)
