### PR TITLE
Make keyword conversion actually expand types to all cases

### DIFF
--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -462,11 +462,17 @@
   [#:for-each (f) (f ty)])
 
 
+(define (keyword-sorted/c kws)
+  (or (empty? kws)
+      (= (length kws) 1)
+      (apply keyword<? (map Keyword-kw kws))))
+
+
 (def-rep arr ([dom (listof Type?)]
               [rng SomeValues?]
               [rest (or/c #f Type?)]
               [drest (or/c #f (cons/c Type? (or/c natural-number/c symbol?)))]
-              [kws (listof Keyword?)])
+              [kws (and/c (listof Keyword?) keyword-sorted/c)])
   [#:frees
    [#:vars (f)
     (combine-frees
@@ -506,6 +512,7 @@
    (when drest (f (car drest)))
    (when rest (f rest))
    (for-each f kws)])
+
 
 ;; arities : Listof[arr]
 (def-type Function ([arities (listof arr?)])

--- a/typed-racket-lib/typed-racket/types/kw-types.rkt
+++ b/typed-racket-lib/typed-racket/types/kw-types.rkt
@@ -7,71 +7,63 @@
          "../utils/tc-utils.rkt"
          "../base-env/annotate-classes.rkt"
          "tc-result.rkt"
-         racket/list racket/set racket/dict racket/match
+         racket/list racket/set racket/match
          racket/format racket/string
          syntax/parse)
 
 ;; convert : [Listof Keyword] [Listof Type] [Listof Type] [Option Type]
 ;;           [Option Type] [Option (Pair Type symbol)] boolean -> Type
 (define (convert kw-t plain-t opt-t rng rest drest split?)
-  (define-values (mand-kw-t opt-kw-t) (partition (match-lambda [(Keyword: _ _ m) m]) kw-t))
-
   (when drest
     (int-err "drest passed to kw-convert"))
-
-  (define arities
-    (for/list ([i (in-range (length opt-t))])
-      (make-arr* (append plain-t (take opt-t i))
-                 rng
-                 #:kws kw-t
-                 #:rest rest
-                 #:drest drest)))
   ;; the kw function protocol passes rest args as an explicit list
-  (define rest-type (if rest (-lst rest) empty))
-  (define ts 
-    (flatten
-     (list
-      (for/list ([k (in-list kw-t)])
-        (match k
-          [(Keyword: _ t #t) t]
-          [(Keyword: _ t #f) (list (-opt t) -Boolean)]))
-      plain-t
-      (for/list ([t (in-list opt-t)]) (-opt t))
-      (for/list ([t (in-list opt-t)]) -Boolean)
-      rest-type)))
+  (define rest-type (if rest (list (-lst rest)) empty))
+
   ;; the kw protocol puts the arguments in keyword-sorted order in the
   ;; function header, so we need to sort the types to match
   (define sorted-kws
     (sort kw-t keyword<? #:key (match-lambda [(Keyword: kw _ _) kw])))
-  (define ts/true
-    (flatten
-     (list
-      (for/list ([k (in-list sorted-kws)])
-        (match k
-          [(Keyword: _ t #t) t]
-          [(Keyword: _ t #f) (list t (-val #t))]))
-      plain-t
-      (for/list ([t (in-list opt-t)]) t)
-      (for/list ([t (in-list opt-t)]) (-val #t))
-      rest-type)))
-  (define ts/false
-    (flatten
-     (list
-      (for/list ([k (in-list sorted-kws)])
-        (match k
-          [(Keyword: _ t #t) t]
-          [(Keyword: _ t #f) (list (-val #f) (-val #f))]))
-      plain-t
-      (for/list ([t (in-list opt-t)]) (-val #f))
-      (for/list ([t (in-list opt-t)]) (-val #f))
-      rest-type)))
-  (make-Function
-    (if split?
-        (remove-duplicates
-          (list (make-arr* ts/true rng #:drest drest)
-                (make-arr* ts/false rng #:drest drest)))
-        (list (make-arr* ts rng #:rest rest #:drest drest)))))
 
+  (make-Function
+    (cond
+      [(not split?)
+       (define ts 
+         (flatten
+          (list
+           (for/list ([k (in-list sorted-kws)])
+             (match k
+               [(Keyword: _ t #t) t]
+               [(Keyword: _ t #f) (list (-opt t) -Boolean)]))
+           plain-t
+           (for/list ([t (in-list opt-t)]) (-opt t))
+           (for/list ([t (in-list opt-t)]) -Boolean)
+           rest-type)))
+       (list (make-arr* ts rng #:rest rest #:drest drest))]
+      [else
+       ;; The different types for each possibile combination of keywords
+       (define keyword-possibilities
+         (map append*
+           (apply cartesian-product
+             (for/list ([k (in-list sorted-kws)])
+               (match k
+                 [(Keyword: _ t #t) (list (list t))]
+                 [(Keyword: _ t #f) (list (list t -True)
+                                          (list -False -False))])))))
+
+       ;; The different types for each possibile supplied number of optional arguments
+       (define optional-possibilities
+         (for/list ([supplied (in-range (add1 (length opt-t)))])
+            (define unsupplied (- (length opt-t) supplied))
+            (append
+              (take opt-t supplied)
+              (make-list unsupplied -False)
+              (make-list supplied -True)
+              (make-list unsupplied -False))))
+
+       (remove-duplicates
+         (for*/list ([kw-pos (in-list keyword-possibilities)]
+                     [opt-pos (in-list optional-possibilities)])
+          (make-arr* (append kw-pos plain-t opt-pos rest-type) rng #:drest drest)))])))
 
 ;; This is used to fix the props of keyword types.
 ;; TODO: This should also explore deeper into the actual types and remove props in there as well.
@@ -121,12 +113,12 @@
 
 (define (find-prefixes l)
   (define l* (sort l < #:key arity-length))
-  (for/fold ([d (list)]) ([e (in-list l*)])
-    (define prefix (for/or ([p (in-dict-keys d)])
+  (for/fold ([h (hash)]) ([e (in-list l*)])
+    (define prefix (for/or ([p (in-hash-keys h)])
                      (and (prefix-of p e) p)))
     (if prefix
-        (dict-set d prefix (arg-diff prefix e))
-        (dict-set d e empty))))
+        (hash-set h prefix (arg-diff prefix e))
+        (hash-set h e null))))
 
 ;; handle-extra-or-missing-kws : (Listof Keyword) LambdaKeywords
 ;;                               -> (Listof Keyword)
@@ -153,14 +145,16 @@
 (define (inner-kw-convert arrs actual-kws split?)
   (define table (find-prefixes arrs))
   (define fns
-    (for/set ([(k v) (in-dict table)])
+    ;; use for/list and remove duplicates afterwards instead of
+    ;; set and set->list to retain determinism
+    (for/list ([(k v) (in-hash table)])
       (match k
         [(arr: mand rng rest drest kws)
          (define kws* (if actual-kws
                           (handle-extra-or-missing-kws kws actual-kws)
                           kws))
          (convert kws* mand v rng rest drest split?)])))
-  (apply cl->* (set->list fns)))
+  (apply cl->* (remove-duplicates fns)))
 
 ;; kw-convert : Type (Option LambdaKeywords) [Boolean] -> Type
 ;; Given an ordinary function type, convert it to a type that matches the keyword

--- a/typed-racket-lib/typed-racket/types/kw-types.rkt
+++ b/typed-racket-lib/typed-racket/types/kw-types.rkt
@@ -9,11 +9,12 @@
          "tc-result.rkt"
          racket/list racket/set racket/match
          racket/format racket/string
+         racket/dict
          syntax/parse)
 
 ;; convert : [Listof Keyword] [Listof Type] [Listof Type] [Option Type]
 ;;           [Option Type] [Option (Pair Type symbol)] boolean -> Type
-(define (convert kw-t plain-t opt-t rng rest drest split?)
+(define (convert kw-ts plain-ts opt-ts rng rest drest split?)
   (when drest
     (int-err "drest passed to kw-convert"))
   ;; the kw function protocol passes rest args as an explicit list
@@ -22,7 +23,8 @@
   ;; the kw protocol puts the arguments in keyword-sorted order in the
   ;; function header, so we need to sort the types to match
   (define sorted-kws
-    (sort kw-t keyword<? #:key (match-lambda [(Keyword: kw _ _) kw])))
+    (sort kw-ts (λ (kw1 kw2) (keyword<? (Keyword-kw kw1)
+                                       (Keyword-kw kw2)))))
 
   (make-Function
     (cond
@@ -34,35 +36,32 @@
              (match k
                [(Keyword: _ t #t) t]
                [(Keyword: _ t #f) (list (-opt t) -Boolean)]))
-           plain-t
-           (for/list ([t (in-list opt-t)]) (-opt t))
-           (for/list ([t (in-list opt-t)]) -Boolean)
+           plain-ts
+           (for/list ([t (in-list opt-ts)]) (-opt t))
+           (for/list ([t (in-list opt-ts)]) -Boolean)
            rest-type)))
        (list (make-arr* ts rng #:rest rest #:drest drest))]
       [else
-       ;; The different types for each possibile combination of keywords
-       (define keyword-possibilities
+       ;; The keyword argument types including boolean flags for
+       ;; optional keyword arguments
+       (define kw-args
          (for/fold ([pos '()])
                    ([k (in-list (reverse sorted-kws))])
            (match k
+             ;; mandatory keyword arguments have no extra args
              [(Keyword: _ t #t) (cons t pos)]
+             ;; we can safely assume 't' and not (-opt t) here
+             ;; because if the keyword is not provided, the value
+             ;; will only appear in dead code (i.e. where the kw-flag arg is #f)
+             ;; within the body of the function
              [(Keyword: _ t #f) (list* t -Boolean pos)])))
 
-       ;; The different types for each possibile supplied number of optional arguments
-       (define optional-possibilities
-         (for/list ([supplied (in-range (add1 (length opt-t)))])
-            (define unsupplied (- (length opt-t) supplied))
-            (append
-              (take opt-t supplied)
-              (make-list unsupplied -False)
-              (make-list supplied -True)
-              (make-list unsupplied -False))))
+       ;; Add boolean arguments for the optional type flaggs.
+       (define opt-flags (make-list (length opt-ts) -Boolean))
 
-       (remove-duplicates
-        (for/list ([opt-pos (in-list optional-possibilities)])
-          (make-arr* (append keyword-possibilities plain-t opt-pos rest-type)
-                     rng
-                     #:drest drest)))])))
+       (list (make-arr* (append kw-args plain-ts opt-ts opt-flags rest-type)
+                        rng
+                        #:drest drest))])))
 
 ;; This is used to fix the props of keyword types.
 ;; TODO: This should also explore deeper into the actual types and remove props in there as well.
@@ -103,7 +102,7 @@
 
 (define (arity-length a)
   (match a
-    [(arr: args result rest drest kws) (length args)]))
+    [(arr: args _ _ _ _) (length args)]))
 
 
 (define (arg-diff a1 a2)
@@ -111,13 +110,14 @@
     [(arr: args _ _ _ _) (drop args (arity-length a1))]))
 
 (define (find-prefixes l)
-  (define l* (sort l < #:key arity-length))
-  (for/fold ([h (hash)]) ([e (in-list l*)])
-    (define prefix (for/or ([p (in-hash-keys h)])
+  (define l* (sort l (λ (arr1 arr2) (< (arity-length arr1)
+                                       (arity-length arr2)))))
+  (for/fold ([d '()]) ([e (in-list l*)])
+    (define prefix (for/or ([p (in-dict-keys d)])
                      (and (prefix-of p e) p)))
     (if prefix
-        (hash-set h prefix (arg-diff prefix e))
-        (hash-set h e null))))
+        (dict-set d prefix (arg-diff prefix e))
+        (dict-set d e null))))
 
 ;; handle-extra-or-missing-kws : (Listof Keyword) LambdaKeywords
 ;;                               -> (Listof Keyword)
@@ -146,14 +146,15 @@
   (define fns
     ;; use for/list and remove duplicates afterwards instead of
     ;; set and set->list to retain determinism
-    (for/list ([(k v) (in-hash table)])
-      (match k
-        [(arr: mand rng rest drest kws)
-         (define kws* (if actual-kws
-                          (handle-extra-or-missing-kws kws actual-kws)
-                          kws))
-         (convert kws* mand v rng rest drest split?)])))
-  (apply cl->* (remove-duplicates fns)))
+    (remove-duplicates
+     (for/list ([(k v) (in-dict table)])
+       (match k
+         [(arr: mand rng rest drest kws)
+          (define kws* (if actual-kws
+                           (handle-extra-or-missing-kws kws actual-kws)
+                           kws))
+          (convert kws* mand v rng rest drest split?)]))))
+  (apply cl->* fns))
 
 ;; kw-convert : Type (Option LambdaKeywords) [Boolean] -> Type
 ;; Given an ordinary function type, convert it to a type that matches the keyword
@@ -324,19 +325,21 @@
     [(arr: args result _ _ _) #f]))
 
 (define (opt-convert ft required-pos optional-pos)
-  (let/ec exit
-    (let loop ((ft ft))
-      (match ft
-        [(Function: arrs)
-         (let ((arrs (map (opt-convert-arr required-pos optional-pos) arrs)))
-           (if (andmap values arrs)
-               (make-Function arrs)
-               (exit #f)))]
-        [(Poly-names: names f)
-         (make-Poly names (loop f))]
-        [(PolyDots-names: names f)
-         (make-PolyDots names (loop f))]
-        [t t]))))
+  (let loop ([ft ft])
+    (match ft
+      [(Function: arrs)
+       (let ([arrs (map (opt-convert-arr required-pos optional-pos) arrs)])
+         (and (andmap values arrs)
+              (make-Function arrs)))]
+      [(Poly-names: names f)
+       (match (loop f)
+         [#f #f]
+         [t (make-Poly names t)])]
+      [(PolyDots-names: names f)
+       (match (loop f)
+         [#f #f]
+         [t (make-PolyDots names t)])]
+      [t t])))
 
 ;; opt-unconvert : Type (Listof Syntax) -> Type
 ;; Given a type for a core optional arg function, unconvert it to a

--- a/typed-racket-lib/typed-racket/types/kw-types.rkt
+++ b/typed-racket-lib/typed-racket/types/kw-types.rkt
@@ -42,13 +42,11 @@
       [else
        ;; The different types for each possibile combination of keywords
        (define keyword-possibilities
-         (map append*
-           (apply cartesian-product
-             (for/list ([k (in-list sorted-kws)])
-               (match k
-                 [(Keyword: _ t #t) (list (list t))]
-                 [(Keyword: _ t #f) (list (list t -True)
-                                          (list -False -False))])))))
+         (for/fold ([pos '()])
+                   ([k (in-list (reverse sorted-kws))])
+           (match k
+             [(Keyword: _ t #t) (cons t pos)]
+             [(Keyword: _ t #f) (list* t -Boolean pos)])))
 
        ;; The different types for each possibile supplied number of optional arguments
        (define optional-possibilities
@@ -61,9 +59,10 @@
               (make-list unsupplied -False))))
 
        (remove-duplicates
-         (for*/list ([kw-pos (in-list keyword-possibilities)]
-                     [opt-pos (in-list optional-possibilities)])
-          (make-arr* (append kw-pos plain-t opt-pos rest-type) rng #:drest drest)))])))
+        (for/list ([opt-pos (in-list optional-possibilities)])
+          (make-arr* (append keyword-possibilities plain-t opt-pos rest-type)
+                     rng
+                     #:drest drest)))])))
 
 ;; This is used to fix the props of keyword types.
 ;; TODO: This should also explore deeper into the actual types and remove props in there as well.

--- a/typed-racket-test/fail/gh56.rkt
+++ b/typed-racket-test/fail/gh56.rkt
@@ -1,0 +1,5 @@
+#lang typed/racket
+
+(: f (Number [#:y Boolean] -> Number))
+(define (f x #:y [y #f] #:z [z 'this-can-be-anything])
+   (if y "y is truthy" x))


### PR DESCRIPTION
## Related PR

This PR is more or less an updated version of https://github.com/racket/typed-racket/pull/62 (thank you @endobson for initially proposing a correct fix for this that ended up only needing a slight tweak!)

## Problem Description

Keyword functions are a little tricky. This PR (and the preceding one) were addressing issues checking the _body_ of kw functions.

Basically, a function with keyword arguments such as `inc`:

```racket
(define (inc x #:n [n 1])
   (+ x n))
```

actually expands into a more complex function with 3 arguments that looks something resembling the following:

```racket
(define (inc-expanded n* n-given? x)
   (let ([n (if n-given? n* 1)]) (+ x n)))
```

and calls to `inc` are converted to match this form:

```racket
(inc 42) => (inc-expanded #f #f 42)

(inc 42 #:n 2) => (inc-expanded 2 #t 42)

```

Note that each optional keyword argument has a boolean flag argument that signals whether or not the caller provided that keyword argument.

Without diving into all of the reasons as to why, basically our handling that typechecked the body of functions such as `inc` has been incorrect for quite some time. An example program that should not typecheck (but has for some time) is the following:

```racket
(: f (Number [#:y Boolean] -> Number))
(define (f x #:y [y #f] #:z [z 'this-can-be-anything])
   (if y "y is truthy" x))
```

This problem was discovered and a fix was presented in https://github.com/racket/typed-racket/pull/62

This fix, however, basically expanded the function type into _every possible combination_ of function types w.r.t. the optional arguments and their accompanying boolean flags.

The body for `inc`, for example, would be checked against the following function type:

```racket
(case->
  [-> False False Number Number]
  [-> Number True Number Number])
```

Unfortunately, this sort of _complete_ expansion of the type resulted in astronimically large types for libraries that use a lot of keyword arguments (see `plot`).

As a tweak to this approach, this PR noticed that the value for the `n*` in `inc` is _only_ rachable in code when `n-given?` is `#t`, and so, assuming the kw-expansion protocol always only accesses `n*` if `n-given?` is `#t`, we can actually safely check the body of the function against the following simpler type:

```racket
(-> Number Boolean Number Number)
```

## Performance issue w/ original

Here example of a file that currently takes a ridiculously long time to type check w/ the original changes because expanding into every possible optional argument combination was prohibitively costly for type checking: `plot-lib/plot/private/no-gui/plot3d.rkt` ([link](https://github.com/racket/plot/blob/master/plot-lib/plot/private/no-gui/plot3d.rkt))