### PR TITLE
fix types of `exact?` and `inexact?`, closes #502

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -728,8 +728,10 @@
 [complex? (make-pred-ty N)]
 ;; `rational?' includes all Reals, except infinities and NaN.
 [rational? (asym-pred Univ B (-PS (-is-type 0 -Real) (-not-type 0 -Rat)))]
-[exact? (make-pred-ty -ExactNumber)]
-[inexact? (make-pred-ty (Un -InexactReal -InexactImaginary -InexactComplex))]
+[exact?   (-> N B : (-PS (-is-type 0 -ExactNumber)
+                         (-is-type 0 (Un -InexactReal -InexactImaginary -InexactComplex))))]
+[inexact? (-> N B : (-PS (-is-type 0 (Un -InexactReal -InexactImaginary -InexactComplex))
+                         (-is-type 0 -ExactNumber)))]
 [fixnum? (make-pred-ty -Fixnum)]
 [index? (make-pred-ty -Index)]
 [positive? (-> -Real B : (-PS (-is-type 0 -PosReal) (-is-type 0 -NonPosReal)))]


### PR DESCRIPTION
The current types for `exact?` and `inexact?` mismatch with the untyped implementation and cause runtime errors as in issue #502.

This commit attepmts to fix the domains and make the types more precise, knowing that the tested value is a number.