### PR TITLE
WIP: tidy TR arrow rep, add dependent domains

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-indexing-abs.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-indexing-abs.rkt
@@ -231,7 +231,7 @@
 
    ;; flvector ops
 
-   [flvector? (make-pred-ty -FlVector)]
+   [flvector? (pred-> -FlVector)]
    [flvector (->* (list) -Flonum -FlVector)]
    [make-flvector (cl->* (-> index-type -FlVector)
                          (-> index-type -Flonum -FlVector))]
@@ -252,7 +252,7 @@
    [unsafe-flvector-set! (-> -FlVector index-type -Flonum -Void)]
    
    ;; Section 4.2.5.2 (ExtFlonum Vectors)
-   [extflvector? (make-pred-ty -ExtFlVector)]
+   [extflvector? (pred-> -ExtFlVector)]
    [extflvector (->* (list) -ExtFlonum -ExtFlVector)]
    [make-extflvector (cl->* (-> index-type -ExtFlVector)
                             (-> index-type -ExtFlonum -ExtFlVector))]
@@ -273,7 +273,7 @@
    [unsafe-extflvector-set! (-> -ExtFlVector index-type -ExtFlonum -Void)]
    
    ;; Section 4.2.4.2 (Fixnum vectors)
-   [fxvector? (make-pred-ty -FxVector)]
+   [fxvector? (pred-> -FxVector)]
    [fxvector (->* (list) -Fixnum -FxVector)]
    [make-fxvector (cl->* (-> index-type -FxVector)
                          (-> index-type -Fixnum -FxVector))]

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -3,11 +3,10 @@
 ;; This module provides functions for parsing types written by the user
 
 (require (rename-in "../utils/utils.rkt" [infer infer-in])
-         (except-in (rep core-rep type-rep object-rep rep-utils) make-arr)
-         (rename-in (types abbrev utils prop-ops resolve
-                           classes prefab signatures
-                           subtype path-type numeric-tower)
-                    [make-arr* make-arr])
+         (rep core-rep type-rep object-rep rep-utils)
+         (types abbrev utils prop-ops resolve
+                classes prefab signatures
+                subtype path-type numeric-tower)
          (only-in (infer-in infer) intersect)
          (utils tc-utils stxclass-util literal-syntax-class)
          syntax/stx (prefix-in c: (contract-req))

--- a/typed-racket-lib/typed-racket/rep/core-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/core-rep.rkt
@@ -18,16 +18,12 @@
          (for-syntax racket/base racket/syntax
                      syntax/parse))
 
-(provide Type Type?
-         Prop Prop?
-         Object Object? OptObject?
-         PathElem PathElem?
-         SomeValues SomeValues?
-         def-type
-         def-values
-         def-prop
-         def-object
-         def-path-elem)
+(provide Type Type? def-type
+         Prop Prop? def-prop
+         Object Object? OptObject? def-object
+         PathElem PathElem? def-path-elem
+         SomeValues SomeValues? def-values
+         Arr Arr? def-arr)
 
 
 ;;************************************************************
@@ -37,7 +33,8 @@
 (lazy-require
  ["../types/printer.rkt" (print-type
                           print-prop print-object print-pathelem
-                          print-values print-propset print-result)])
+                          print-values print-propset print-result
+                          print-arr)])
 
 ;; comment out the above lazy-require and uncomment the following
 ;; s-exp for simple debug printing of Rep structs
@@ -209,3 +206,12 @@
    #:methods gen:custom-write
    [(define (write-proc v port write?) (print-result v port write?))]])
 
+
+;;************************************************************
+;; Arrows (i.e. function types)
+;;************************************************************
+;;
+;; Note: we represent all function types as case-> types
+;; which contain a list of arrows (i.e. the individual function
+;; types---see arrow-rep.rkt and  'Function' in type-rep.rkt)
+(def-rep-class Arr #:printer print-arr #:define-form def-arr)

--- a/typed-racket-lib/typed-racket/rep/core-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/core-rep.rkt
@@ -23,7 +23,7 @@
          Object Object? OptObject? def-object
          PathElem PathElem? def-path-elem
          SomeValues SomeValues? def-values
-         Arr Arr? def-arr)
+         Arrow Arrow? def-arrow)
 
 
 ;;************************************************************
@@ -34,7 +34,7 @@
  ["../types/printer.rkt" (print-type
                           print-prop print-object print-pathelem
                           print-values print-propset print-result
-                          print-arr)])
+                          print-arrow)])
 
 ;; comment out the above lazy-require and uncomment the following
 ;; s-exp for simple debug printing of Rep structs
@@ -214,4 +214,4 @@
 ;; Note: we represent all function types as case-> types
 ;; which contain a list of arrows (i.e. the individual function
 ;; types---see arrow-rep.rkt and  'Function' in type-rep.rkt)
-(def-rep-class Arr #:printer print-arr #:define-form def-arr)
+(def-rep-class Arrow #:printer print-arrow #:define-form def-arrow)

--- a/typed-racket-lib/typed-racket/rep/rep-utils.rkt
+++ b/typed-racket-lib/typed-racket/rep/rep-utils.rkt
@@ -37,15 +37,13 @@
 
 (define (name-ref/c x)
   (or (identifier? x)
-      (and (pair? x)
-           (exact-integer? (car x))
-           (exact-integer? (cdr x)))))
+      exact-nonnegative-integer?))
 
 (define (name-ref=? x y)
   (cond
     [(identifier? x)
      (and (identifier? y) (free-identifier=? x y))]
-    [else (equal? x y)]))
+    [else (= x y)]))
 
 ;; normal-id-table
 ;;

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -565,7 +565,7 @@
 ;;      and (first dom) is index 1 in (third dom),
 ;; etc, where 'index i' is actually (Path '() i)
 (def-arr ArrowDep ([dom (listof Type?)]
-                   [rst (or/c #f Type? RestDots?)]
+                   [rst (or/c #f Type?)]
                    [rng SomeValues?])
   [#:frees (f)
    (combine-frees

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -54,17 +54,21 @@
          Union-all-flat:
          Union/set:
          Intersection?
-         subst-names
-         inc-lvl
-         abstract-names
          -refine
          Refine:
          Refine-obj:
          Refine-name:
          save-term-var-names!
          extract-props
-         (rename-out [instantiate instantiate-raw-type]
-                     [Union:* Union:]
+         instantiate/type
+         instantiate-many/type
+         abstract/type
+         abstract-many/type
+         instantiate/obj
+         instantiate-many/obj
+         abstract/obj
+         abstract-many/obj
+         (rename-out [Union:* Union:]
                      [Intersection:* Intersection:]
                      [make-Intersection* make-Intersection]
                      [Class:* Class:]
@@ -113,6 +117,11 @@
 ;; it's a dangerous type to have accidently floating around
 ;; as it is both Top and Bottom.
 (def-type Error () [#:singleton Err])
+
+;;************************************************************
+;; Type Variables/Applications
+;;************************************************************
+
 
 ;; de Bruijn indexes - should never appear outside of this file
 ;; bound type variables
@@ -385,9 +394,9 @@
 (def-structural Continuation-Mark-Keyof ([value #:invariant])
   [#:mask mask:continuation-mark-key])
 
-;; * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
+;;************************************************************
 ;; List/Vector Types (that are not simple structural types)
-;; * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
+;;************************************************************
 
 ;; dotted list -- after expansion, becomes normal Pair-based list type
 (def-type ListDots ([dty Type?] [dbound (or/c symbol? natural-number/c)])
@@ -413,9 +422,10 @@
   [#:mask mask:vector])
 
 
-;; * * * * * * *
-;; Type Binders
-;; * * * * * * *
+;;************************************************************
+;; Type Binders (Polys, Mus, etc)
+;;************************************************************
+
 
 
 (def-type Mu ([body Type?])
@@ -470,73 +480,124 @@
 
 
 
-;; kw : keyword?
-;; ty : Type
-;; required? : Boolean
+;;************************************************************
+;; Functions
+;;************************************************************
+
+
+
+;; basic function arrow type with domain and range
+;; Note: no term bindings are introduced
+;; (i.e. they're not at all dependent)
+(def-arr Arrow ([dom (listof Type?)]
+                [rng SomeValues?])
+  [#:frees (f)
+   (combine-frees
+    (cons (f rng)
+          (for/list ([d (in-list dom)])
+            (flip-variances (f d)))))]
+  [#:fmap (f) (make-Arrow (map f dom)
+                          (f rng))]
+  [#:for-each (f)
+   (for-each f dom)
+   (f rng)])
+
+
+;; keyword arguments
 (def-rep Keyword ([kw keyword?] [ty Type?] [required? boolean?])
   [#:frees (f) (f ty)]
   [#:fmap (f) (make-Keyword kw (f ty) required?)]
   [#:for-each (f) (f ty)])
 
-
-(define (keyword-sorted/c kws)
-  (or (empty? kws)
+;; contract for a sorted keyword list
+(define-for-cond-contract (keyword-sorted/c kws)
+  (or (null? kws)
       (= (length kws) 1)
       (apply keyword<? (map Keyword-kw kws))))
 
-
-(def-rep arr ([dom (listof Type?)]
-              [rng SomeValues?]
-              [rest (or/c #f Type?)]
-              [drest (or/c #f (cons/c Type? (or/c natural-number/c symbol?)))]
-              [kws (and/c (listof Keyword?) keyword-sorted/c)])
+(def-rep RestDots ([ty Type?]
+                   [nm (or/c natural-number/c symbol?)])
   [#:frees
    [#:vars (f)
-    (combine-frees
-     (append (map (compose flip-variances f)
-                  (append (if rest (list rest) null)
-                          (map Keyword-ty kws)
-                          dom))
-             (match drest
-               [(cons t (? symbol? bnd))
-                (list (free-vars-remove (flip-variances (f t)) bnd))]
-               [(cons t _)
-                (list (flip-variances (f t)))]
-               [_ null])
-             (list (f rng))))]
+    (cond
+      [(symbol? nm) (free-vars-remove (f ty) nm)]
+      [else (f ty)])]
    [#:idxs (f)
-    (combine-frees
-     (append (map (compose flip-variances f)
-                  (append (if rest (list rest) null)
-                          (map Keyword-ty kws)
-                          dom))
-             (match drest
-               [(cons t (? symbol? bnd))
-                (list (single-free-var bnd variance:contra)
-                      (flip-variances (f t)))]
-               [(cons t _)
-                (list (flip-variances (f t)))]
-               [_ null])
-             (list (f rng))))]]
-  [#:fmap (f) (make-arr (map f dom)
-                        (f rng)
-                        (and rest (f rest))
-                        (and drest (cons (f (car drest)) (cdr drest)))
-                        (map f kws))]
+    (cond
+      [(symbol? nm) (combine-frees (list (f ty) (single-free-var nm)))]
+      [else (f ty)])]]
+  [#:fmap (f) (make-RestDots (f ty) nm)]
+  [#:for-each (f) (f ty)])
+
+
+;; more complicated arrow types which may have rst arguments
+;; (simple or dotted dotted) and keyword arguments
+;; Note: no term bindings are introduced
+;; (i.e. they're not at all dependent)
+(def-arr ArrowStar ([dom (listof Type?)]
+                    [rst (or/c #f Type? RestDots?)]
+                    [kws (listof Keyword?)]
+                    [rng SomeValues?])
+  [#:frees (f)
+   (combine-frees
+    (cons (f rng)
+          (append
+           (if rst (list (f rst)) null)
+           (for/list ([kw (in-list kws)])
+             (flip-variances (f kw)))
+           (for/list ([d (in-list dom)])
+             (flip-variances (f d))))))]
+  [#:fmap (f) (make-Arrow (map f dom)
+                          (f rng))]
   [#:for-each (f)
    (for-each f dom)
-   (f rng)
-   (when drest (f (car drest)))
-   (when rest (f rest))
-   (for-each f kws)])
+   (when rst (f rst))
+   (f rng)])
 
 
-;; arities : Listof[arr]
-(def-type Function ([arities (listof arr?)])
+;; ArrowDep
+;;
+;; 'dom' is a telescope of types which introduces term
+;; binders for each type such that, let n = (length dom),
+;; i. (list-ref dom n-1) is index 0 in 'rst' and 'rng',
+;; ii. (first dom) is index n-1 in 'rst' and 'rng',
+;; iii. (second dom) is index 0 in (third dom),
+;;      and (first dom) is index 1 in (third dom),
+;; etc, where 'index i' is actually (Path '() i)
+(def-arr ArrowDep ([dom (listof Type?)]
+                   [rst (or/c #f Type? RestDots?)]
+                   [rng SomeValues?])
+  [#:frees (f)
+   (combine-frees
+    (cons (f rng)
+          (append
+           (if rst (list (f rst)) null)
+           (for/list ([d (in-list dom)])
+             (flip-variances (f d))))))]
+  [#:fmap (f) (make-ArrowDep (map f dom)
+                             (and rst (f rst))
+                             (f rng))]
+  [#:for-each (f)
+   (for-each f dom)
+   (when rst (f rst))
+   (f rng)])
+
+
+
+;; all functions are case-> internally
+;; (hence they all contain a list of Arr?)
+(def-type Function ([arrows (cons/c Arr? (listof Arr?))])
   [#:mask mask:procedure]
-  [#:frees (f) (combine-frees (map f arities))]
-  [#:fmap (f) (make-Function (map f arities))]
-  [#:for-each (f) (for-each f arities)])
+  [#:frees (f) (combine-frees (map f arrows))]
+  [#:fmap (f) (make-Function (map f arrows))]
+  [#:for-each (f) (for-each f arrows)])
+
+
+
+;;************************************************************
+;; Structs
+;;************************************************************
+
 
 
 (def-rep fld ([t Type?] [acc identifier?] [mutable? boolean?])
@@ -602,6 +663,9 @@
   [#:mask (mask-union mask:struct mask:procedure)])
 
 
+;;************************************************************
+;; Singleton Values (see also Base)
+;;************************************************************
 
 
 ;; v : Racket Value
@@ -624,6 +688,12 @@
      [0 -Zero]
      [1 -One]
      [_ (make-Value val)])])
+
+
+;;************************************************************
+;; Unions
+;;************************************************************
+
 
 ;; mask - cached type mask
 ;; base - any Base types, or Bottom if none are present
@@ -776,6 +846,10 @@
 (define (Un . args)
   (Union-fmap (λ (x) x) -Bottom args))
 
+;;************************************************************
+;; Intersection/Refinement
+;;************************************************************
+
 
 ;; Intersection
 ;; ts - the list of types (gives deterministic behavior)
@@ -868,7 +942,7 @@
        [((Intersection: ts prop* tset) _)
         (-refine (make-Intersection ts -tt tset) (-and prop prop*))]
        [(_ _) (make-Intersection (list t) prop (hash t #t))])]
-    [(nm t prop) (-refine t (abstract-names prop (list nm)))]))
+    [(nm t prop) (-refine t (abstract/obj prop nm))]))
 
 (define-match-expander Intersection:*
   (λ (stx) (syntax-case stx ()
@@ -917,6 +991,43 @@
                      (app Intersection-w/o-prop t)
                      (app (λ (i) (Intersection-prop* obj i)) prop)))])))
 
+
+(define (Intersection-prop* obj t)
+  (define p (Intersection-prop t))
+  (and p (instantiate/obj p obj)))
+
+
+;; given the fact that 'obj' is of type 'type',
+;; look inside of type trying to learn
+;; more info about obj
+(define (extract-props obj type)
+  (cond
+    [(Empty? obj) '()]
+    [else
+     (define props '())
+     (let extract! ([rep type]
+                    [obj obj])
+       (match rep
+         [(== -Zero)
+          #:when (with-linear-integer-arithmetic?)
+          (set! props (cons (-eq obj (-lexp 0)) props))]
+         [(== -One)
+          #:when (with-linear-integer-arithmetic?)
+          (set! props (cons (-eq obj (-lexp 1)) props))]
+         [(Pair: t1 t2) (extract! t1 (-car-of obj))
+                        (extract! t2 (-cdr-of obj))]
+         [(Refine-obj: obj t prop)
+          (set! props (cons prop props))
+          (extract! t obj)]
+         [(HeterogeneousVector: ts)
+          #:when (with-linear-integer-arithmetic?)
+          (set! props (cons (-eq (-vec-len-of obj) (-lexp (length ts)))
+                            props))]
+         [(Intersection: ts _ _) (for ([t (in-list ts)])
+                                   (extract! t obj))]
+         [_ (void)]))
+     props]))
+
 ;; refinement based on some predicate function 'pred'
 (def-type Refinement ([parent Type?] [pred identifier?])
   [#:frees (f) (f parent)]
@@ -924,6 +1035,13 @@
   [#:for-each (f) (f parent)]
   [#:mask (λ (t) (mask (Refinement-parent t)))]
   [#:custom-constructor (make-Refinement parent (normalize-id pred))])
+
+
+;;************************************************************
+;; Object Oriented
+;;************************************************************
+
+
 
 ;; A Row used in type instantiation
 ;; For now, this should not appear in user code. It's used
@@ -998,6 +1116,11 @@
   [#:fmap (f) (make-Instance (f cls))]
   [#:for-each (f) (f cls)]
   [#:mask mask:instance])
+
+;;************************************************************
+;; Units
+;;************************************************************
+
 
 ;; interp:
 ;; name is the id of the signature
@@ -1075,19 +1198,22 @@
 
 
 ;;************************************************************
-;; Locally Nameles Type Variable Abstraction/Instantiation
+;; Type Variable tools (i.e. Abstraction/Instantiation)
+;; Note: see the 'Locally Nameless' binder
+;;       representation strategy for general
+;;       details on the approach we're using
 ;;************************************************************
 
 
-;; abstract
+;; abstract/type
 ;;
 ;; abstracts type variable 'name'
 ;; to De Bruijn index 0 in 'initial'
-(define/cond-contract (abstract name initial)
-  (-> symbol? Rep? Rep?)
-  (abstract-many (list name) initial))
+(define/cond-contract (abstract/type initial name)
+  (-> Rep? symbol? Rep?)
+  (abstract-many/type initial (list name)))
 
-;; abstract-many
+;; abstract-many/type
 ;;
 ;; abstracts the type variable names from 'names-to-abstract'
 ;; to de bruijn indices in 'initial'.
@@ -1096,106 +1222,204 @@
 ;; names-to-abstract[1] gets mapped to n-2
 ;; ...
 ;; names-to-abstract[n-1] gets mapped to 0
-(define/cond-contract (abstract-many names-to-abstract initial)
-  (-> (listof symbol?) Rep? Rep?)
-  (define n-1 (sub1 (length names-to-abstract)))
-  (define (abstract-name name lvl default dotted?)
-    (match (index-of names-to-abstract name eq?)
-      [#f default]
-      ;; adjust index properly before using (see comments above
-      ;; and note we are under 'lvl' additional binders)
-      [idx (let ([idx (+ lvl (- n-1 idx))])
-             (cond [dotted? idx]
-                   [else (make-B idx)]))]))
-  (let rec/lvl ([cur initial] [lvl 0])
-    (define (rec rep) (rec/lvl rep lvl))
-    (match cur
-      ;; Free type variables
-      [(F: name) (abstract-name name lvl cur #f)]
-      ;; forms w/ (potential) dotted type variables
-      [(arr: dom rng rest drest kws)
-       (make-arr (map rec dom)
-                 (rec rng)
-                 (and rest (rec rest))
-                 (match drest
-                   [(cons d-ty d)
-                    (cons (rec d-ty) (abstract-name d lvl d #t))]
-                   [_ #f])
-                 (map rec kws))]
-      [(ValuesDots: rs dty d)
-       (make-ValuesDots (map rec rs)
-                        (rec dty)
-                        (abstract-name d lvl d #t))]
-      [(ListDots: dty d)
-       (make-ListDots (rec dty)
-                      (abstract-name d lvl d #t))]
-      ;; forms which introduce bindings (increment lvls appropriately)
-      [(Mu: body) (make-Mu (rec/lvl body (add1 lvl)))]
-      [(PolyRow: constraints body)
-       (make-PolyRow constraints (rec/lvl body (add1 lvl)))]
-      [(PolyDots: n body)
-       (make-PolyDots n (rec/lvl body (+ n lvl)))]
-      [(Poly: n body)
-       (make-Poly n (rec/lvl body (+ n lvl)))]
-      [_ (Rep-fmap cur rec)])))
+(define/cond-contract (abstract-many/type initial names-to-abstract)
+  (-> Rep? (listof symbol?) Rep?)
+  (cond
+    [(null? names-to-abstract) initial]
+    [else
+     (define n-1 (sub1 (length names-to-abstract)))
+     (define (abstract-name name depth default dotted?)
+       (cond
+         [(symbol? name)
+          (match (index-of names-to-abstract name eq?)
+            [#f default]
+            ;; adjust index properly before using (see comments above
+            ;; and note we are under 'lvl' additional binders)
+            [idx (let ([idx (+ depth (- n-1 idx))])
+                   (cond [dotted? idx]
+                         [else (make-B idx)]))])]
+         [else default]))
+     (type-var-transform initial abstract-name)]))
 
 
-;; instantiate
+;; instantiate/type
 ;;
-;; instantiates De Bruijn index 0 with
+;; instantiates De Bruijn index 0 (i.e. (B 0)) with
 ;; 'type' in 'initial'
-(define/cond-contract (instantiate type initial)
+(define/cond-contract (instantiate/type initial type)
   (-> Type? Rep? Rep?)
-  (instantiate-many (list type) initial))
+  (instantiate-many/type initial (list type)))
 
-;; instantiate-many
+
+;; instantiate/types
 ;;
-;; instantiates De Bruijn indices 0 through
-;; (sub1 (length images)) with the types from images.
+;; instantiates type De Bruijn indices 0 (i.e. (B 0))
+;; through (sub1 (length images)) with images.
+;; (i.e. De Bruin i = (B i))
 ;; Specifically, if n = (length images), then
 ;; index 0 gets mapped to images[n-1]
 ;; index 1 gets mapped to images[n-2]
 ;; ...
 ;; index n-1 gets mapped to images[0]
-(define/cond-contract (instantiate-many images initial)
-  (-> (listof Type?) Rep? Rep?)
-  (define n-1 (sub1 (length images)))
-  (define (instantiate-idx idx lvl default dotted?)
-    ;; adjust for being under 'lvl' binders and for
-    ;; index 0 gets mapped to images[n-1], etc
-    (let ([idx (- n-1 (- idx lvl))])
-      (match (list-ref/default images idx #f)
-        [#f default]
-        [image (cond [dotted? (F-n image)]
-                     [else image])])))
-  (let rec/lvl ([cur initial] [lvl 0])
-    (define (rec rep) (rec/lvl rep lvl))
+(define (instantiate-many/type initial images)
+  (cond
+    [(null? images) initial]
+    [else
+     (define n-1 (sub1 (length images)))
+     (define (instantiate-idx idx depth default dotted?)
+       (cond
+         [(exact-nonnegative-integer? idx)
+          ;; adjust for being under 'depth' binders and for
+          ;; index 0 gets mapped to images[n-1], etc
+          (let ([idx (- n-1 (- idx depth))])
+            (match (list-ref/default images idx #f)
+              [#f default]
+              [image (cond [dotted? (F-n image)]
+                           [else image])]))]
+         [else default]))
+     (type-var-transform initial instantiate-idx)]))
+
+
+
+;; type-var-transform
+;;
+;; Helper function for instantiate[-many]/type
+;; and abstract[-many]/type.
+;;
+;; transform : [target : (or nat sym)]
+;;             [depth : nat]
+;;             [default : (or Type nat sym)]
+;;             [dotted? : boolean]
+;;             ->
+;;             (or Type nat sym)
+;; where 'target' is the thing potentially being replaced
+;; 'depth' is how many binders we're under
+;; 'default' is what it uses if we're not replacing 'target'
+;; 'dotted?' is a flag denoting if this is a dotted var/idx
+(define (type-var-transform initial transform)
+  (let rec/depth ([cur initial] [depth 0])
+    (define (rec rep) (rec/depth rep depth))
     (match cur
-      ;; Bound De Bruijn indices
-      [(B: idx) (instantiate-idx idx lvl cur #f)]
-      ;; forms w/ (potential) dotted type indices
-      [(arr: dom rng rest (cons d-ty (? exact-integer? d)) kws)
-       (make-arr (map rec dom)
-                 (rec rng)
-                 (and rest (rec rest))
-                 (cons (rec d-ty) (instantiate-idx d lvl d #t))
-                 (map rec kws))]
-      [(ValuesDots: rs dty (? exact-integer? d))
+      ;; De Bruijn indices
+      [(B: idx) (transform idx depth cur #f)]
+      ;; Type variables
+      [(F: var) (transform var depth cur #f)]
+      ;; forms w/ dotted type vars/indices
+      [(RestDots: ty d)
+       (make-RestDots (rec ty) (transform d depth d #t))]
+      [(ValuesDots: rs dty d)
        (make-ValuesDots (map rec rs)
                         (rec dty)
-                        (instantiate-idx d lvl d #t))]
-      [(ListDots: dty (? exact-integer? d))
+                        (transform d depth d #t))]
+      [(ListDots: dty d)
        (make-ListDots (rec dty)
-                      (instantiate-idx d lvl d #t))]
+                      (transform d depth d #t))]
       ;; forms which introduce bindings (increment lvls appropriately)
-      [(Mu: body) (make-Mu (rec/lvl body (add1 lvl)))]
+      [(Mu: body) (make-Mu (rec/depth body (add1 depth)))]
       [(PolyRow: constraints body)
-       (make-PolyRow constraints (rec/lvl body (add1 lvl)))]
+       (make-PolyRow constraints (rec/depth body (add1 depth)))]
       [(PolyDots: n body)
-       (make-PolyDots n (rec/lvl body (+ n lvl)))]
+       (make-PolyDots n (rec/depth body (+ n depth)))]
       [(Poly: n body)
-       (make-Poly n (rec/lvl body (+ n lvl)))]
+       (make-Poly n (rec/depth body (+ n depth)))]
       [_ (Rep-fmap cur rec)])))
+
+
+
+;;***************************************************************
+;; Dependent Function/Refinement tools
+;; Note: see the 'Locally Nameless' binder
+;;       representation strategy for general
+;;       details on the approach we're using
+;;***************************************************************
+
+
+;; instantiates term DeBruijn index 0 in 'initial'
+;; with object 'o'---
+(define/cond-contract (instantiate/obj initial o)
+  (-> Rep? OptObject? Rep?)
+  (instantiate-many/obj initial (list o)))
+
+;; instantiates term De Bruijn indices 0...(sub1 (length os))
+;; in 'initial with objects from 'os'
+(define/cond-contract (instantiate-many/obj initial os)
+  (-> Rep? (listof OptObject?) Rep?)
+  (cond
+    [(null? os) initial]
+    [else
+     (define n-1 (sub1 (length os)))
+     (define (instantiate-idx idx lvl)
+       (cond
+         [(exact-nonnegative-integer?)
+          ;; adjust for being under 'lvl' binders and for
+          ;; index 0 gets mapped to os[n-1], etc
+          (let ([idx (- n-1 (- idx lvl))])
+            (or (list-ref/default os idx #f) idx))]
+         [else idx]))
+     (term-var-transform initial instantiate-idx)]))
+
+;; abstract 'id' in 'initial' to be
+;; term De Bruijn index 0 (or its appropriate
+;; successor under additional binders)
+(define (abstract/obj initial id)
+  (abstract-many/obj initial (list id)))
+
+;; abstract 'ids-to-abstract' in 'initial' to be
+;; term De Bruijn index n-1 ... 0 (or their appropriate
+;; successors under additional binders)
+(define/cond-contract (abstract-many/obj initial ids-to-abstract)
+  (-> Rep? (listof identifier?) Rep?)
+  (cond
+    [(null? ids-to-abstract) initial]
+    [else
+     (define n-1 (sub1 (length ids-to-abstract)))
+     (define (abstract-id id lvl)
+       (cond
+         [(identifier? id)
+          (match (index-of ids-to-abstract id eq?)
+            [#f id]
+            ;; adjust index properly before using (see comments above
+            ;; and note we are under 'lvl' additional binders)
+            [idx (+ lvl (- n-1 idx))])]
+         [else id]))
+     (term-var-transform initial abstract-id)]))
+
+
+;; term-binder-transform
+;;
+;; Helper function for abstract[-many]/obj
+;; and instantiate[-many]/obj.
+;;
+;; transform : [target : (or nat sym)]
+;;             [depth : nat]
+;;             ->
+;;             (or nat sym)
+;; where 'target' is the thing potentially being replaced
+;; 'depth' is how many binders we're under
+(define (term-var-transform initial transform)
+  (let rec/depth ([rep initial] [depth 0])
+    (define (rec rep) (rec/depth rep depth))
+    (match rep
+      ;; Functions
+      ;; increment the level of the substituted object
+      [(ArrowDep: dom rst rng)
+       (define k (length dom))
+       (make-ArrowDep
+        (for/list ([d (in-list dom)]
+                   [depth (in-naturals)])
+          (rec/depth d (+ depth depth)))
+        (and rst (rec/depth rst (+ depth k)))
+        (rec/depth rng (+ depth k)))]
+      ;; Refinement types e.g. {x ∈ τ | ψ(x)}
+      ;; increment the level of the substituted object
+      [(Intersection: ts p _) (-refine
+                               (apply -unsafe-intersect (map rec ts))
+                               (rec/depth p (add1 depth)))]
+      [(Path: flds (? exact-integer? n))
+       (make-Path (map rec flds)
+                  (transform n depth))]
+      [_ (Rep-fmap rep rec)])))
+
 
 
 ;;************************************************************
@@ -1211,7 +1435,7 @@
 
 ;; the 'smart' constructor
 (define (Mu* name body)
-  (let ([v (make-Mu (abstract name body))])
+  (let ([v (make-Mu (abstract/type body name))])
     (hash-set! type-var-name-table v name)
     v))
 
@@ -1219,13 +1443,13 @@
 (define (Mu-body* name t)
   (match t
     [(Mu: body)
-     (instantiate (make-F name) body)]))
+     (instantiate/type body (make-F name))]))
 
 ;; unfold : Mu -> Type
 (define/cond-contract (unfold t)
   (Mu? . -> . Type?)
   (match t
-    [(Mu-unsafe: body) (instantiate t body)]
+    [(Mu-unsafe: body) (instantiate/type body t)]
     [t (error 'unfold "not a mu! ~a" t)]))
 
 
@@ -1241,7 +1465,7 @@
 ;;
 (define (Poly* names body #:original-names [orig names])
   (if (null? names) body
-      (let ([v (make-Poly (length names) (abstract-many names body))])
+      (let ([v (make-Poly (length names) (abstract-many/type body names))])
         (hash-set! type-var-name-table v orig)
         v)))
 
@@ -1251,12 +1475,12 @@
     [(Poly: n body)
      (unless (= (length names) n)
        (int-err "Wrong number of names: expected ~a got ~a" n (length names)))
-     (instantiate-many (map make-F names) body)]))
+     (instantiate-many/type body (map make-F names))]))
 
 ;; PolyDots 'smart' constructor
 (define (PolyDots* names body)
   (if (null? names) body
-      (let ([v (make-PolyDots (length names) (abstract-many names body))])
+      (let ([v (make-PolyDots (length names) (abstract-many/type body names))])
         (hash-set! type-var-name-table v names)
         v)))
 
@@ -1266,7 +1490,7 @@
     [(PolyDots: n body)
      (unless (= (length names) n)
        (int-err "Wrong number of names: expected ~a got ~a" n (length names)))
-     (instantiate-many (map make-F names) body)]))
+     (instantiate-many/type body (map make-F names))]))
 
 
 ;; PolyRow 'smart' constructor
@@ -1276,7 +1500,7 @@
 ;; a time. This may change in the future.
 ;;
 (define (PolyRow* names constraints body #:original-names [orig names])
-  (let ([v (make-PolyRow constraints (abstract-many names body))])
+  (let ([v (make-PolyRow constraints (abstract-many/type body names))])
     (hash-set! type-var-name-table v orig)
     v))
 
@@ -1284,7 +1508,7 @@
 (define (PolyRow-body* names t)
   (match t
     [(PolyRow: constraints body)
-     (instantiate-many (map make-F names) body)]))
+     (instantiate-many/type body (map make-F names))]))
 
 
 ;;***************************************************************
@@ -1542,108 +1766,3 @@
       [(_ name-pat) #'(Name: name-pat _ #t)])))
 
 
-;;***************************************************************
-;; Intersection/Refinement related tools
-;;***************************************************************
-
-
-;; inc-lvl
-;; (cons nat nat) -> (cons nat nat)
-;; DeBruijn indexes are represented as a pair of naturals.
-;; This function increments the 'lvl' field of such an index.
-(define (inc-lvl x)
-  (match x
-    [(cons lvl arg) (cons (add1 lvl) arg)]
-    [_ x]))
-
-;; inc-lvls
-;; This function increments the 'lvl' field in all of the targets
-;; and objects of substitution (see 'inc-lvl' above)
-;; (side note: there is a similar but _different_ version
-;; of this function in tc-subst.rkt)
-(define (inc-lvls targets)
-  (for/list ([tgt (in-list targets)])
-    (match tgt
-      [(cons nm1 (Path: flds nm2))
-       (cons (inc-lvl nm1) (make-Path flds (inc-lvl nm2)))]
-      [(cons nm1 rst)
-       (cons (inc-lvl nm1) rst)])))
-
-
-;; name substitution -- like subst-rep in
-;; tc-subst but much simpler
-(define/cond-contract (subst-names rep targets)
-  (-> Rep? (listof (cons/c name-ref/c OptObject?)) Rep?)
-  (define (rec/inc-lvl rep)
-    (subst-names rep (inc-lvls targets)))
-  (let rec ([rep rep])
-    (match rep
-      ;; Functions
-      ;; increment the level of the substituted object
-      [(arr: dom rng rest drest kws)
-       (make-arr (map rec dom)
-                 (rec/inc-lvl rng)
-                 (and rest (rec rest))
-                 (and drest (cons (rec (car drest)) (cdr drest)))
-                 (map rec kws))]
-      ;; Refinement types e.g. {x ∈ τ | ψ(x)}
-      ;; increment the level of the substituted object
-      [(Intersection: ts p _) (-refine
-                               (for/fold ([res Univ])
-                                         ([t (in-list ts)])
-                                 (intersect res (rec t)))
-                               (rec/inc-lvl p))]
-      [(Path: flds nm)
-       (let ([flds (map rec flds)])
-         (cond
-           [(assoc nm targets name-ref=?)
-            => (match-lambda
-                 [(cons _ (Path: flds* nm*)) (make-Path (append flds flds*) nm*)]
-                 [(cons _ (Empty:)) -empty-obj]
-                 [(cons _ (? LExp? l)) #:when (null? flds) l]
-                 [_ -empty-obj])]
-           [else (make-Path flds nm)]))]
-      [_ (Rep-fmap rep rec)])))
-
-(define (abstract-names rep ids)
-  (define sub (for/list ([id (in-list ids)]
-                         [idx (in-range (length ids))])
-                (cons id (-id-path (cons 0 idx)))))
-  (subst-names rep sub))
-
-
-(define (Intersection-prop* obj t)
-  (define p (Intersection-prop t))
-  (and p (subst-names p (list (cons (cons 0 0) obj)))))
-
-
-;; given the fact that 'obj' is of type 'type',
-;; look inside of type trying to learn
-;; more info about obj
-(define (extract-props obj type)
-  (cond
-    [(Empty? obj) '()]
-    [else
-     (define props '())
-     (let extract! ([rep type]
-                    [obj obj])
-       (match rep
-         [(== -Zero)
-          #:when (with-linear-integer-arithmetic?)
-          (set! props (cons (-eq obj (-lexp 0)) props))]
-         [(== -One)
-          #:when (with-linear-integer-arithmetic?)
-          (set! props (cons (-eq obj (-lexp 1)) props))]
-         [(Pair: t1 t2) (extract! t1 (-car-of obj))
-                        (extract! t2 (-cdr-of obj))]
-         [(Refine-obj: obj t prop)
-          (set! props (cons prop props))
-          (extract! t obj)]
-         [(HeterogeneousVector: ts)
-          #:when (with-linear-integer-arithmetic?)
-          (set! props (cons (-eq (-vec-len-of obj) (-lexp (length ts)))
-                            props))]
-         [(Intersection: ts _ _) (for ([t (in-list ts)])
-                                   (extract! t obj))]
-         [_ (void)]))
-     props]))

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -22,7 +22,7 @@
          (for-syntax racket/base syntax/parse))
 
 (provide (all-defined-out)
-         (except-out (all-from-out "base-abbrev.rkt" "match-expanders.rkt") make-arr))
+         (all-from-out "base-abbrev.rkt" "match-expanders.rkt"))
 
 ;; Convenient constructors
 (define -App make-App)
@@ -149,28 +149,43 @@
 ;; Function type constructors
 (define/decl top-func (make-Function (list)))
 
-(define (asym-pred dom rng prop)
-  (make-Function (list (make-arr* (list dom) rng #:props prop))))
 
-(define/cond-contract make-pred-ty
-  (c:case-> (c:-> Type? Type?)
-            (c:-> (c:listof Type?) Type? Type? Type?)
-            (c:-> (c:listof Type?) Type? Type? Object? Type?))
-  (case-lambda
-    [(in out t o)
-     (->* in out : (-PS (-is-type o t) (-not-type o t)))]
-    [(in out t)
-     (make-pred-ty in out t (make-Path null (cons 0 0)))]
-    [(t)
-     (make-pred-ty (list Univ) -Boolean t (make-Path null (cons 0 0)))]))
+#;(define (asym-pred dom rng prop)
+    (make-Function (list (make-arr* (list dom) rng #:props prop))))
+
+#;(define/cond-contract make-pred-ty
+    (c:case-> (c:-> Type? Type?)
+              (c:-> (c:listof Type?) Type? Type? Type?)
+              (c:-> (c:listof Type?) Type? Type? Object? Type?))
+    (case-lambda
+      [(in out t o)
+       (->* in out : (-PS (-is-type o t) (-not-type o t)))]
+      [(in out t)
+       (make-pred-ty in out t (make-Path null (cons 0 0)))]
+      [(t)
+       (make-pred-ty (list Univ) -Boolean t (make-Path null (cons 0 0)))]))
+
+(define-syntax (pred-> stx)
+  (syntax-parse stx
+    [(_ t:expr)
+     (syntax/loc stx
+       (dep-> ([x : Univ]) -Boolean : (-PS (-is-type x t) (-not-type x t))))]
+    [(_ in:expr out:expr t:expr)
+     (syntax/loc stx
+       (dep-> ([x : in]) out : (-PS (-is-type x t) (-not-type x t))))]
+    [(_ ([x:id (~datum :) in:expr]) out:expr t:expr o:expr)
+     (syntax/loc stx
+       (dep-> ([x : in]) out : (-PS (-is-type o t) (-not-type o t))))]))
 
 (define/decl -true-propset (-PS -tt -ff))
 (define/decl -false-propset (-PS -ff -tt))
 
 (define (opt-fn args opt-args result #:rest [rest #f] #:kws [kws null])
   (apply cl->* (for/list ([i (in-range (add1 (length opt-args)))])
-                 (make-Function (list (make-arr* (append args (take opt-args i)) result
-                                                 #:rest rest #:kws kws))))))
+                 (make-Function (list (-Arr (append args (take opt-args i))
+                                            result
+                                            #:rest rest
+                                            #:kws kws))))))
 
 (define-syntax-rule (->opt args ... [opt ...] res)
   (opt-fn (list args ...) (list opt ...) res))

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -149,22 +149,6 @@
 ;; Function type constructors
 (define/decl top-func (make-Function (list)))
 
-
-#;(define (asym-pred dom rng prop)
-    (make-Function (list (make-arr* (list dom) rng #:props prop))))
-
-#;(define/cond-contract make-pred-ty
-    (c:case-> (c:-> Type? Type?)
-              (c:-> (c:listof Type?) Type? Type? Type?)
-              (c:-> (c:listof Type?) Type? Type? Object? Type?))
-    (case-lambda
-      [(in out t o)
-       (->* in out : (-PS (-is-type o t) (-not-type o t)))]
-      [(in out t)
-       (make-pred-ty in out t (make-Path null (cons 0 0)))]
-      [(t)
-       (make-pred-ty (list Univ) -Boolean t (make-Path null (cons 0 0)))]))
-
 (define-syntax (pred-> stx)
   (syntax-parse stx
     [(_ t:expr)

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -98,87 +98,157 @@
 (define/decl ManyUniv (make-AnyValues -tt))
 
 ;; Function types
-(define/cond-contract (make-arr* dom rng
-                                 #:rest [rest #f] #:drest [drest #f] #:kws [kws null]
-                                 #:props [props -tt-propset] #:object [obj -empty-obj])
+(define/cond-contract (-Arr dom rng
+                            #:rest [rst #f] #:drest [drst #f]
+                            #:kws [kws null]
+                            #:props [props #f] #:object [obj #f])
   (c:->* ((c:listof Type?) (c:or/c SomeValues? Type?))
          (#:rest (c:or/c #f Type?)
-          #:drest (c:or/c #f (c:cons/c Type? symbol?))
+          #:drest (c:or/c #f Type? RestDots?)
           #:kws (c:listof Keyword?)
           #:props PropSet?
           #:object OptObject?)
          arr?)
-  (make-arr dom (if (Type? rng)
-                    (make-Values (list (-result rng props obj)))
-                    rng)
-            rest drest (sort #:key Keyword-kw kws keyword<?)))
+  (let ([rng (if (Type? rng)
+                 (make-Values (list (-result rng props obj)))
+                 rng)])
+    (cond
+      ;; simple arrows (Arrow)
+      [(not (or rst drst (pair? kws) props obj))
+       (make-Arrow dom rng)]
+      ;; complex arrows (ArrowStar)
+      [(and (or rst drst (pair? kws))
+            (not (or props obj)))
+       (when (and rst drst)
+         (error -Arr "rst and drst provided: ~a ~a" rst drst))
+       (let ([rst (or rst drst)])
+         (make-ArrowStar dom rst kws rng))]
+      ;; dependent arrows (ArrowDep)
+      [(or props obj)
+       (when (and rst drst)
+         (error -Arr "rst and drst provided: ~a ~a" rst drst))
+       (unless (null? kws)
+         (error -Arr "dependent arrow cannot have kws, given ~a" kws))
+       (let ([rst (or rst drst)])
+         (make-ArrowDep dom rst rng))]
+      [else
+       (error -Arr
+              "unsupported args ~a ~a ~a ~a ~a ~a ~a"
+              (format "dom ~a" rst)
+              (format "rng ~a" rst)
+              (format "#:rest ~a" rst)
+              (format "#:drest ~a" drst)
+              (format "#:kws ~a" kws)
+              (format "#:props ~a" props)
+              (format "#:object ~a" obj))])))
+
+(begin-for-syntax
+  (define-syntax-class c
+    (pattern x:id #:fail-unless (eq? ': (syntax-e #'x)) #f)))
 
 (define-syntax (->* stx)
-  (define-syntax-class c
-    (pattern x:id #:fail-unless (eq? ': (syntax-e #'x)) #f))
   (syntax-parse stx
     [(_ dom rng)
      (syntax/loc stx
-       (make-Function (list (make-arr* dom rng))))]
+       (make-Function (list (-Arr dom rng))))]
     [(_ dom rst rng)
      (syntax/loc stx
-       (make-Function (list (make-arr* dom rng #:rest rst))))]
-    [(_ dom rng :c props)
-     (syntax/loc stx
-       (make-Function (list (make-arr* dom rng #:props props))))]
+       (make-Function (list (make-arr* dom rng #:rest rst))))]))
+
+(define-syntax (dep-> stx)
+  (syntax-parse stx
+    [(_ dom rng _:c props)
+     (syntax/loc stx (dep-> dom #f rng : props : -empty-obj))]
     [(_ dom rng _:c props _:c object)
-     (syntax/loc stx
-       (make-Function (list (make-arr* dom rng #:props props #:object object))))]
+     (syntax/loc stx (dep-> dom #f rng : props : object))]
     [(_ dom rst rng _:c props)
-     (syntax/loc stx
-       (make-Function (list (make-arr* dom rng #:rest rst #:props props))))]
-    [(_ dom rst rng _:c props : object)
-     (syntax/loc stx
-       (make-Function (list (make-arr* dom rng #:rest rst #:props props #:object object))))]))
+     (syntax/loc stx (dep-> dom rst rng : props : object))]
+    [(_ ([x0:id _:c t0:expr] [x-rst:id _:c t-rst:expr] ...)
+        rst
+        rng
+        _:c props
+        _:c object)
+     (define xs (syntax->list #'(x0 x-rst ...)))
+     (with-syntax
+         ([(dom-id ...) (generate-temporaries #'(x0 x-rst ...))])
+       (with-syntax
+           ([(domain-bindings ...)
+             (apply
+              append
+              (for/list ([x (in-list xs)]
+                         [dom (in-list (syntax->list #'(dom-id ...)))]
+                         [dom-ty (in-list (syntax->list #'(t0 t-rst ...)))]
+                         [n (in-naturals)])
+                ;; each domain arg is in scope for
+                ;; domain types that proceed it
+                (with-syntax ([(n-xs ...) (take xs n)])
+                  (list #`[#,dom (abstract-many/obj #,dom-ty (list n-xs ...))]
+                        #`[#,x (quote-syntax #,x)]))))])
+         (syntax/loc stx
+           (let* (domain-bindings ...
+                  [names (list (quote-syntax x0) (quote-syntax x-rst) ...)]
+                  [domain (list dom-id ...)])
+             (make-Function
+              (list
+               (-Arr domain
+                     (abstract-many/obj rng names)
+                     #:rest (and rst (abstract-many/obj rst names))
+                     #:props (abstract-many/obj props names)
+                     #:object (abstract-many/obj object names))))))))]))
+
 
 (define-syntax (-> stx)
-  (define-syntax-class c
-    (pattern x:id #:fail-unless (eq? ': (syntax-e #'x)) #f))
   (syntax-parse stx
-    [(_ dom ... rng _:c props _:c objects)
-     (syntax/loc stx
-       (->* (list dom ...) rng : props : objects))]
-    [(_ dom ... rng :c props)
-     (syntax/loc stx
-       (->* (list dom ...) rng : props))]
+    [(_ dom rng _:c props _:c objects)
+     (syntax/loc stx (dep-> dom rng : props : objects))]
+    [(_ dom rng :c props)
+     (syntax/loc stx (dep-> dom  rng : props))]
     [(_ dom ... rng)
-     (syntax/loc stx
-       (->* (list dom ...) rng))]))
+     (syntax/loc stx (->* (list dom ...) rng))]))
 
 (define-syntax (->... stx)
   (syntax-parse stx
     [(_ dom rng) (syntax/loc stx (->* dom rng))]
     [(_ dom (dty dbound) rng)
      (syntax/loc stx
-       (make-Function (list (make-arr* dom rng #:drest (cons dty 'dbound)))))]
-    [(_ dom rng (~datum :) props)
+       (make-Function
+        (list (-Arr dom rng #:drest (make-RestDots dty 'dbound)))))]
+    [(_ dom rng _:c props)
+     (syntax/loc stx (dep-> dom rng : props))]
+    [(_ dom (dty dbound) rng _:c props)
      (syntax/loc stx
-       (->* dom rng (~datum :) props))]
-    [(_ dom (dty dbound) rng (~datum :) props)
+       (dep-> dom (make-RestDots dty 'dbound) rng : props))]
+    [(_ dom (dty dbound) rng _:c props _:c obj)
      (syntax/loc stx
-       (make-Function (list (make-arr* dom rng #:drest (cons dty 'dbound) #:props props))))]))
+       (dep-> dom (make-RestDots dty 'dbound) rng : props : obj))]))
 
 (define (simple-> doms rng)
-  (->* doms rng))
+  (-Arr doms rng))
 
-(define (->acc dom rng path #:var [var (cons 0 0)])
-  (define obj (-acc-path path (-id-path var)))
-  (make-Function
-   (list (make-arr* dom rng
-                    #:props (-PS (-not-type obj (-val #f))
-                                 (-is-type obj (-val #f)))
-                    #:object obj))))
+;; specify a function which is an accessor into one
+;; of its arguments (but use a macro so use sites
+;; don't have to worry about our binder representation)
+(define-syntax (->acc stx)
+  (syntax-parse stx
+    [(_ ([x:id _:c ty:expr] ...)
+        rng:expr
+        path:expr
+        #:arg arg:id)
+     (define n (length (syntax->list #'(x ...))))
+     (with-syntax ([(idx ...) (range (sub1 n) -1 -1)])
+       (syntax/loc stx
+         (let ([obj (-acc-path path
+                               (-id-path (let ([x idx] ...)
+                                           arg)))])
+           (make-Function
+            (list (-Arr (list ty ...)
+                        rng
+                        #:props (-PS (-not-type obj (-val #f))
+                                     (-is-type obj (-val #f)))
+                        #:object obj))))))]))
 
 (define (cl->* . args)
-  (define (funty-arities f)
-    (match f
-      [(Function: as) as]))
-  (make-Function (apply append (map funty-arities args))))
+  (make-Function (apply append (map Function-arrows args))))
 
 (define-syntax (cl-> stx)
   (syntax-parse stx
@@ -194,13 +264,16 @@
         (list
          (make-arr* (list ty ...)
                     rng
-                    #:kws (sort #:key (match-lambda [(Keyword: kw _ _) kw])
+                    #:kws (sort #:key Keyword-kw
                                 (list (make-Keyword 'k kty opt) ...)
                                 keyword<?)))))]))
 
 (define-syntax (->optkey stx)
   (syntax-parse stx
-    [(_ ty:expr ... [oty:expr ...] #:rest rst:expr (~seq k:keyword kty:expr opt:boolean) ... rng)
+    [(_ ty:expr ... [oty:expr ...]
+        #:rest rst:expr
+        (~seq k:keyword kty:expr opt:boolean) ...
+        rng)
      (let ([l (syntax->list #'(oty ...))])
        (with-syntax ([((extra ...) ...)
                       (for/list ([i (in-range (add1 (length l)))])
@@ -209,14 +282,17 @@
          (syntax/loc stx
            (make-Function
             (list
-             (make-arr* (list ty ... extra ...)
-                        rng
-                        #:rest rsts
-                        #:kws (sort #:key (match-lambda [(Keyword: kw _ _) kw])
-                                    (list (make-Keyword 'k kty opt) ...)
-                                    keyword<?))
+             (-Arr (list ty ... extra ...)
+                   rng
+                   #:rest rsts
+                   #:kws (sort #:key Keyword-kw
+                               (list (make-Keyword 'k kty opt) ...)
+                               keyword<?))
              ...)))))]
-    [(_ ty:expr ... [oty:expr ...] (~seq k:keyword kty:expr opt:boolean) ... rng)
+    [(_ ty:expr ...
+        [oty:expr ...]
+        (~seq k:keyword kty:expr opt:boolean) ...
+        rng)
      (let ([l (syntax->list #'(oty ...))])
        (with-syntax ([((extra ...) ...)
                       (for/list ([i (in-range (add1 (length l)))])
@@ -224,16 +300,16 @@
          (syntax/loc stx
            (make-Function
             (list
-             (make-arr* (list ty ... extra ...)
-                        rng
-                        #:rest #f
-                        #:kws (sort #:key (match-lambda [(Keyword: kw _ _) kw])
-                                    (list (make-Keyword 'k kty opt) ...)
-                                    keyword<?))
+             (-Arr (list ty ... extra ...)
+                   rng
+                   #:rest #f
+                   #:kws (sort #:key Keyword-kw
+                               (list (make-Keyword 'k kty opt) ...)
+                               keyword<?))
              ...)))))]))
 
 (define (make-arr-dots dom rng dty dbound)
-  (make-arr* dom rng #:drest (cons dty dbound)))
+  (-Arr dom rng #:drest (make-RestDots dty dbound)))
 
 ;; Convenient syntax for polymorphic types
 (define-syntax -poly

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -11,6 +11,7 @@
          "../rep/object-rep.rkt"
          "../rep/base-types.rkt"
          "../rep/numeric-base-types.rkt"
+         (utils tc-utils)
          (rep values-rep rep-utils)
          (env mvar-env)
          racket/match racket/list (prefix-in c: (contract-req))
@@ -113,32 +114,32 @@
     (cond
       ;; simple arrows (Arrow)
       [(not (or rst drst (pair? kws) props obj))
-       (make-Arrow dom rng)]
+       (make-ArrowSimp dom rng)]
       ;; complex arrows (ArrowStar)
       [(and (or rst drst (pair? kws))
             (not (or props obj)))
        (when (and rst drst)
-         (error -Arr "rst and drst provided: ~a ~a" rst drst))
+         (int-err "-Arr: rst and drst provided: ~a ~a" rst drst))
        (let ([rst (or rst drst)])
          (make-ArrowStar dom rst kws rng))]
       ;; dependent arrows (ArrowDep)
       [(or props obj)
        (when drst
-         (error -Arr "drst provided for dep arrow: ~a" drst))
+         (int-err "-Arr: drst provided for dependent arrow: ~a" drst))
        (unless (null? kws)
-         (error -Arr "dependent arrow cannot have kws, given ~a" kws))
+         (int-err "-Arr: dependent arrow cannot have kws, given ~a" kws))
        (let ([rst (or rst drst)])
          (make-ArrowDep dom rst rng))]
       [else
-       (error -Arr
-              "unsupported args ~a ~a ~a ~a ~a ~a ~a"
-              (format "dom ~a" rst)
-              (format "rng ~a" rst)
-              (format "#:rest ~a" rst)
-              (format "#:drest ~a" drst)
-              (format "#:kws ~a" kws)
-              (format "#:props ~a" props)
-              (format "#:object ~a" obj))])))
+       (int-err
+        "unsupported -Arr args: ~a ~a ~a ~a ~a ~a ~a"
+        (format "dom ~a" rst)
+        (format "rng ~a" rst)
+        (format "#:rest ~a" rst)
+        (format "#:drest ~a" drst)
+        (format "#:kws ~a" kws)
+        (format "#:props ~a" props)
+        (format "#:object ~a" obj))])))
 
 (begin-for-syntax
   (define-syntax-class c

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -80,8 +80,6 @@
 (define/decl -tt-propset (make-PropSet -tt -tt))
 (define/decl -ff-propset (make-PropSet -ff -ff))
 
-(define (-arg-path arg [depth 0])
-  (make-Path null (cons depth arg)))
 (define (-acc-path path-elems o)
   (match o
     [(Empty:) -empty-obj]
@@ -125,8 +123,8 @@
          (make-ArrowStar dom rst kws rng))]
       ;; dependent arrows (ArrowDep)
       [(or props obj)
-       (when (and rst drst)
-         (error -Arr "rst and drst provided: ~a ~a" rst drst))
+       (when drst
+         (error -Arr "drst provided for dep arrow: ~a" drst))
        (unless (null? kws)
          (error -Arr "dependent arrow cannot have kws, given ~a" kws))
        (let ([rst (or rst drst)])
@@ -212,15 +210,7 @@
     [(_ dom (dty dbound) rng)
      (syntax/loc stx
        (make-Function
-        (list (-Arr dom rng #:drest (make-RestDots dty 'dbound)))))]
-    [(_ dom rng _:c props)
-     (syntax/loc stx (dep-> dom rng : props))]
-    [(_ dom (dty dbound) rng _:c props)
-     (syntax/loc stx
-       (dep-> dom (make-RestDots dty 'dbound) rng : props))]
-    [(_ dom (dty dbound) rng _:c props _:c obj)
-     (syntax/loc stx
-       (dep-> dom (make-RestDots dty 'dbound) rng : props : obj))]))
+        (list (-Arr dom rng #:drest (make-RestDots dty 'dbound)))))]))
 
 (define (simple-> doms rng)
   (-Arr doms rng))

--- a/typed-racket-lib/typed-racket/types/match-expanders.rkt
+++ b/typed-racket-lib/typed-racket/types/match-expanders.rkt
@@ -75,7 +75,7 @@
       [(Mu-unsafe:
         (Union: (== -Null)
                 (list (pair-matcher elem-t (B: 0)))))
-       (define elem-t* (instantiate-raw-type t elem-t))
+       (define elem-t* (instantiate/type elem-t t))
        (cond
          [simple? (and (equal? elem-t elem-t*) elem-t)]
          [else elem-t*])]


### PR DESCRIPTION
This WIP PR more or less has the following goals:

1. have cleaner representation of arrow types inside of TR, use interface functions for arrow types when it's more clear than manually tearing apart structs with a `match`, etc...
2. be more explicit about when function types are dependent
3. Within TR's implementation, use macros w/ clear names for bound variables instead of raw De Bruijn indices
4. add user-level syntax which uses clear variable names for bound variables and deprecate/discourage using the old raw De Bruijn index syntax in actual TR code
5. add dependent domains to our dependent functions

...well to be perfectly honest, the real goal is item 5, but our arrow representation and binder code is pretty complex right now, so I'm trying to make things easier to reason about so I can add dependent domains w/o just making everything slower and even more complex.

If anyone wants to comment regarding how we're doing things in this PR, it would be wonderful to get said comments earlier as opposed to later, since this PR will likely affect a lot of files and I'm not exactly swimming in free time this summer =)