### PR TITLE
sync with change to `for` expansion (goes with racket/racket PR)

### DIFF
--- a/typed-racket-lib/info.rkt
+++ b/typed-racket-lib/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '(("base" #:version "6.4.0.5")
+(define deps '(("base" #:version "6.7.0.4")
                "source-syntax"
                "compatibility-lib" ;; to assign types
                "string-constants-lib"))

--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -58,6 +58,7 @@
                  (lambda (a)
                    (-values (list
                              (-> Univ (-values a))
+                             (Un (-> Univ Univ) (-val #f))
                              (-> Univ Univ)
                              Univ
                              (Un (-> Univ Univ) (-val #f))

--- a/typed-racket-lib/typed-racket/optimizer/sequence.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/sequence.rkt
@@ -48,7 +48,7 @@
   (pattern (#%plain-app op:make-sequence _ l:list-expr)
     #:do [(log-seq-opt "in-list" #'l)]
     #:with opt #'(let ((i l.opt))
-                   (values unsafe-car unsafe-cdr i
+                   (values unsafe-car unsafe-cdr values i
                            (lambda (x) (not (null? x)))
                            (lambda (x) #t)
                            (lambda (x y) #t))))
@@ -58,6 +58,7 @@
     #:with opt #'(let* ((i   v.opt)
                         (len (unsafe-vector-length i)))
                    (values (lambda (x) (unsafe-vector-ref i x))
+                           #f
                            (lambda (x) (unsafe-fx+ 1 x))
                            0
                            (lambda (x) (unsafe-fx< x len))
@@ -69,6 +70,7 @@
     #:with opt #'(let* ((i   s.opt)
                         (len (string-length i)))
                    (values (lambda (x) (string-ref i x))
+                           #f
                            (lambda (x) (unsafe-fx+ 1 x))
                            0
                            (lambda (x) (unsafe-fx< x len))
@@ -79,6 +81,7 @@
     #:with opt #'(let* ((i   s.opt)
                         (len (bytes-length i)))
                    (values (lambda (x) (bytes-ref i x))
+                           #f
                            (lambda (x) (unsafe-fx+ 1 x))
                            0
                            (lambda (x) (unsafe-fx< x len))
@@ -88,6 +91,7 @@
     #:do [(log-seq-opt "in-range" #'s)]
     #:with opt #'(let* ((end s.opt))
                    (values (lambda (x) x)
+                           #f
                            (lambda (x) (unsafe-fx+ 1 x))
                            0
                            (lambda (x) (unsafe-fx< x end))


### PR DESCRIPTION
In racket/racket#1534, the expansion of `for` for a generic sequence has changed to receive
and use an extra result from the internal `make-sequence` function. These appear to be the needed changes for TR.

The public interface of `make-do-sequence` has also changed to allow a function that returns one more result. I don't think that anyone will ever want to provide that extra result, so I left the type as-is.