### PR TITLE
require-typed: more informative error when struct field is missing :

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -449,8 +449,8 @@
   (define ((rts legacy) stx)
     (syntax-parse stx #:literals (:)
       [(_ name:opt-parent
-          (~optional (~seq (tvar:id ...)) #:defaults ([(tvar 1) '()]))
-          ([fld : ty] ...)
+          (~seq (tvar:id ...))
+          (~describe "struct fields" ([fld : ty] ...))
           (~var input-maker (constructor-term legacy #'name.nm))
           (~optional (~seq #:type-name type:id) #:defaults ([type #'name.nm]))
           unsafe:unsafe-clause

--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -111,6 +111,10 @@
   (pattern nm:id #:with parent #'#f)
   (pattern (nm:id parent:id)))
 
+(define-syntax-class typed-field
+  #:attributes (field type)
+  #:literals (:)
+  (pattern [field:id : type]))
 
 (define-values (require/typed-legacy require/typed -unsafe-require/typed)
  (let ()
@@ -142,7 +146,7 @@
     #:attributes (nm type (body 1) (constructor-parts 1) (tvar 1))
     (pattern [(~or (~datum struct) #:struct)
               (~optional (~seq (tvar ...)) #:defaults ([(tvar 1) '()]))
-              nm:opt-parent (body ...)
+              nm:opt-parent (body:typed-field ...)
               (~var opts (struct-opts legacy #'nm.nm))]
              #:with (constructor-parts ...) #'opts.ctor-value
              #:attr type #'opts.type))
@@ -150,7 +154,9 @@
   (define-syntax-class signature-clause
     #:literals (:)
     #:attributes (sig-name [var 1] [type 1])
-    (pattern [#:signature sig-name:id ([var:id : type] ...)]))
+    (pattern [#:signature sig-name:id (body:typed-field ...)]
+      #:with (var ...) #'(body.field ...)
+      #:with (type ...) #'(body.type ...)))
 
   (define-syntax-class opaque-clause
     ;#:literals (opaque)
@@ -165,8 +171,7 @@
    (pattern oc:opaque-clause #:attr spec
      #`(require/opaque-type oc.ty oc.pred #,lib #,@(if unsafe? #'(unsafe-kw) #'()) . oc.opt))
    (pattern (~var strc (struct-clause legacy)) #:attr spec
-     #`(require-typed-struct strc.nm #,@(let ([tvars #'(strc.tvar ...)])
-                                          (if (null? (syntax-e tvars)) '() (list tvars)))
+     #`(require-typed-struct strc.nm (strc.tvar ...)
                              (strc.body ...) strc.constructor-parts ...
                              #:type-name strc.type
                              #,@(if unsafe? #'(unsafe-kw) #'())
@@ -451,7 +456,7 @@
     (syntax-parse stx #:literals (:)
       [(_ name:opt-parent
           (~optional (~seq (tvar:id ...)) #:defaults ([(tvar 1) '()]))
-          (~describe "struct fields" ([fld : ty] ...))
+          (body:typed-field ...)
           (~var input-maker (constructor-term legacy #'name.nm))
           (~optional (~seq #:type-name type:id) #:defaults ([type #'name.nm]))
           unsafe:unsafe-clause
@@ -461,6 +466,8 @@
                       [hidden (generate-temporary #'name.nm)]
                       [orig-struct-info (generate-temporary #'nm)]
                       [spec (if (syntax-e #'name.parent) #'(nm parent) #'nm)]
+                      [(fld ...) #'(body.field ...)]
+                      [(ty ...) #'(body.type ...)]
                       [num-fields (syntax-length #'(fld ...))]
                       [(type-des _ pred sel ...)
                        (build-struct-names #'nm (syntax->list #'(fld ...)) #f #t)]
@@ -541,7 +548,7 @@
                                   (make-struct-info-self-ctor #'internal-maker si)
                                   si))
 
-                         (dtsi* (tvar ...) spec type ([fld : ty] ...) #:maker maker-name #:type-only)
+                         (dtsi* (tvar ...) spec type (body ...) #:maker maker-name #:type-only)
                          #,(ignore #'(require/contract pred hidden (or/c struct-predicate-procedure?/c (c-> any-wrap/c boolean?)) lib))
                          #,(internal #'(require/typed-internal hidden (Any -> Boolean : type)))
                          (require/typed #:internal (maker-name real-maker) type lib

--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -165,7 +165,8 @@
    (pattern oc:opaque-clause #:attr spec
      #`(require/opaque-type oc.ty oc.pred #,lib #,@(if unsafe? #'(unsafe-kw) #'()) . oc.opt))
    (pattern (~var strc (struct-clause legacy)) #:attr spec
-     #`(require-typed-struct strc.nm (strc.tvar ...)
+     #`(require-typed-struct strc.nm #,@(let ([tvars #'(strc.tvar ...)])
+                                          (if (null? (syntax-e tvars)) '() (list tvars)))
                              (strc.body ...) strc.constructor-parts ...
                              #:type-name strc.type
                              #,@(if unsafe? #'(unsafe-kw) #'())
@@ -449,7 +450,7 @@
   (define ((rts legacy) stx)
     (syntax-parse stx #:literals (:)
       [(_ name:opt-parent
-          (~seq (tvar:id ...))
+          (~optional (~seq (tvar:id ...)) #:defaults ([(tvar 1) '()]))
           (~describe "struct fields" ([fld : ty] ...))
           (~var input-maker (constructor-term legacy #'name.nm))
           (~optional (~seq #:type-name type:id) #:defaults ([type #'name.nm]))

--- a/typed-racket-test/fail/require-typed-struct-missing-colon.rkt
+++ b/typed-racket-test/fail/require-typed-struct-missing-colon.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred ".*struct fields.*")
+(exn-pred ".*while parsing typed-field.*")
 #lang racket/base
 
 (module server racket

--- a/typed-racket-test/fail/require-typed-struct-missing-colon.rkt
+++ b/typed-racket-test/fail/require-typed-struct-missing-colon.rkt
@@ -1,0 +1,13 @@
+#;
+(exn-pred ".*struct fields.*")
+#lang racket/base
+
+(module server racket
+  (provide (struct-out posn))
+  (struct posn [x y]))
+
+(module client typed/racket
+  (require/typed (submod ".." server)
+    (#:struct posn ((x Integer) (y Integer)))))
+
+(require 'client)


### PR DESCRIPTION
Today I made a mistake writing a `require/typed`, I was missing a colon in the struct fields. Something like:

```
(require/typed "file.rkt"
  (#:struct posn ([x Integer] [y Integer])))
```

The error message was confusing:
```
<pkgs>/typed-racket-lib/typed-racket/base-env/prims-contract.rkt:168.7: require-typed-struct: expected constructor-term
  at: (((x Integer) (y Integer)) #:type-name posn (submod ".." server))
  within: (require-typed-struct posn () ((x Integer) (y Integer)) #:type-name posn (submod ".." server))
  in: (require-typed-struct posn () ((x Integer) (y Integer)) #:type-name posn (submod ".." server))
  ....
```

After this commit, the error message is better:
```
<pkgs>/typed-racket-lib/typed-racket/base-env/prims-contract.rkt:168.7: require-typed-struct: expected the identifier `:'
  at: Integer
  in: (require-typed-struct posn () ((x Integer) (y Integer)) #:type-name posn (submod ".." server))
  parsing context: 
   while parsing struct field
    term: ((x Integer) (y Integer))
    location: <pkgs>/typed-racket-lib/typed-racket/base-env/prims-contract.rkt:169.29
  ....
```

- - -

Though, I'm not sure this is the right fix.

The problem is that [`require-typed-struct`](https://github.com/racket/typed-racket/blob/master/typed-racket-lib/typed-racket/base-env/prims-contract.rkt#L449) is getting called on a syntax object with an empty list of type variables and malformed struct fields, like in the 2nd error message above:

```
(require-typed-struct posn () ((x Integer) (y Integer)) #:type-name posn (submod ".." server))
```

So, one other way to fix would be to check [here](https://github.com/racket/typed-racket/blob/master/typed-racket-lib/typed-racket/base-env/prims-contract.rkt#L168) if the list of type variables is empty, and if so then omit the `()`

Maybe there's a 3rd way via `syntax-parse`? I don't know.