### PR TITLE
`in-query` returns a sequence of single value instead of result-arity-based multiple values

### DIFF
--- a/typed-racket-more/typed/db/sqlite3.rkt
+++ b/typed-racket-more/typed/db/sqlite3.rkt
@@ -1,4 +1,4 @@
-#lang typed/racket
+#lang typed/racket/base
 
 (provide (all-defined-out))
 

--- a/typed-racket-test/succeed/pr468-in-query.rkt
+++ b/typed-racket-test/succeed/pr468-in-query.rkt
@@ -1,0 +1,32 @@
+#lang typed/racket
+
+;; https://github.com/racket/typed-racket/issues/460
+;; https://github.com/racket/typed-racket/pull/468
+
+(require typed/db)
+
+(define sqlite : Connection (sqlite3-connect #:database 'memory))
+
+(struct master ([id : Integer] [type : Symbol] [name : String] [sql : String])
+  #:prefab #:type-name Master
+  #:constructor-name make-master)
+
+(define record : Master
+  (make-master (current-milliseconds) 'table "manual_index"
+               "CREATE TABLE manual_index(id, name, content);"))
+
+(query-exec sqlite (master-sql record))
+(query-exec sqlite "insert into manual_index values ($1, $2, $3)"
+            (master-id record) (master-name record) (~s record))
+
+(for ([s (in-query sqlite "SELECT content FROM manual_index WHERE name = $1;" (master-name record))])
+  (define ?record (with-input-from-string (~a s) read))
+  (if (not (master? ?record))
+      (fprintf (current-error-port) "in-query: unexpected value: ~s"
+               ?record)
+      (fprintf (current-output-port) "[~a]~a: ~s~n"
+               (master-type ?record)
+               (master-name ?record)
+               (master-sql ?record))))
+
+(disconnect sqlite)


### PR DESCRIPTION
Replaced #461 and fixed #460 

Currently, Typed Racket denies sequences that provide 3 or more values,
thus, `in-query` always returns a sequence of vector instead of value/values.
It's okay since applications may predicate column types with `match` after receiving data.

Also, this fix makes the `SQL-Datum` more precision,
since `Any` shadows all opaque types (such as `SQL-Null`) which lead to contract errors.