### PR TITLE
Fix typed/rackunit contract exception when using `run-tests`

### DIFF
--- a/typed-racket-more/typed/rackunit/main.rkt
+++ b/typed-racket-more/typed/rackunit/main.rkt
@@ -134,7 +134,7 @@
 (require/opaque-type TestCase test-case? rackunit)
 (provide TestCase test-case?)
 
-(define-type Seed (U #f (Object)))
+(define-type Seed Any)
 
 (define-type test-suite-handler-down
   (rackunit-test-suite (Option String) (Thunk Any) (Thunk Any) Seed -> Seed))

--- a/typed-racket-test/succeed/rackunit-suite.rkt
+++ b/typed-racket-test/succeed/rackunit-suite.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket
+
+(require typed/rackunit
+         typed/rackunit/text-ui)
+
+(define passing-suite
+  (test-suite "Example Typed Rackunit test suite"
+    (check-equal? 1 1)))
+
+(check-equal? (run-tests passing-suite 'quiet) 0)


### PR DESCRIPTION
This adds a test and fixes a bug that [broke the `semver` package](https://plt.eecs.northwestern.edu/pkg-build/server/built/test-fail/semver.txt) in the latest build. The "seed" type used in TR's wrapper around rackunit could be any value, but #564 incorrectly restricted it to only objects and `#f`. It previously worked because rackunit wrapped all seed values in a special "monad" wrapper, which no longer exists. The seed values aren't used by test suites anyway, only functions that call `fold-test-results` or `foldts-test-suite`.