### PR TITLE
stronger logical check-below

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/check-below.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-below.rkt
@@ -6,6 +6,7 @@
          (types utils union subtype prop-ops abbrev)
          (utils tc-utils)
          (rep type-rep object-rep prop-rep)
+         (env lexical-env)
          (typecheck error-message))
 
 (provide/cond-contract
@@ -18,6 +19,10 @@
  [fix-results (--> tc-results/c full-tc-results/c)])
 
 (provide type-mismatch)
+
+(define (implies-in-lexical-env p q)
+  (define-values (new-env _) (env+ (lexical-env) (list p (negate-prop q))))
+  (not new-env))
 
 (define (print-object o)
   (match o
@@ -88,8 +93,8 @@
       [(p p) #t]
       [(p #f) #t]
       [((PropSet: p1+ p1-) (PropSet: p2+ p2-))
-       (and (implies-atomic? p1+ p2+)
-            (implies-atomic? p1- p2-))]
+       (and (implies-in-lexical-env p1+ p2+)
+            (implies-in-lexical-env p1- p2-))]
       [(_ _) #f]))
   (define (object-better? o1 o2)
     (match* (o1 o2)

--- a/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
@@ -16,25 +16,6 @@
 
 (provide with-lexical-env/extend-props)
 
-;; Returns #f if anything becomes (U)
-(define (env+ env ps)
-  (let/ec exit*
-    (define (exit) (exit* #f empty))
-    (define-values (props atoms) (combine-props ps (env-props env) exit))
-    (values
-      (for/fold ([Γ (replace-props env props)]) ([p (in-list atoms)])
-        (match p
-          [(or (TypeProp: (Path: lo x) pt) (NotTypeProp: (Path: lo x) pt))
-           (update-type/lexical
-             (lambda (x t)
-               (define new-t (update t pt (TypeProp? p) lo))
-               (when (type-equal? new-t -Bottom)
-                 (exit))
-               new-t)
-             x Γ)]
-          [_ Γ]))
-      atoms)))
-
 ;; run code in an extended env and with replaced props. Requires the body to return a tc-results.
 ;; TODO make this only add the new prop instead of the entire environment once tc-id is fixed to
 ;; include the interesting props in its prop.

--- a/typed-racket-lib/typed-racket/types/prop-ops.rkt
+++ b/typed-racket-lib/typed-racket/types/prop-ops.rkt
@@ -5,7 +5,8 @@
          (prefix-in c: (contract-req))
          (rep type-rep prop-rep object-rep rep-utils)
          (only-in (infer infer) intersect)
-         (types union subtype overlap abbrev tc-result))
+         (types union subtype overlap abbrev tc-result update)
+         (env lexical-env type-env-structs))
 
 (provide/cond-contract
   [-and (c:->* () #:rest (c:listof Prop?) Prop?)]
@@ -17,7 +18,12 @@
   [add-unconditional-prop-all-args (c:-> Function? Type/c Function?)]
   [add-unconditional-prop (c:-> tc-results/c Prop? tc-results/c)]
   [erase-props (c:-> tc-results/c tc-results/c)]
-  [name-ref=? (c:-> name-ref/c name-ref/c boolean?)])
+  [name-ref=? (c:-> name-ref/c name-ref/c boolean?)]
+  [combine-props (c:-> (c:listof Prop?) (c:listof Prop?) procedure?
+                       (values (c:or/c (c:listof Prop?) #f)
+                               (c:or/c (c:listof Prop?) #f)))]
+  [env+ (c:-> env? (c:listof Prop?)
+              (values (c:or/c env? #f) (c:listof Prop?)))])
 
 (define (atomic-prop? p)
   (or (TypeProp? p) (NotTypeProp? p)
@@ -255,3 +261,84 @@
           empties
           empties
           dty dbound)]))
+
+
+(define/cond-contract (resolve atoms prop)
+  ((listof Prop?)
+   Prop?
+   . -> .
+   Prop?)
+  (for/fold ([prop prop])
+    ([a (in-list atoms)])
+    (match prop
+      [(AndProp: ps)
+       (let loop ([ps ps] [result null])
+         (if (null? ps)
+             (apply -and result)
+             (let ([p (car ps)])
+               (cond [(contradictory? a p) -ff]
+                     [(implies-atomic? a p) (loop (cdr ps) result)]
+                     [else (loop (cdr ps) (cons p result))]))))]
+      [_ prop])))
+
+(define (flatten-props ps)
+  (let loop ([ps ps])
+    (match ps
+      [(list) null]
+      [(cons (AndProp: ps*) ps) (loop (append ps* ps))]
+      [(cons p ps) (cons p (loop ps))])))
+
+(define/cond-contract (combine-props new-props old-props exit)
+  ((listof Prop?) (listof Prop?) (-> none/c)
+                  . -> .
+                  (values (listof OrProp?) (listof (or/c TypeProp? NotTypeProp?))))
+  (define (atomic-prop? p) (or (TypeProp? p) (NotTypeProp? p)))
+  (define-values (new-atoms new-formulas) (partition atomic-prop? (flatten-props new-props)))
+  (let loop ([derived-formulas null]
+             [derived-atoms new-atoms]
+             [worklist (append old-props new-formulas)])
+    (if (null? worklist)
+        (values derived-formulas derived-atoms)
+        (let* ([p (car worklist)]
+               [p (resolve derived-atoms p)])
+          (match p
+            [(OrProp: ps)
+             (let ([new-or
+                    (let or-loop ([ps ps] [result null])
+                      (cond
+                        [(null? ps) (apply -or result)]
+                        [(for/or ([other-p (in-list (append derived-formulas derived-atoms))])
+                           (contradictory? (car ps) other-p))
+                         (or-loop (cdr ps) result)]
+                        [(for/or ([other-p (in-list derived-atoms)])
+                           (implies-atomic? other-p (car ps)))
+                         -tt]
+                        [else (or-loop (cdr ps) (cons (car ps) result))]))])
+               (if (OrProp? new-or)
+                   (loop (cons new-or derived-formulas) derived-atoms (cdr worklist))
+                   (loop derived-formulas derived-atoms (cons new-or (cdr worklist)))))]
+            [(or (? TypeProp?) (? NotTypeProp?)) (loop derived-formulas (cons p derived-atoms) (cdr worklist))]
+
+            [(AndProp: ps) (loop derived-formulas derived-atoms (append ps (cdr worklist)))]
+            [(TrueProp:) (loop derived-formulas derived-atoms (cdr worklist))]
+            [(FalseProp:) (exit)])))))
+
+
+;; Returns #f if anything becomes (U)
+(define (env+ env ps)
+  (let/ec exit*
+    (define (exit) (exit* #f null))
+    (define-values (props atoms) (combine-props ps (env-props env) exit))
+    (values
+      (for/fold ([Γ (replace-props env props)]) ([p (in-list atoms)])
+        (match p
+          [(or (TypeProp: (Path: lo x) pt) (NotTypeProp: (Path: lo x) pt))
+           (update-type/lexical
+             (lambda (x t)
+               (define new-t (update t pt (TypeProp? p) lo))
+               (when (type-equal? new-t -Bottom)
+                 (exit))
+               new-t)
+             x Γ)]
+          [_ Γ]))
+      atoms)))

--- a/typed-racket-test/succeed/pr429.rkt
+++ b/typed-racket-test/succeed/pr429.rkt
@@ -1,0 +1,15 @@
+#lang typed/racket
+
+(: stx-car/c (∀ (Result Pos Neg) (→ (→ Any Result : #:+ Pos #:- Neg)
+                                    (→ Any (U #f Result)
+                                       : #:+ (Syntaxof (Pairof Pos Any))))))
+(define ((stx-car/c nested-c) v)
+  (if (syntax? v)
+      (if (pair? (syntax-e v))
+          (let ([result (nested-c (car (syntax-e v)))])
+            (if result
+                (begin (ann v (Syntaxof (Pairof Pos Any)))
+                       result)
+                #f))
+          #f)
+      #f))

--- a/typed-racket-test/unit-tests/metafunction-tests.rkt
+++ b/typed-racket-test/unit-tests/metafunction-tests.rkt
@@ -4,7 +4,7 @@
          rackunit racket/format
          (typecheck tc-metafunctions tc-subst)
          (rep prop-rep type-rep object-rep)
-         (types abbrev union prop-ops tc-result numeric-tower)
+         (types abbrev union prop-ops tc-result numeric-tower prop-ops)
          (for-syntax racket/base syntax/parse))
 
 (provide tests)


### PR DESCRIPTION
Makes the `check-below` behavior for logical propositions use the standard logic we use when refining the type environment with new info (also uses the info from the type environment when attempting to prove the propositions).

Addresses #429.
