### PR TITLE
clean up tc-let-unit

### DIFF
--- a/typed-racket-lib/typed-racket/env/lexical-env.rkt
+++ b/typed-racket-lib/typed-racket/env/lexical-env.rkt
@@ -20,57 +20,60 @@
 
 (provide lexical-env 
          with-lexical-env 
-         with-lexical-env/extend-types
-         with-lexical-env/extend-types+aliases)
+         with-extended-lexical-env)
 (provide/cond-contract
  [lookup-type/lexical ((identifier?) (env? #:fail (or/c #f (-> any/c #f))) . ->* . (or/c Type? #f))]
  [lookup-alias/lexical ((identifier?) (env?) . ->* . (or/c Path? Empty?))])
 
 ;; the current lexical environment
-(define lexical-env (make-parameter empty-prop-env))
+(define lexical-env (make-parameter empty-env))
 
 ;; run code in a new env
 (define-syntax-rule (with-lexical-env e . b)
   (parameterize ([lexical-env e]) . b))
 
 ;; run code in an extended env
-(define-syntax-rule (with-lexical-env/extend-types is ts . b)
-  (with-lexical-env (extend/values (lexical-env) is ts) . b))
+(define-syntax (with-extended-lexical-env stx)
+  (syntax-parse stx
+    [(_ [#:identifiers ids:expr
+         #:types tys:expr
+         (~optional (~seq #:aliased-objects objs:expr)
+                    #:defaults ([objs #'#f]))]
+        . body)
+     (syntax/loc stx
+       (with-lexical-env (env-extend/bindings (lexical-env) ids tys objs) . body))]))
 
-;; run code in an extended env + an alias extension
-(define-syntax-rule (with-lexical-env/extend-types+aliases is ts os . b)
-  (with-lexical-env (extend+alias/values (lexical-env) is ts os) . b))
 
 ;; find the type of identifier i, looking first in the lexical env, then in the top-level env
 ;; identifier -> Type
 (define (lookup-type/lexical i [env (lexical-env)] #:fail [fail #f])
-  (lookup env i (λ (i) (lookup-type i (λ () 
-                                        (cond 
-                                          [(syntax-property i 'constructor-for)
-                                           => (λ (prop)
-                                                (define orig (un-rename prop))
-                                                (define t (lookup-type/lexical orig env))
-                                                (register-type i t)
-                                                t)]
-                                          [(syntax-procedure-alias-property i) 
-                                           => (λ (prop)
-                                                (define orig (car (flatten prop)))
-                                                (define t (lookup-type/lexical orig env))
-                                                (register-type i t)
-                                                t)]
-                                          [(syntax-procedure-converted-arguments-property i)
-                                           => (λ (prop)
-                                                (define orig (car (flatten prop)))
-                                                (define pre-t
-                                                  (lookup-type/lexical 
-                                                   orig env #:fail (lambda (i) (lookup-fail i) #f)))
-                                                (define t (if pre-t
-                                                              (kw-convert pre-t #f)
-                                                              Err))
-                                                (register-type i t)
-                                                t)]
-                                          [else ((or fail lookup-fail) i)]))))))
+  (env-lookup env i (λ (i) (lookup-type i (λ ()
+                                            (cond 
+                                              [(syntax-property i 'constructor-for)
+                                               => (λ (prop)
+                                                    (define orig (un-rename prop))
+                                                    (define t (lookup-type/lexical orig env))
+                                                    (register-type i t)
+                                                    t)]
+                                              [(syntax-procedure-alias-property i)
+                                               => (λ (prop)
+                                                    (define orig (car (flatten prop)))
+                                                    (define t (lookup-type/lexical orig env))
+                                                    (register-type i t)
+                                                    t)]
+                                              [(syntax-procedure-converted-arguments-property i)
+                                               => (λ (prop)
+                                                    (define orig (car (flatten prop)))
+                                                    (define pre-t
+                                                      (lookup-type/lexical
+                                                       orig env #:fail (lambda (i) (lookup-fail i) #f)))
+                                                    (define t (if pre-t
+                                                                  (kw-convert pre-t #f)
+                                                                  Err))
+                                                    (register-type i t)
+                                                    t)]
+                                              [else ((or fail lookup-fail) i)]))))))
 
 ;; looks up the representative object for an id (i.e. itself or an alias if one exists)
 (define (lookup-alias/lexical i [env (lexical-env)])
-  (lookup-alias env i -id-path))
+  (env-lookup-alias env i -id-path))

--- a/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-envops.rkt
@@ -23,7 +23,7 @@
     [props
      (let loop ([ps atoms]
                 [negs '()]
-                [Γ (replace-props env props)])
+                [Γ (env-replace-props env props)])
        (match ps
          [(cons p ps)
           (match p
@@ -34,7 +34,7 @@
                     [new-t (update t pt #t lo)])
                (if (type-equal? new-t -Bottom)
                    (values #f '())
-                   (loop ps negs (extend Γ x new-t))))]
+                   (loop ps negs (env-set-type Γ x new-t))))]
             ;; process negative info _after_ positive info so we don't miss anything
             [(NotTypeProp: (Path: _ x) _)
              #:when (and (not (is-var-mutated? x))
@@ -49,7 +49,7 @@
                                  [new-t (update t pt #f lo)])
                             (if (type-equal? new-t -Bottom)
                                 #f
-                                (loop rst (extend Γ x new-t))))]
+                                (loop rst (env-set-type Γ x new-t))))]
                          [_ Γ]))])
               (values Γ atoms))]))]
     [else (values #f '())]))
@@ -57,6 +57,7 @@
 ;; run code in an extended env and with replaced props. Requires the body to return a tc-results.
 ;; TODO make this only add the new prop instead of the entire environment once tc-id is fixed to
 ;; include the interesting props in its prop.
+;; TODO figure out what the heck the above TODO means -amk
 ;; WARNING: this may bail out when code is unreachable
 (define-syntax (with-lexical-env/extend-props stx)
   (define-splicing-syntax-class unreachable?

--- a/typed-racket-lib/typed-racket/typecheck/tc-send.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-send.rkt
@@ -62,14 +62,18 @@
     #:literal-sets (kernel-literals)
     #:literals (list)
     [(#%plain-app meth obj arg ...)
-     (with-lexical-env/extend-types vars types
+     (with-extended-lexical-env
+       [#:identifiers vars
+        #:types types]
        (tc-expr/check (syntax/loc app-stx (#%plain-app meth arg ...))
                       expected))]
     [(let-values ([(arg-var) arg] ...)
        (~and outer-loc (#%plain-app (~and inner-loc (#%plain-app cpce s-kp meth kpe kws num))
                                     kws2 kw-args
                                     obj pos-arg ...)))
-     (with-lexical-env/extend-types vars types
+     (with-extended-lexical-env
+       [#:identifiers vars
+        #:types types]
        (tc-expr/check
         (with-syntax* ([inner-app (syntax/loc app-stx (#%plain-app cpce s-kp meth kpe kws num))]
                        [outer-app (syntax/loc app-stx

--- a/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
@@ -22,7 +22,10 @@
  [replace-names (-> (listof identifier?)
                     (listof OptObject?)
                     tc-results/c
-                    tc-results/c)])
+                    tc-results/c)]
+ [erase-names (-> (listof identifier?)
+                  tc-results/c
+                  tc-results/c)])
 
 
 ;; Substitutes the given objects into the values and turns it into a
@@ -66,6 +69,12 @@
     (for/list ([nm (in-list names)]
                [o (in-list objects)])
       (list nm o Univ)))
+  (subst-tc-results res targets))
+
+(define (erase-names names res)
+  (define targets
+    (for/list ([nm (in-list names)])
+      (list nm -empty-obj Univ)))
   (subst-tc-results res targets))
 
 (define (subst-tc-results res targets)

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -115,9 +115,9 @@
   ;; the golden function to the expanded syntax of the expression.
   (define (test/proc expr golden-fun (expected #f) (new-mapping '()))
     (define expanded-expr (tr-expand expr))
-    (define result (with-lexical-env/extend-types
-                     (map car new-mapping)
-                     (map cadr new-mapping)
+    (define result (with-extended-lexical-env
+                     [#:identifiers (map car new-mapping)
+                      #:types (map cadr new-mapping)]
                      (tc expanded-expr expected)))
     (define golden (golden-fun expanded-expr))
     (check-tc-results result golden #:name "tc-expr"))
@@ -141,9 +141,9 @@
                                         "tc-expr raised the wrong error message")))))])
           (define result
             (parameterize ([delay-errors? #t])
-              (with-lexical-env/extend-types
-                (map car new-mapping)
-                (map cadr new-mapping)
+              (with-extended-lexical-env
+                [#:identifiers (map car new-mapping)
+                 #:types (map cadr new-mapping)]
                 (tc (tr-expand code) expected))))
           (check-tc-results result golden #:name "tc-expr")
           (report-first-error)


### PR DESCRIPTION
clean up tc-let-unit

This commit cleans up some helper functions that have been
pretty awful for a long time. The code is now more readable
and it does less work (i.e. unneeded substitutions are no longer
done).