### PR TITLE
Fix Prefab flds

### DIFF
--- a/typed-racket-lib/typed-racket/types/path-type.rkt
+++ b/typed-racket-lib/typed-racket/types/path-type.rkt
@@ -49,10 +49,15 @@
        (path-type rst t (hash))]
 
       ;; struct ops
-      [((Struct: nm par flds proc poly pred) (cons (StructPE: struct-ty idx) rst))
+      [((Struct: _ _ flds _ _ _) (cons (StructPE: struct-ty idx) rst))
        #:when  (subtype t struct-ty)
        (match-let ([(fld: ft _ _) (list-ref flds idx)])
          (path-type rst ft (hash)))]
+
+      ;; prefab struct ops
+      [((Prefab: _ flds) (cons (StructPE: struct-ty idx) rst))
+       #:when  (subtype t struct-ty)
+       (path-type rst (list-ref flds idx) (hash))]
 
       [((Intersection: ts) _)
        (apply -unsafe-intersect (for*/list ([t (in-list ts)]

--- a/typed-racket-lib/typed-racket/types/update.rkt
+++ b/typed-racket-lib/typed-racket/types/update.rkt
@@ -47,23 +47,24 @@
          
          ;; struct ops
          [((Struct: nm par flds proc poly pred)
-           (StructPE: (? (λ (s) (subtype t s))) idx))
+           (StructPE: struct-type idx))
+          #:when (subtype t struct-type)
           ;; Note: this updates fields even if they are not polymorphic.
           ;; Because subtyping is nominal and accessor functions do not
           ;; reflect this, this behavior is unobservable except when a
           ;; variable aliases the field in a let binding
-          (define-values (lhs rhs) (split-at flds idx))
-          (define-values (ty* acc-id)
-            (match rhs
-              [(cons (fld: ty acc-id #f) _)
-               (values (update ty rst) acc-id)]
-              [_ (int-err "update on mutable struct field")]))
-          (cond 
-            [(Bottom? ty*) ty*]
-            [else
-             (define flds*
-               (append lhs (cons (make-fld ty* acc-id #f) (cdr rhs))))
-             (make-Struct nm par flds* proc poly pred)])]
+          (match-define-values (lhs (cons (fld: ty acc-id #f) rhs)) (split-at flds idx))
+          (let ([ty (update ty rst)])
+            (cond
+              [(Bottom? ty) ty]
+              [else
+               (make-Struct nm
+                            par
+                            (append lhs (cons (make-fld ty acc-id #f) rhs))
+                            proc
+                            poly
+                            pred)]))]
+
          
          ;; class field ops
          ;;

--- a/typed-racket-lib/typed-racket/types/update.rkt
+++ b/typed-racket-lib/typed-racket/types/update.rkt
@@ -65,6 +65,19 @@
                             poly
                             pred)]))]
 
+         ;; prefab struct ops
+         [((Prefab: nm flds) (StructPE: struct-type idx))
+          #:when (subtype t struct-type)
+          ;; Note: this updates fields even if they are not polymorphic.
+          ;; Because subtyping is nominal and accessor functions do not
+          ;; reflect this, this behavior is unobservable except when a
+          ;; variable aliases the field in a let binding
+          (match-define-values (lhs (cons fld-ty rhs)) (split-at flds idx))
+          (let ([fld-ty (update fld-ty rst)])
+            (cond
+              [(Bottom? fld-ty) fld-ty]
+              [else
+               (make-Prefab nm (append lhs (cons fld-ty rhs)))]))]
          
          ;; class field ops
          ;;

--- a/typed-racket-test/succeed/prefab.rkt
+++ b/typed-racket-test/succeed/prefab.rkt
@@ -56,10 +56,10 @@
 
 
 
-(struct msg ([str : String]) #:prefab)
+(struct msg ([str : String] [maybe-str : (Option String)]) #:prefab)
 
 ;; tests let bindings fields of prefab structs
-;; works as expected
+;; works as expected (requires path-type.rkt to be correct w.r.t. prefabs)
 (: test-let-binding (-> Any String))
 (define (test-let-binding x)
   (cond
@@ -69,9 +69,29 @@
     [else "Not a msg"]))
 
 ;; tests matching w/ fields of prefab structs
-;; works as expected
+;; works as expected (requires path-type.rkt to be correct w.r.t. prefabs)
 (: test-let-binding-via-match (-> Any String))
 (define (test-let-binding-via-match x)
   (match x
-    [(msg str) str]
-    [_ "no match found"]))
+    [(msg str _) str]
+    [_ "no match found"])) 
+
+
+;; tests if prefab fields are updated with let
+;; (requires update.rkt to be correct w.r.t. prefabs)
+(: test-update-for-prefab (-> msg String))
+(define (test-update-for-prefab x)
+  (let ([maybe-str (msg-maybe-str x)])
+    (cond
+      [maybe-str maybe-str]
+      [else "oops no string"])))
+
+;; tests if prefab fields are updated with match
+;; (requires update.rkt to be correct w.r.t. prefabs)
+(: test-update-for-prefab/match (-> msg String))
+(define (test-update-for-prefab/match x)
+  (match x
+    [(msg _ maybe-str)
+     (cond
+       [maybe-str maybe-str]
+       [else "oops no string"])]))

--- a/typed-racket-test/succeed/prefab.rkt
+++ b/typed-racket-test/succeed/prefab.rkt
@@ -53,3 +53,25 @@
 ;; Test match (indirectly tests unsafe-struct-ref)
 (match (foo 'x) [(foo s) s])
 (match (foo* 'x) [(foo* s) s])
+
+
+
+(struct msg ([str : String]) #:prefab)
+
+;; tests let bindings fields of prefab structs
+;; works as expected
+(: test-let-binding (-> Any String))
+(define (test-let-binding x)
+  (cond
+    [(msg? x)
+     (let ([str (msg-str x)])
+       str)]
+    [else "Not a msg"]))
+
+;; tests matching w/ fields of prefab structs
+;; works as expected
+(: test-let-binding-via-match (-> Any String))
+(define (test-let-binding-via-match x)
+  (match x
+    [(msg str) str]
+    [_ "no match found"]))


### PR DESCRIPTION
Description in terms of Typed Racket usage: Fixes bugs w.r.t. let binding and matching on the fields of prefabs (see, for example, https://github.com/racket/typed-racket/issues/415).

Description in terms of Typed Racket internals: Fixes how prefab field path elements are handed w.r.t. `path-type` and `update`.

