### PR TITLE
less overhead in contract gen

### DIFF
--- a/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
@@ -10,6 +10,7 @@
   "../structures.rkt"
   "../constraints.rkt"
   racket/match
+  (only-in racket/unsafe/ops unsafe-fxior)
   (contract-req))
 
 (provide/cond-contract
@@ -55,13 +56,13 @@
                  (recur (simple-contract-name s1)
                         (simple-contract-name s2))))
           (define (hash-proc sc hash-code)
-            (hash-code (list (syntax->datum (simple-contract-syntax sc))
-                             (simple-contract-kind sc)
-                             (simple-contract-name sc))))
+            (unsafe-fxior (hash-code (syntax->datum (simple-contract-syntax sc)))
+                          (unsafe-fxior (hash-code (simple-contract-kind sc))
+                                        (hash-code (simple-contract-name sc)))))
           (define (hash2-proc sc hash-code)
-            (hash-code (list (syntax->datum (simple-contract-syntax sc))
-                             (simple-contract-kind sc)
-                             (simple-contract-name sc))))]
+            (unsafe-fxior (hash-code (syntax->datum (simple-contract-syntax sc)))
+                          (unsafe-fxior (hash-code (simple-contract-kind sc))
+                                        (hash-code (simple-contract-name sc)))))]
         #:methods gen:sc
          [(define (sc-map v f) v)
           (define (sc-traverse v f) (void))

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
@@ -7,6 +7,7 @@
          "../structures.rkt"
          "../constraints.rkt"
          racket/match
+         (only-in racket/unsafe/ops unsafe-fxior)
          (for-syntax racket/base racket/syntax syntax/stx syntax/parse)
          racket/set
          racket/sequence
@@ -123,19 +124,21 @@
                       (merge-restricts* 'kind.category-stx (sc.->restricts v recur)))]
                 #:methods gen:equal+hash
                   [(define (equal-proc a b recur)
-                     (and (recur (length (combinator-args a))
-                                 (length (combinator-args b)))
+                     (and (eqv? (length (combinator-args a))
+                                (length (combinator-args b)))
                           (for/and ([sub-a (in-list (combinator-args a))]
                                     [sub-b (in-list (combinator-args b))])
                             (recur sub-a sub-b))))
                    (define (hash-proc v recur)
-                     (+ (recur 'sc.name)
-                        (for/sum ((sub (in-list (combinator-args v))))
-                           (recur sub))))
+                     (unsafe-fxior (recur 'sc.name)
+                                   (for/fold ([hc 102593]) ;; misc prime
+                                             ([sub (in-list (combinator-args v))])
+                                     (unsafe-fxior hc (recur sub)))))
                    (define (hash2-proc v recur)
-                     (+ (recur 'sc.name)
-                        (for/sum ((sub (in-list (combinator-args v))))
-                           (recur sub))))]
+                     (unsafe-fxior (recur 'sc.name)
+                                   (for/fold ([hc 99971]) ;; misc prime
+                                             ([sub (in-list (combinator-args v))])
+                                     (unsafe-fxior hc (recur sub)))))]
                  #:property prop:combinator-name (symbol->string 'sc.name))
          sc.matcher
          sc.definition

--- a/typed-racket-lib/typed-racket/static-contracts/equations.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/equations.rkt
@@ -4,8 +4,6 @@
 ;; An equation set has two components
 ;;  1. a mapping of variables to initial values.
 ;;  2. a mapping of variables to thunks that compute new values.
-;; 
-;; Variables are an opaque structure, which support accessing their current value.
 
 
 (provide
@@ -15,19 +13,16 @@
   resolve-equations
   variable-ref)
 
-
-(struct var ())
-
-; equations: (hash/c var? (-> value?))
-; initial-values: (hash/c var? (-> value?))
+; equations:(hash/c symbol? value?)
+; initial-values: (hash/c symbol?  value?)
 (struct equation-set (equations initial-values))
 
 (define (make-equation-set)
-  (equation-set (make-hash) (make-hash)))
+  (equation-set (make-hasheq) (make-hasheq)))
 
 ; add-variable!: (equation-set? value? -> var?)
 (define (add-variable! eqs initial-value)
-  (define a-var (var))
+  (define a-var (gensym 'var))
   (hash-set! (equation-set-initial-values eqs) a-var initial-value)
   a-var)
 
@@ -35,24 +30,26 @@
 (define (add-equation! eqs var thunk)
   (hash-set! (equation-set-equations eqs) var thunk))
 
-(define current-variable-values (make-parameter (hash)))
+(define current-variable-values (make-parameter (make-hasheq)))
 
-;; resolve-equations (equation-set? -> (hash/c var? value?))
+;; resolve-equations (equation-set? -> (hash/c symbol? value?)
 ;; Produces a mapping of variables to values such that every equation holds.
 (define (resolve-equations eqs)
-  (define values (hash-copy (equation-set-initial-values eqs)))
-  (parameterize ((current-variable-values values))
+  (define vals (make-hasheq))
+  (for ([(key val) (in-hash (equation-set-initial-values eqs))])
+    (hash-set! vals key val))
+  (parameterize ((current-variable-values vals))
     (let loop ()
       (define change #f) 
-      (for (((v thunk) (equation-set-equations eqs)))
+      (for ([(v thunk) (in-hash (equation-set-equations eqs))])
         (define new-value (thunk))
-        (define old-value (hash-ref values v))
+        (define old-value (hash-ref vals v))
         (unless (equal? new-value old-value)
           (set! change #t)
-          (hash-set! values v new-value)))
+          (hash-set! vals v new-value)))
       (when change
         (loop)))
-    values))
+    vals))
 
 (define (variable-ref v)
-  (hash-ref (current-variable-values) v (lambda () (error 'variable-ref "No value available."))))
+  (hash-ref (current-variable-values) v (λ () (error 'variable-ref "No value available."))))

--- a/typed-racket-lib/typed-racket/static-contracts/parametric-check.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/parametric-check.rkt
@@ -5,10 +5,9 @@
 
 (require
   "../utils/utils.rkt"
+  (utils fid-hash)
   (contract-req)
   racket/match
-  racket/dict
-  syntax/private/id-table
   "structures.rkt"
   "equations.rkt"
   "combinators/parametric.rkt"
@@ -22,12 +21,12 @@
 
   (define eqs (make-equation-set))
   (define vars (make-hash))
-  (define rec-vars (make-free-id-table))
+  (define rec-vars (make-fid-hash))
 
   (define (get-var sc)
     (hash-ref! vars sc (lambda () (add-variable! eqs 0))))
   (define (get-rec-var id)
-    (dict-ref! rec-vars id (lambda () (add-variable! eqs 0))))
+    (fid-hash-set! rec-vars id (lambda () (add-variable! eqs 0))))
 
   (define seen (make-hash))
 
@@ -35,7 +34,7 @@
     (define seen? #f)
     (match sc
       ;; skip already seen sc
-      [(? (λ (sc) (hash-ref seen (list sc variance) #f)))
+      [(? (λ (sc) (hash-ref seen (cons sc variance) #f)))
        (set! seen? #t)]
       [(or (or/sc: elems ...) (and/sc: elems ...))
        (add-equation! eqs (get-var sc)
@@ -52,7 +51,7 @@
       [else
        (get-var sc)])
     (unless seen?
-      (hash-set! seen (list sc variance) #t)
+      (hash-set! seen (cons sc variance) #t)
       (sc-traverse sc recur)))
 
   (recur sc 'covariant)

--- a/typed-racket-lib/typed-racket/utils/fid-hash.rkt
+++ b/typed-racket-lib/typed-racket/utils/fid-hash.rkt
@@ -78,7 +78,7 @@
 ;; fid-hash-set
 (define (fid-hash-set h x val)
   (define entry (cons x val))
-  (define x-sym (syntax-e x))
+  (define x-sym (identifier-binding-symbol x))
   (cond
     [(hash-ref h x-sym #f)
      => (λ (l)
@@ -88,7 +88,7 @@
 ;; fid-hash-set!
 (define (fid-hash-set! h x val)
   (define entry (cons x val))
-  (define x-sym (syntax-e x))
+  (define x-sym (identifier-binding-symbol x))
   (cond
     [(hash-ref h x-sym #f)
      => (λ (l)
@@ -103,7 +103,7 @@
   (define (return-fail)
     (if (procedure? fail) (fail) fail))
   (cond
-    [(hash-ref h (syntax-e x) fail)
+    [(hash-ref h (identifier-binding-symbol x) fail)
      => (λ (l)
           (match (assf (λ (y) (free-identifier=? x y)) l)
             [(cons _ val) val]
@@ -113,13 +113,13 @@
 
 ;; fid-hash-has-key?
 (define (fid-hash-has-key? h x)
-  (define l (hash-ref h (syntax-e x) #f))
+  (define l (hash-ref h (identifier-binding-symbol x) #f))
   (and l (assf (λ (y) (free-identifier=? x y)) l) #t))
 
 
 ;; fid-hash-remove
 (define (fid-hash-remove h x)
-  (define x-sym (syntax-e x))
+  (define x-sym (identifier-binding-symbol x))
   (cond
     [(hash-ref h x-sym #f)
      => (λ (l)
@@ -132,7 +132,7 @@
 
 ;; fid-hash-remove
 (define (fid-hash-remove! h x)
-  (define x-sym (syntax-e x))
+  (define x-sym (identifier-binding-symbol x))
   (cond
     [(hash-ref h x-sym #f)
      => (λ (l)

--- a/typed-racket-lib/typed-racket/utils/fid-hash.rkt
+++ b/typed-racket-lib/typed-racket/utils/fid-hash.rkt
@@ -1,0 +1,307 @@
+#lang racket/base
+(require "utils.rkt"
+         (contract-req)
+         racket/match
+         racket/list
+         (for-syntax racket/base racket/match))
+
+;; Lightweight variant of free-id-tables
+
+(provide fid-hash
+         make-fid-hash
+         fid-hash-count
+         fid-hash-empty?
+         fid-hash-set
+         fid-hash-set!
+         fid-hash-ref
+         fid-hash-remove
+         fid-hash-remove!
+         fid-hash-copy
+         in-fid-hash-buckets
+         in-fid-hash-bucket
+         for/fid-hash
+         for*/fid-hash
+         for/mutable-fid-hash
+         for*/mutable-fid-hash
+         fid-hash-keys
+         fid-hash-values)
+
+(provide-for-cond-contract fid-hashof)
+
+(define-for-cond-contract (fid-hashof c)
+  (hash/c symbol? (listof (cons/c identifier? c))))
+
+
+(define fid-hash
+  (case-lambda
+    [() #hash()]
+    [l (let loop ([h #hash()]
+                  [args l])
+         (match args
+           [(list) h]
+           [(cons id (cons val rst))
+            (loop (fid-hash-set h id val) rst)]
+           [(list (? identifier? id))
+            (error 'fid-hash
+                   "identifier not provided a value: ~a"
+                   (syntax-e id))]
+           [_ (error 'fid-hash
+                     "expected even length list of identifier/value bindings, given ~a"
+                     (length l))]))]))
+
+(define make-fid-hash
+  (case-lambda
+    [() (make-hash)]
+    [l (define h (make-hash))
+       (let loop ([args l])
+         (match args
+           [(list) h]
+           [(cons id (cons val rst))
+            (fid-hash-set! h id val)
+            (loop rst)]
+           [(list (? identifier? id))
+            (error 'fid-hash
+                   "identifier not provided a value: ~a"
+                   (syntax-e id))]
+           [_ (error 'fid-hash
+                     "expected even length list of identifier/value bindings, given ~a"
+                     (length l))]))
+       h]))
+
+(define-syntax fid-hash-empty? (make-rename-transformer #'hash-empty?))
+
+(define (fid-hash-count h)
+  (for/sum ([l (in-fid-hash-buckets h)])
+    (length l)))
+
+
+;; fid-hash-set
+(define (fid-hash-set h x val)
+  (define entry (cons x val))
+  (define x-sym (syntax-e x))
+  (cond
+    [(hash-ref h x-sym #f)
+     => (λ (l)
+          (hash-set h x-sym (cons entry (remf (λ (p) (free-identifier=? x (car p))) l))))]
+    [else (hash-set h x-sym (list entry))]))
+
+;; fid-hash-set!
+(define (fid-hash-set! h x val)
+  (define entry (cons x val))
+  (define x-sym (syntax-e x))
+  (cond
+    [(hash-ref h x-sym #f)
+     => (λ (l)
+          (hash-set! h x-sym (cons entry (remf (λ (p) (free-identifier=? x (car p))) l))))]
+    [else (hash-set! h x-sym (list entry))]))
+
+
+;; fid-hash-ref
+(define (fid-hash-ref h x [fail (λ () (error 'fid-hash-ref
+                                             "id not found in fid-hash: ~a"
+                                             x))])
+  (define (return-fail)
+    (if (procedure? fail) (fail) fail))
+  (cond
+    [(hash-ref h (syntax-e x) fail)
+     => (λ (l)
+          (match (assf (λ (y) (free-identifier=? x y)) l)
+            [(cons _ val) val]
+            [else (return-fail)]))]
+    [else (return-fail)]))
+
+
+;; fid-hash-has-key?
+(define (fid-hash-has-key? h x)
+  (define l (hash-ref h (syntax-e x) #f))
+  (and l (assf (λ (y) (free-identifier=? x y)) l) #t))
+
+
+;; fid-hash-remove
+(define (fid-hash-remove h x)
+  (define x-sym (syntax-e x))
+  (cond
+    [(hash-ref h x-sym #f)
+     => (λ (l)
+          (let ([l (remf (λ (p) (free-identifier=? x (car p))) l)])
+            (if (null? l)
+                (hash-remove h x-sym)
+                (hash-set h x-sym l))))]
+    [else h]))
+
+
+;; fid-hash-remove
+(define (fid-hash-remove! h x)
+  (define x-sym (syntax-e x))
+  (cond
+    [(hash-ref h x-sym #f)
+     => (λ (l)
+          (let ([l (remf (λ (p) (free-identifier=? x (car p))) l)])
+            (if (null? l)
+                (hash-remove! h x-sym)
+                (hash-set! h x-sym l))))]
+    [else (void)]))
+
+
+(define (fid-hash-keys h)
+  (for*/list ([b (in-fid-hash-buckets h)]
+              [id/val (in-fid-hash-bucket b)])
+    (car id/val)))
+
+(define (fid-hash-values h)
+  (for*/list ([b (in-fid-hash-buckets h)]
+              [id/val (in-fid-hash-bucket b)])
+    (cdr id/val)))
+
+;; fid-hash iterating forms
+(define-syntax in-fid-hash-buckets (make-rename-transformer #'in-hash-values))
+(define-syntax in-fid-hash-bucket (make-rename-transformer #'in-list))
+
+
+;; for/fid-hash
+(define-syntax-rule (for/fid-hash bindings body ...)
+  (for/fold ([h (fid-hash)])
+            bindings
+    (let-values ([(key val) (let () body ...)])
+      (fid-hash-set h key val))))
+
+;; for/mutable-fid-hash
+(define-syntax-rule (for/mutable-fid-hash bindings body ...)
+  (let ([h (make-fid-hash)])
+    (for bindings
+      (let-values ([(key val) (let () body ...)])
+        (fid-hash-set! h key val)))
+    h))
+
+
+;; for*/fid-hash
+(define-syntax-rule (for*/fid-hash bindings body ...)
+  (for*/fold ([h (fid-hash)])
+             bindings
+    (let-values ([(key val) (let () body ...)])
+      (fid-hash-set h key val))))
+
+;; for*/mutable-fid-hash
+(define-syntax-rule (for*/mutable-fid-hash bindings body ...)
+  (let ([h (make-fid-hash)])
+    (for* bindings
+      (let-values ([(key val) (let () body ...)])
+        (fid-hash-set! h key val)))
+    h))
+
+;; fid-copy
+(define-syntax fid-hash-copy (make-rename-transformer #'hash-copy))
+
+
+(module+ test
+  (module sub1 racket/base
+    (provide x1)
+    (define x 42)
+    (define x1 #'x))
+  (require 'sub1)
+
+  (module sub2 racket/base
+    (provide x2)
+    (define x 42)
+    (define x2 #'x))
+  (require 'sub2)
+  (define x #'x)
+  (define y #'y)
+  (define h (fid-hash))
+
+  (define-syntax (assert stx)
+    (syntax-case stx ()
+      [(_ expr)
+       #`(unless expr #,(quasisyntax/loc stx (error 'assert "failed!")))]))
+
+  ;; tests for immutable fid-hash features
+  (let ()
+    (assert (fid-hash-empty? h))
+    (assert (= 0 (fid-hash-count h)))
+
+    (set! h (fid-hash-set h x 0))
+    (assert (not (fid-hash-empty? h)))
+    (assert (= 1 (fid-hash-count h)))
+    (assert (= (fid-hash-ref h x) 0))
+    (assert (not (fid-hash-ref h x1 #f)))
+    (assert (not (fid-hash-ref h x1 (λ () #f))))
+
+    (set! h (fid-hash-set h x1 1))
+    (set! h (fid-hash-set h x2 2))
+    (set! h (fid-hash-set h y 'y))
+    (assert (not (fid-hash-empty? h)))
+    
+    (assert (= 4 (fid-hash-count h)))
+    (assert (= (fid-hash-ref h x) 0))
+    (assert (= (fid-hash-ref h x1) 1))
+    (assert (= (fid-hash-ref h x2) 2))
+    (assert (eq? (fid-hash-ref h y) 'y))
+
+    (set! h (fid-hash-remove h x2))
+    (assert (not (fid-hash-empty? h)))
+    (assert (= 3 (fid-hash-count h)))
+    (assert (= (fid-hash-ref h x) 0))
+    (assert (= (fid-hash-ref h x1) 1))
+    (assert (eq? (fid-hash-ref h y) 'y))
+  
+    (set! h (for*/fid-hash ([b (in-fid-hash-buckets h)]
+                            [id/val (in-fid-hash-bucket b)])
+              (values (car id/val) (if (number? (cdr id/val))
+                                       (add1 (cdr id/val))
+                                       (cdr id/val)))))
+  
+    (assert (not (fid-hash-empty? h)))
+    (assert (= 3 (fid-hash-count h)))
+    (assert (= (fid-hash-ref h x) 1))
+    (assert (= (fid-hash-ref h x1) 2))
+    (assert (eq? (fid-hash-ref h y) 'y)))
+
+
+
+
+  ;; tests for mutable fid-hash features
+  (let ()
+    (define h (make-fid-hash))
+  
+    (assert (fid-hash-empty? h))
+    (assert (= 0 (fid-hash-count h)))
+
+    (fid-hash-set! h x 0)
+    (assert (not (fid-hash-empty? h)))
+    (assert (= 1 (fid-hash-count h)))
+    (assert (= (fid-hash-ref h x) 0))
+    (assert (not (fid-hash-ref h x1 #f)))
+    (assert (not (fid-hash-ref h x1 (λ () #f))))
+
+    (fid-hash-set! h x1 1)
+    (fid-hash-set! h x2 2)
+    (fid-hash-set! h y 'y)
+    (assert (not (fid-hash-empty? h)))
+    
+    (assert (= 4 (fid-hash-count h)))
+    (assert (= (fid-hash-ref h x) 0))
+    (assert (= (fid-hash-ref h x1) 1))
+    (assert (= (fid-hash-ref h x2) 2))
+    (assert (eq? (fid-hash-ref h y) 'y))
+
+    (fid-hash-remove! h x2)
+    (assert (not (fid-hash-empty? h)))
+    (assert (= 3 (fid-hash-count h)))
+    (assert (= (fid-hash-ref h x) 0))
+    (assert (= (fid-hash-ref h x1) 1))
+    (assert (eq? (fid-hash-ref h y) 'y))
+  
+    (set! h (for*/mutable-fid-hash ([b (in-fid-hash-buckets h)]
+                                    [id/val (in-fid-hash-bucket b)])
+              (values (car id/val) (if (number? (cdr id/val))
+                                       (add1 (cdr id/val))
+                                       (cdr id/val)))))
+
+    (fid-hash-set! h y 42)
+    (assert (not (fid-hash-empty? h)))
+    (assert (= 3 (fid-hash-count h)))
+    (assert (= (fid-hash-ref h x) 1))
+    (assert (= (fid-hash-ref h x1) 2))
+    (assert (eq? (fid-hash-ref h y) 42))))
+
+

--- a/typed-racket-lib/typed-racket/utils/fid-hset.rkt
+++ b/typed-racket-lib/typed-racket/utils/fid-hset.rkt
@@ -58,7 +58,7 @@
 
 ;; fid-hset-add
 (define (fid-hset-add h x)
-  (define x-sym (syntax-e x))
+  (define x-sym (identifier-binding-symbol x))
   (cond
     [(hash-ref h x-sym #f)
      => (λ (l) (if (member x l free-identifier=?)
@@ -68,7 +68,7 @@
 
 
 (define (fid-hset-add! h x)
-  (define x-sym (syntax-e x))
+  (define x-sym (identifier-binding-symbol x))
   (cond
     [(hash-ref h x-sym #f)
      => (λ (l) (unless (member x l free-identifier=?)
@@ -78,14 +78,14 @@
 ;; fid-hset-member?
 (define (fid-hset-member? h x)
   (cond
-    [(hash-ref h (syntax-e x) #f)
+    [(hash-ref h (identifier-binding-symbol x) #f)
      => (λ (l) (and (member x l free-identifier=?) #t))]
     [else #f]))
 
 
 ;; fid-hset-remove
 (define (fid-hset-remove h x)
-  (define x-sym (syntax-e x))
+  (define x-sym (identifier-binding-symbol x))
   (cond
     [(hash-ref h x-sym #f)
      => (λ (l)
@@ -96,7 +96,7 @@
     [else h]))
 
 (define (fid-hset-remove! h x)
-  (define x-sym (syntax-e x))
+  (define x-sym (identifier-binding-symbol x))
   (cond
     [(hash-ref h x-sym #f)
      => (λ (l)
@@ -195,7 +195,7 @@
   
     (set! h (for*/fid-hset ([b (in-fid-hset-buckets h)]
                             [id (in-fid-hset-bucket b)]
-                            #:when (eq? 'x (syntax-e id)))
+                            #:when (eq? 'x (identifier-binding-symbol id)))
               id))
   
     (assert (not (fid-hset-empty? h)))

--- a/typed-racket-lib/typed-racket/utils/fid-hset.rkt
+++ b/typed-racket-lib/typed-racket/utils/fid-hset.rkt
@@ -1,0 +1,245 @@
+#lang racket/base
+(require "utils.rkt"
+         (contract-req)
+         racket/match
+         racket/list
+         (for-syntax racket/base racket/match))
+
+;; Lightweight variant of free-id-sets
+
+(provide fid-hset
+         make-fid-hset
+         fid-hset-count
+         fid-hset-empty?
+         fid-hset-add
+         fid-hset-add!
+         fid-hset-member?
+         fid-hset-remove
+         fid-hset-union
+         fid-hset-map
+         fid-hset-copy
+         fid-hset-remove!
+         in-fid-hset-buckets
+         in-fid-hset-bucket
+         for/fid-hset
+         for*/fid-hset
+         ;for/mutable-fid-hset
+         ;for*/mutable-fid-hset
+         )
+
+(provide-for-cond-contract fid-hset?)
+
+(define-for-cond-contract fid-hset? (hash/c symbol? (listof identifier?) #:immutable #t #:flat? #t))
+
+(define fid-hset
+  (case-lambda
+    [() #hash()]
+    [l (let loop ([h #hash()]
+                  [args l])
+         (match args
+           [(list) h]
+           [(cons id rst)
+            (loop (fid-hset-add h id) rst)]))]))
+
+(define make-fid-hset
+  (case-lambda
+    [() (make-hash)]
+    [args (let ([h (make-hash)])
+            (for ([id (in-list args)])
+              (fid-hset-add! h id))
+            h)]))
+
+(define-syntax fid-hset-empty? (make-rename-transformer #'hash-empty?))
+
+(define (fid-hset-count h)
+  (for/sum ([l (in-fid-hset-buckets h)])
+    (length l)))
+
+
+;; fid-hset-add
+(define (fid-hset-add h x)
+  (define x-sym (syntax-e x))
+  (cond
+    [(hash-ref h x-sym #f)
+     => (λ (l) (if (member x l free-identifier=?)
+                   h
+                   (hash-set h x-sym (cons x l))))]
+    [else (hash-set h x-sym (list x))]))
+
+
+(define (fid-hset-add! h x)
+  (define x-sym (syntax-e x))
+  (cond
+    [(hash-ref h x-sym #f)
+     => (λ (l) (unless (member x l free-identifier=?)
+                 (hash-set! h x-sym (cons x l))))]
+    [else (hash-set! h x-sym (list x))]))
+
+;; fid-hset-member?
+(define (fid-hset-member? h x)
+  (cond
+    [(hash-ref h (syntax-e x) #f)
+     => (λ (l) (and (member x l free-identifier=?) #t))]
+    [else #f]))
+
+
+;; fid-hset-remove
+(define (fid-hset-remove h x)
+  (define x-sym (syntax-e x))
+  (cond
+    [(hash-ref h x-sym #f)
+     => (λ (l)
+          (let ([l (remf (λ (y) (free-identifier=? x y)) l)])
+            (if (null? l)
+                (hash-remove h x-sym)
+                (hash-set h x-sym l))))]
+    [else h]))
+
+(define (fid-hset-remove! h x)
+  (define x-sym (syntax-e x))
+  (cond
+    [(hash-ref h x-sym #f)
+     => (λ (l)
+          (let ([l (remf (λ (y) (free-identifier=? x y)) l)])
+            (if (null? l)
+                (hash-remove! h x-sym)
+                (hash-set! h x-sym l))))]
+    [else (void)]))
+
+
+(define (fid-hset-union s1 s2)
+  (if (< (hash-count s1) (hash-count s2))
+      (fid-hset-union s2 s1)
+      (for*/fold ([s1 s1])
+                 ([b (in-fid-hset-buckets s2)]
+                  [id (in-fid-hset-bucket b)])
+        (fid-hset-add s1 id))))
+
+(define (fid-hset-map s f)
+  (for*/fold ([l '()])
+             ([b (in-fid-hset-buckets s)]
+              [id (in-fid-hset-bucket b)])
+    (cons (f id) l)))
+
+;; fid-hash iterating forms
+(define-syntax in-fid-hset-buckets (make-rename-transformer #'in-hash-values))
+(define-syntax in-fid-hset-bucket (make-rename-transformer #'in-list))
+
+
+;; for/fid-hash
+(define-syntax-rule (for/fid-hset bindings body ...)
+  (for/fold ([h (fid-hset)])
+            bindings
+    (fid-hset-add h (let () body ...))))
+
+
+;; for*/fid-hash
+(define-syntax-rule (for*/fid-hset bindings body ...)
+  (for*/fold ([h (fid-hset)])
+             bindings
+    (fid-hset-add h (let () body ...))))
+
+;; fid-hset-copy
+(define-syntax fid-hset-copy (make-rename-transformer #'hash-copy))
+
+
+(module+ test
+  (module sub1 racket/base
+    (provide x1)
+    (define x 42)
+    (define x1 #'x))
+  (require 'sub1)
+
+  (module sub2 racket/base
+    (provide x2)
+    (define x 42)
+    (define x2 #'x))
+  (require 'sub2)
+  (define x #'x)
+  (define y #'y)
+
+  (define-syntax (assert stx)
+    (syntax-case stx ()
+      [(_ expr)
+       #`(unless expr #,(quasisyntax/loc stx (error 'assert "failed!")))]))
+
+  ;; tests for immutable fid-hset features
+  (let ()
+    (define h (fid-hset))
+    (assert (fid-hset-empty? h))
+    (assert (= 0 (fid-hset-count h)))
+
+    (set! h (fid-hset-add h x))
+    (assert (not (fid-hset-empty? h)))
+    (assert (= 1 (fid-hset-count h)))
+    (assert (fid-hset-member? h x))
+    (assert (not (fid-hset-member? h x1)))
+
+    (set! h (fid-hset-add h x1))
+    (set! h (fid-hset-add h x2))
+    (set! h (fid-hset-add h y))
+    (assert (not (fid-hset-empty? h)))
+    
+    (assert (= 4 (fid-hset-count h)))
+    (assert (fid-hset-member? h x))
+    (assert (fid-hset-member? h x1))
+    (assert (fid-hset-member? h x2))
+    (assert (fid-hset-member? h y))
+
+    (set! h (fid-hset-remove h x2))
+    (assert (not (fid-hset-empty? h)))
+    (assert (= 3 (fid-hset-count h)))
+    (assert (fid-hset-member? h x))
+    (assert (fid-hset-member? h x1))
+    (assert (fid-hset-member? h y))
+  
+    (set! h (for*/fid-hset ([b (in-fid-hset-buckets h)]
+                            [id (in-fid-hset-bucket b)]
+                            #:when (eq? 'x (syntax-e id)))
+              id))
+  
+    (assert (not (fid-hset-empty? h)))
+    (assert (= 2 (fid-hset-count h)))
+    (assert (fid-hset-member? h x))
+    (assert (fid-hset-member? h x1))
+    (assert (not (fid-hset-member? h y))))
+
+  ;; tests for mutable fid-hset
+  (let ()
+    (define h (make-fid-hset))
+    (assert (fid-hset-empty? h))
+    (assert (= 0 (fid-hset-count h)))
+
+    (fid-hset-add! h x)
+    (assert (not (fid-hset-empty? h)))
+    (assert (= 1 (fid-hset-count h)))
+    (assert (fid-hset-member? h x))
+    (assert (not (fid-hset-member? h x1)))
+
+    (fid-hset-add! h x1)
+    (fid-hset-add! h x2)
+    (fid-hset-add! h y)
+    
+    (assert (not (fid-hset-empty? h)))
+    (assert (= 4 (fid-hset-count h)))
+    (assert (fid-hset-member? h x))
+    (assert (fid-hset-member? h x1))
+    (assert (fid-hset-member? h x2))
+    (assert (fid-hset-member? h y))
+
+    (fid-hset-remove! h x2)
+    (assert (not (fid-hset-empty? h)))
+    (assert (= 3 (fid-hset-count h)))
+    (assert (fid-hset-member? h x))
+    (assert (fid-hset-member? h x1))
+    (assert (fid-hset-member? h y))
+    (assert (not (fid-hset-member? h x2)))
+  
+    (fid-hset-remove! h y)
+    (assert (not (fid-hset-empty? h)))
+    (assert (= 2 (fid-hset-count h)))
+    (assert (fid-hset-member? h x))
+    (assert (fid-hset-member? h x1))
+    (assert (not (fid-hset-member? h y)))))
+
+

--- a/typed-racket-lib/typed-racket/utils/hset.rkt
+++ b/typed-racket-lib/typed-racket/utils/hset.rkt
@@ -1,0 +1,163 @@
+#lang racket/base
+(require "utils.rkt"
+         (contract-req)
+         racket/match
+         (for-syntax racket/base racket/match))
+
+;; Lightweight variant of sets
+
+(provide hset hseteq hseteqv
+         hset?
+         hset-empty?
+         hset-member?
+         hset-count
+         hset-add
+         hset-remove
+         hset-first
+         hsubset?
+         hset=?
+         hset-subtract
+         hset-union
+         hset-intersect
+         hset-partition
+         hset-filter
+         hset-map
+         hset-for-each
+         hset->list
+         list->hset
+         list->hseteq
+         for/hset
+         for/hseteq
+         for/hseteqv
+         for*/hset
+         for*/hseteq
+         in-hset)
+
+(provide-for-cond-contract hsetof)
+
+(define-for-cond-contract (hsetof c) (hash/c c #t #:immutable #t #:flat? #t))
+
+(define build-hset
+  (case-lambda
+    [() #hash()]
+    [l (for/fold ([s #hash()]) ([e (in-list l)])
+         (hash-set s e #t))]))
+
+
+(define hset
+  (case-lambda
+    [() #hash()]
+    [l (for/fold ([s #hash()]) ([e (in-list l)])
+         (hash-set s e #t))]))
+
+(define hseteq
+  (case-lambda
+    [() #hasheq()]
+    [l (for/fold ([s #hasheq()]) ([e (in-list l)])
+         (hash-set s e #t))]))
+
+(define (hseteqv)
+  (case-lambda
+    [() #hasheqv()]
+    [l (for/fold ([s #hasheqv()]) ([e (in-list l)])
+         (hash-set s e #t))]))
+
+(define (hset? s) (hash? s))
+
+(define (hset-empty? s) (zero? (hash-count s)))
+(define (hset-member? s e) (hash-ref s e #f))
+(define (hset-count s) (hash-count s))
+
+(define (hset-add s e) (hash-set s e #t))
+(define (hset-remove s e) (hash-remove s e))
+(define (hset-first s) (hash-iterate-key s (hash-iterate-first s)))
+
+(define-syntax in-hset (make-rename-transformer #'in-immutable-hash-keys))
+
+(define (hsubset? s1 s2)
+  (hash-keys-subset? s1 s2))
+
+(define (hset=? s1 s2)
+  (or (eq? s1 s2)
+      (and (= (hash-count s1) (hash-count s2))
+           (hash-keys-subset? s1 s2))))
+
+(define (hset-subtract s1 s2)
+  (for/fold ([s1 s1]) ([k (in-hset s2)])
+    (hash-remove s1 k)))
+
+(define (hset-union s1 s2)
+  (if ((hset-count s1) . < . (hset-count s2))
+      (hset-union s2 s1)
+      (for/fold ([s1 s1]) ([k (in-hset s2)])
+        (hash-set s1 k #t))))
+
+(define (hset-intersect s1 s2)
+  (if ((hset-count s1) . < . (hset-count s2))
+      (hset-union s2 s1)
+      (for/fold ([s s2]) ([k (in-hset s2)])
+        (if (hash-ref s1 k #f)
+            s
+            (hash-remove s k)))))
+
+(define (hset-partition s pred empty-y-set empty-n-set)
+  (for/fold ([y empty-y-set] [n empty-n-set]) ([v (in-hset s)])
+    (if (pred v)
+        (values (hset-add y v) n)
+        (values y (hset-add n v)))))
+
+(define (hset-filter s pred)
+  (for/fold ([s (hset)])
+            ([v (in-hset s)])
+    (if (pred v)
+        (hset-add s v)
+        s)))
+
+(define (hset->list s) (hash-keys s))
+
+(define (list->hset l)
+  (for/hset ([k (in-list l)])
+    k))
+
+(define (list->hseteq l)
+  (for/hseteq ([k (in-list l)])
+    k))
+
+(define (hset-map h f)
+  (for/fold ([result '()])
+            ([x (in-hset h)])
+    (cons (f x) result)))
+
+(define (hset-for-each h f)
+  (for ([x (in-hset h)])
+    (f x)))
+
+(define-syntax-rule (for/hset bindings body ...)
+  (for/hash bindings (values
+                      (let ()
+                        body ...)
+                      #t)))
+
+(define-syntax-rule (for/hseteq bindings body ...)
+  (for/hasheq bindings (values
+                        (let ()
+                          body ...)
+                        #t)))
+
+(define-syntax-rule (for/hseteqv bindings body ...)
+  (for/hasheqv bindings (values
+                         (let ()
+                           body ...)
+                         #t)))
+
+(define-syntax-rule (for*/hset bindings body ...)
+  (for*/hash bindings (values
+                       (let ()
+                         body ...)
+                       #t)))
+
+(define-syntax-rule (for*/hseteq bindings body ...)
+  (for*/hasheq bindings (values
+                         (let ()
+                           body ...)
+                         #t)))


### PR DESCRIPTION
This PR introduces lightweight interfaces to hash tables that allow us to treat them as tables/sets which use free-identifier=? as the equality predicate.

Swapping these data structures in for those provided by `syntax/private/id-table` and `syntax/private/id-set` reduce contract generation time from 12.5 seconds to 4.5 seconds in a [test](https://github.com/pnwamk/tr-performance/blob/master/schml-interp-casts-help.rkt) case which stresses contract generation in Typed Racket.

`utils/fid-hash.rkt` contains a lightweight definition for free-identifier=? hash tables

`utils/fid-hset.rkt` contains a lightweight definition for free-identifier=? sets

`utils/hset.rkt` contains a lightweight definition for standard sets

The changes were mostly made in the `static-contract` sub-directory -- I have not investigated how these data structures might affect type checking time if used in other places inside Typed Racket.



