### PR TITLE
Fixes type of udp-open-socket

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -2738,19 +2738,19 @@
 
 ;; Section 15.3.2 (racket/udp)
 [udp-open-socket (->opt [(-opt -String) (-opt -Int)] -UDP-Socket)]
-[udp-bind! (-> -UDP-Socket (-opt -String) -Nat -Void)]
-[udp-connect! (-> -UDP-Socket (-opt -String) (-opt -Nat) -Void)]
+[udp-bind! (-> -UDP-Socket (-opt -String) -Int -Void)]
+[udp-connect! (-> -UDP-Socket (-opt -String) (-opt -Int) -Void)]
 
-[udp-send-to (->opt -UDP-Socket -String -Nat -Bytes [-Nat -Nat] -Void)]
-[udp-send (->opt -UDP-Socket -Bytes [-Nat -Nat] -Void)]
-[udp-send-to* (->opt -UDP-Socket -String -Nat -Bytes [-Nat -Nat] B)]
-[udp-send* (->opt -UDP-Socket -Bytes [-Nat -Nat] B)]
-[udp-send-to/enable-break (->opt -UDP-Socket -String -Nat -Bytes [-Nat -Nat] -Void)]
-[udp-send/enable-break (->opt -UDP-Socket -Bytes [-Nat -Nat] -Void)]
+[udp-send-to (->opt -UDP-Socket -String -Int -Bytes [-Int -Int] -Void)]
+[udp-send (->opt -UDP-Socket -Bytes [-Int -Int] -Void)]
+[udp-send-to* (->opt -UDP-Socket -String -Int -Bytes [-Int -Int] B)]
+[udp-send* (->opt -UDP-Socket -Bytes [-Int -Int] B)]
+[udp-send-to/enable-break (->opt -UDP-Socket -String -Int -Bytes [-Int -Int] -Void)]
+[udp-send/enable-break (->opt -UDP-Socket -Bytes [-Int -Int] -Void)]
 
-[udp-receive! (->opt -UDP-Socket -Bytes [-Nat -Nat] (-values (list -Nat -String -Nat)))]
-[udp-receive!* (->opt -UDP-Socket -Bytes [-Nat -Nat] (-values (list (-opt -Nat) (-opt -String) (-opt -Nat))))]
-[udp-receive!/enable-break (->opt -UDP-Socket -Bytes [-Nat -Nat] (-values (list -Nat -String -Nat)))]
+[udp-receive! (->opt -UDP-Socket -Bytes [-Int -Int] (-values (list -Nat -String -Nat)))]
+[udp-receive!* (->opt -UDP-Socket -Bytes [-Int -Int] (-values (list (-opt -Nat) (-opt -String) (-opt -Nat))))]
+[udp-receive!/enable-break (->opt -UDP-Socket -Bytes [-Int -Int] (-values (list -Nat -String -Nat)))]
 
 [udp-close (-> -UDP-Socket -Void)]
 [udp? (make-pred-ty -UDP-Socket)]
@@ -2759,12 +2759,12 @@
 
 [udp-send-ready-evt (-> -UDP-Socket (-mu x (-evt x)))]
 [udp-receive-ready-evt (-> -UDP-Socket (-mu x (-evt x)))]
-[udp-send-to-evt (->opt -UDP-Socket -String -Nat -Bytes [-Nat -Nat]
+[udp-send-to-evt (->opt -UDP-Socket -String -Int -Bytes [-Int -Int]
                         (-evt -Void))]
-[udp-send-evt (->opt -UDP-Socket -Bytes [-Nat -Nat]
+[udp-send-evt (->opt -UDP-Socket -Bytes [-Int -Int]
                      (-evt -Void))]
 [udp-receive!-evt
- (->opt -UDP-Socket -Bytes [-Nat -Nat]
+ (->opt -UDP-Socket -Bytes [-Int -Int]
         (-evt (-lst* -Nat -String -Nat)))]
 
 [udp-addresses

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -2737,7 +2737,7 @@
 [tcp-port? (asym-pred Univ B (-PS (-is-type 0 (Un -Input-Port -Output-Port)) -tt))]
 
 ;; Section 15.3.2 (racket/udp)
-[udp-open-socket (->opt [(-opt -String) (-opt -String)] -UDP-Socket)]
+[udp-open-socket (->opt [(-opt -String) (-opt -Int)] -UDP-Socket)]
 [udp-bind! (-> -UDP-Socket (-opt -String) -Nat -Void)]
 [udp-connect! (-> -UDP-Socket (-opt -String) (-opt -Nat) -Void)]
 


### PR DESCRIPTION
Many thanks to s455wang on IRC for finding the bug, and to @apg for finding the incriminated line & fix.

I put the post precise type I could, although it really should be `(In-Range 1 65535)`, preferably bound to `Port-Number`, when we get more precise numeric types (ISTR that there is a PR for that or at least someone working on it?). Should I change it to `Exact-Nonnegative-Integer`, or even to `Integer` for convenience?

Here are the docs for `udp-open-socket`: https://docs.racket-lang.org/reference/udp.html?q=udp-open#%28def._%28%28lib._racket%2Fudp..rkt%29._udp-open-socket%29%29