### PR TITLE
add ascii logical type combinator syntax

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -820,6 +820,8 @@ this top type.
         #s((salad food 1) "quinoa" "EVOO" salad))]
 }
 
+@defalias[Union U]
+@defalias[Intersection ∩]
 @defalias[→ ->]
 @defalias[case→ case->]
 @defalias[∀ All]

--- a/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 (require (for-syntax "type-name-error.rkt"
-                     racket/base syntax/stx))
+                     racket/base))
 
 (define-syntax (define-other-types stx)
   (syntax-case stx ()
@@ -12,10 +12,9 @@
 
 ;; special type names that are not bound to particular types
 (define-other-types
-  -> ->* case-> U Rec All Opaque Vector
+  -> ->* case-> U Union ∩ Intersection Rec All Opaque Vector
   Parameterof List List* Class Object Row Unit Values AnyValues Instance Refinement
-  pred Struct Struct-Type Prefab Top Bot Distinction Sequenceof
-  ∩)
+  pred Struct Struct-Type Prefab Top Bot Distinction Sequenceof)
 
 (provide (rename-out [All ∀]
                      [U Un]

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -99,6 +99,7 @@
 (define-literal-syntax-class #:for-label case->^ (case-> case-lambda))
 (define-literal-syntax-class #:for-label Rec)
 (define-literal-syntax-class #:for-label U)
+(define-literal-syntax-class #:for-label Union)
 (define-literal-syntax-class #:for-label All)
 (define-literal-syntax-class #:for-label Opaque)
 (define-literal-syntax-class #:for-label Parameter)
@@ -114,6 +115,7 @@
 (define-literal-syntax-class #:for-label Distinction)
 (define-literal-syntax-class #:for-label Sequenceof)
 (define-literal-syntax-class #:for-label ∩)
+(define-literal-syntax-class #:for-label Intersection)
 
 ;; (Syntax -> Type) -> Syntax Any -> Syntax
 ;; See `parse-type/id`. This is a curried generalization.
@@ -470,9 +472,9 @@
                          (if (memq var (fv t*))
                              (make-Mu var t*)
                              t*))))]
-      [(:U^ ts ...)
+      [((~or :U^ :Union^) ts ...)
        (apply Un (parse-types #'(ts ...)))]
-      [(:∩^ ts ...)
+      [((~or :∩^ :Intersection^) ts ...)
        (for/fold ([ty Univ])
                  ([t (in-list (parse-types #'(ts ...)))])
          (intersect ty t))]

--- a/typed-racket-test/unit-tests/parse-type-tests.rkt
+++ b/typed-racket-test/unit-tests/parse-type-tests.rkt
@@ -121,6 +121,7 @@
    [(-> Number Number Number * Boolean) ((list N N) N . t:->* . B)]
    ;[((. Number) -> Number) (->* (list) N N)] ;; not legal syntax
    [(U Number Boolean) (t:Un N B)]
+   [(Union Number Boolean) (t:Un N B)]
    [(U Number Boolean Number) (t:Un N B)]
    [(U Number Boolean 1) (t:Un N B)]
    [(All (a) (Listof a)) (-poly (a) (make-Listof  a))]
@@ -411,6 +412,7 @@
    [(∩) Univ]
    [(∩ Any) Univ]
    [(∩ String Symbol) -Bottom]
+   [(Intersection String Symbol) -Bottom]
    [(∩ (-> Number Number) (-> String String))
     (-unsafe-intersect (t:-> -String -String)
                        (t:-> -Number -Number))]


### PR DESCRIPTION
Provides ascii friendly syntax for the set-based type combinators (union and intersection) that is clear, concise, and appropriately reflects the dual relationship between U and ∩.

Namely, `(U t ...)` is equivalent to `(Or t ...)` and `(∩ t ...)` is equivalent to `(And t ...)`.
