### PR TITLE
add contracted unit tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ script:
 - raco setup -j 1 math
 - racket -l typed-racket-test -- --math
 - racket -l typed-racket-test/test-docs-complete
+- echo ';; please rebuild me' >> typed-racket-lib/typed-racket/utils/utils.rkt
+- PLT_TR_CONTRACTS=1 raco setup -D typed-racket && raco setup -D typed && raco setup -D typed-racket-test
+- racket -l typed-racket-test -- --unit
 - echo "done"
 
 after_script:

--- a/typed-racket-test/with-tr-contracts.rkt
+++ b/typed-racket-test/with-tr-contracts.rkt
@@ -1,10 +1,11 @@
 #lang racket
 
-(void (putenv "PLT_TR_CONTRACTS" "1"))
+#;(void (putenv "PLT_TR_CONTRACTS" "1"))
 
 (define ns (make-base-namespace))
 (current-namespace ns)
 (use-compiled-file-paths null)
 
+#;
 ((dynamic-require 'typed-racket-test/main 'go/text)
  (dynamic-require 'typed-racket-test/main 'unit-tests))


### PR DESCRIPTION
Currently we run unit tests with our internal development contracts on as a part of our DrDr testing... but we do this without actually recompiling Typed Racket. This leads to the following:

1. The test usually takes 30 or more minutes (lately it's been 50+ minutes)
2. we often don't find out about incorrect development contracts until DrDr builds, instead of finding our as part of the PR review process

This PR moves this testing to our Travis CI builds, which seems to add about 6 or 7 minutes to the overall run time.