### PR TITLE
clean up instantiate/abstract for type vars

### DIFF
--- a/typed-racket-lib/typed-racket/utils/utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/utils.rkt
@@ -400,9 +400,9 @@ at least theoretically.
 
 
 (define (list-ref/default xs idx default)
-  (match xs
-    ['() default]
-    [(cons x xs)
+  (cond
+    [(pair? xs)
      (if (eqv? 0 idx)
-         x
-         (list-ref/default xs (sub1 idx) default))]))
+         (car xs)
+         (list-ref/default (cdr xs) (sub1 idx) default))]
+    [else default]))


### PR DESCRIPTION
This commit involves no functional changes, just tries to clean up some of the helper functions in type-rep, specifically those regarding instantiate/abstract for type variables.