### PR TITLE
Add type (: max (Index * -> Index))

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -1189,7 +1189,7 @@
              (commutative-case -PosIndex -Index)
              (commutative-case -PosFixnum -Fixnum)
              (commutative-case -NonNegFixnum -Fixnum)
-             (map varop (list -NegFixnum -NonPosFixnum -PosFixnum -NonNegFixnum -Fixnum))
+             (map varop (list -Index -NegFixnum -NonPosFixnum -PosFixnum -NonNegFixnum -Fixnum))
              (commutative-case -PosInt -Int)
              (commutative-case -Nat -Int)
              (map varop (list -NegInt -NonPosInt -PosInt -Nat -Int))


### PR DESCRIPTION
Currently, `(max Index Index)` has the type `Nonnegative-Fixnum` from the case
`(-> Nonnegative-Fixnum Fixnum * Fixnum Nonnegative-Fixnum)`
whereas I believe it should be `Index` -- this includes the case where (max 0 0) is 0 -- which is an Index
added `(-> Index * Index)` to second the varop list for the type of `max`

Is the testing automatic? Or do I need to write a test case --- if so where?