### PR TITLE
Remove opaque monad type from typed/rackunit

### DIFF
--- a/typed-racket-more/info.rkt
+++ b/typed-racket-more/info.rkt
@@ -22,4 +22,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.7")
+(define version "1.8")

--- a/typed-racket-more/typed/rackunit/main.rkt
+++ b/typed-racket-more/typed/rackunit/main.rkt
@@ -138,10 +138,7 @@
 (require/opaque-type TestCase test-case? rackunit)
 (provide TestCase test-case?)
 
-(require/typed
- rackunit/private/monad
- [#:opaque monad monad?])
-(define-type Seed (U #f monad (Object)))
+(define-type Seed (U #f (Object)))
 
 (define-type test-suite-handler-down
   (rackunit-test-suite (Option String) (Thunk Any) (Thunk Any) Seed -> Seed))


### PR DESCRIPTION
The "monad" struct in RackUnit's internals is never exposed to users and there's no requirement to use it with `fold-test-results`. The "seed" parameter in `fold-test-results` can be any value and is more accurately described by a parametric type. I'm not quite sure what the correct change to make it parametric is, but this change is necessary to remove the dependency on `rackunit/private/monad`. The monad implementation of `rackunit/text-ui` will hopefully go away soon.