### PR TITLE
be more reasonable about constructor contract checking

### DIFF
--- a/typed-racket-lib/typed-racket/rep/rep-utils.rkt
+++ b/typed-racket-lib/typed-racket/rep/rep-utils.rkt
@@ -262,12 +262,9 @@
                            [raw-constructor-name raw-constructor-name]
                            [raw-constructor-contract raw-constructor-contract]
                            [(struct-fields ...) struct-fields])
-               #'(define/cond-contract (constructor-name struct-fields ...)
-                   constructor-contract
-                   (define/cond-contract constructor-name
-                     raw-constructor-contract
-                     raw-constructor-name)
-                   . body))))
+               #'(define (constructor-name struct-fields ...)
+                   (let ([constructor-name raw-constructor-name])
+                     . body)))))
   ;; definer parser for functions who operate on Reps. Fields are automatically bound
   ;; to the struct-field id names in the body. An optional self argument can be specified.
   (define-syntax-class (generic-transformer struct-fields)


### PR DESCRIPTION
I looked more closely, custom constructors were checked at _both_ the module and local level. Also, in my iterating on how to support custom contracts I ended up leaving two layers of checking in on custom constructors -- removing this reduced contract overhead on some small benchmarks by ~20%. I think this is a fair balance (and its more or less what we were doing before).