### PR TITLE
Makes free-vars use struct properties

### DIFF
--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -59,11 +59,11 @@
 
 ;; Compute for a given type how many times each type inside of it
 ;; is referenced
-(define (compute-popularity ty)
-  (when (Type? ty)
-    (hash-update! pop-table ty add1 0))
-  (when (walkable? ty)
-    (Rep-walk compute-popularity ty)))
+(define (compute-popularity x)
+  (when (Type? x)
+    (hash-update! pop-table x add1 0))
+  (when (Rep? x)
+    (Rep-walk compute-popularity x)))
 
 (define (popular? ty)
   (> (hash-ref pop-table ty 0) 5))

--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -436,7 +436,7 @@
             [else ;; Contravariant
              (subtype* A t2 t1)]))]
        ;; If the type has a registered top type predicate, let's check it!
-       [((? has-top-type?) _) #:when ((top-type-pred t1) t2) A]
+       [((? has-top-type?) _) #:when ((Type-top-pred t1) t2) A]
        ;; quantification over two types preserves subtyping
        [((Poly: ns b1) (Poly: ms b2))               
         #:when (= (length ns) (length ms))


### PR DESCRIPTION
This PR cleans up the struct property code in `rep-utils.rkt` and uses struct properties for a few things, namely:
1. the `free-vars` and `free-idxs` fields from Reps have been removed and are now computed via struct property functions.
2. the code which parses fold-like functions for reps in `rep-utils.rkt` has been cleaned up and consolidated to use a single set of macros (instead of one per fold-like function).

Also, with these changes in place we're one step closer to removing ubiquitous interning.
