### PR TITLE
fix intermittent error in 8e7f390

### DIFF
--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -72,7 +72,7 @@
  ("../types/overlap.rkt" (overlap?))
  ("../types/resolve.rkt" (resolve-app)))
 
-(define var-name-table (make-weak-hash))
+(define var-name-table (make-hash))
 
 ;; Name = Symbol
 


### PR DESCRIPTION
This PR (1) removes some unnecessary nondeterminism from prop-ops and (2) fixes the issue where the `nested-poly` integration test would occasionally fail. Basically, the correctness of type checking currently relies on the `var-name-table` in `type-rep.rkt` being *persistent*... which seems odd and wrong, but that's definitely the issue. I removed the table entirely and that caused the error to consistently happen, and it seems like that program w/ its nested polymorphic applications is the only program I've run into that relied on that particular table being persistent.

A better fix I think would be to further examine how the table is used and remove this requirement --- my initial assumption was that the table was just for error reporting and printing (so that users saw types w/ the same polymorphic variables that appeared in the program) but clearly its doing a little more than that.