### PR TITLE
Remove typed/rackunit references to check-around

### DIFF
--- a/typed-racket-more/info.rkt
+++ b/typed-racket-more/info.rkt
@@ -22,4 +22,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.8")
+(define version "1.9")

--- a/typed-racket-more/typed/rackunit/main.rkt
+++ b/typed-racket-more/typed/rackunit/main.rkt
@@ -66,8 +66,6 @@
 
 (require/typed rackunit/log
   [test-log! (Any -> Any)])
-(require/typed rackunit/private/check
-  [check-around (All (A) ((-> A) -> A))])
 
 ; 3.2.1
 (require-typed-struct check-info
@@ -107,9 +105,7 @@
                            (λ ([e : exn:fail])
                              (test-log! #f)
                              (raise e))])
-          (parameterize
-              ([current-check-handler raise]
-               [current-check-around  check-around])
+          (parameterize ([current-check-handler raise])
             (void)
             expr ...)))))]
     [_

--- a/typed-racket-more/typed/rackunit/type-env-ext.rkt
+++ b/typed-racket-more/typed/rackunit/type-env-ext.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 (require typed-racket/utils/utils
-         (prefix-in ru: (combine-in rackunit rackunit/private/test-case rackunit/private/check))
+         (prefix-in ru: rackunit)
          (for-syntax
           racket/base syntax/parse
           (utils tc-utils)
@@ -11,8 +11,6 @@
 
 (define-for-syntax unit-env
   (make-env
-   [ru:check-around
-    (-poly (a) (-> (-> a) a))]
    [ru:current-test-case-around
     (-poly (a) (-> (-> a) a))]))
 


### PR DESCRIPTION
This is an internal implementation detail of rackunit. The `current-check-around` parameter is set to `check-around` by default, so there's no need to explicitly set it in test-begin.