### PR TITLE
Should TR optimizer docs recommend real->double-flonum instead of exact->inexact?

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/guide/optimization.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/optimization.scrbl
@@ -70,8 +70,8 @@ operations, the result is not necessarily a @racket[Float]. For
 instance, the result of @racket[(* 2.0 0)] is @racket[0] which is not
 a @racket[Float]. This can result in missed optimizations. To prevent
 this, when mixing floating-point numbers and exact reals, coerce exact
-reals to floating-point numbers using @racket[exact->inexact]. This is
-not necessary when using @racket[+] or @racket[-]. When mixing
+reals to floating-point numbers using @racket[real->double-flonum].
+This is not necessary when using @racket[+] or @racket[-]. When mixing
 floating-point numbers of different precisions, results use the
 highest precision possible.
 


### PR DESCRIPTION
Since its usage in the guide is to create a value of type `Float` on which TR can apply optimizations, `real->double-flonum` seems like the the better choice. The type of `exact->inexact` can sometimes produce single flonums or complex numbers, but `real->double-flonum` always returns a `Float`.

For converting exact complex numbers into inexact complex numbers I don't see another option; I'm not sure what to do there.