### PR TITLE
attempt to fix float-complex magnitude optimization.

### DIFF
--- a/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
@@ -570,11 +570,18 @@
            #`(let*-values (c.bindings ...)
                ;; reuses the algorithm used by the Racket runtime
                (let*-values ([(r) (unsafe-flabs c.real-binding)]
-                             [(i) (unsafe-flabs c.imag-binding)]
-                             [(q) (unsafe-fl/ r i)])
-                 (unsafe-fl* i
-                             (unsafe-flsqrt (unsafe-fl+ 1.0
-                                                        (unsafe-fl* q q))))))])))
+                             [(i) (unsafe-flabs c.imag-binding)])
+                 (if (zero? i)
+                     r
+                     (if (unsafe-fl< i r)
+                         (let-values ([(q) (unsafe-fl/ i r)])
+                           (unsafe-fl* r
+                                       (unsafe-flsqrt (unsafe-fl+ 1.0
+                                                                  (unsafe-fl* q q)))))
+                         (let-values ([(q) (unsafe-fl/ r i)])
+                           (unsafe-fl* i
+                                       (unsafe-flsqrt (unsafe-fl+ 1.0
+                                                                  (unsafe-fl* q q)))))))))])))
 
 
   (pattern (#%plain-app op:float-complex-op e:expr ...)


### PR DESCRIPTION
The current optimization missed two things that the runtime implementation does.

1. It does not check if the imag-part is zero, causing this program to behave differently in TR vs Racket:

```
#lang racket
(module untyped racket
  (printf "untyped: ~a\n"
          (magnitude 0.0+0.0i)))


(module typed typed/racket
  (printf "typed: ~a\n"
          (magnitude 0.0+0.0i)))
```

produces :
```
untyped: 0.0
typed: +nan.0
```


2. It does not switch the order of `l` and `r` based on which one is bigger. this program to behave differently in TR vs Racket:

```
#lang racket

(module untyped racket
  (printf "untyped: ~a\n"
          (magnitude 1.6496437860480294e+295+1.7259537815112588e-137i)))


(module typed typed/racket
  (printf "typed: ~a\n"
          (magnitude 1.6496437860480294e+295+1.7259537815112588e-137i)))

(require 'untyped)
(require 'typed)
```

produces:

```
untyped: 1.6496437860480294e+295
typed: +inf.0
```



This PR fixes these programs. However I'm not sure how to add them as tests cases....