### PR TITLE
gitignore: vim swapfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ compiled/
 .DS_Store
 *.bak
 TAGS
+*.swn
+*.swo
+*.swp


### PR DESCRIPTION
Can we ignore vim swapfiles?
This has been bugging me for a while now.