### PR TITLE
static-contracts: less or/sc optimization

### DIFF
--- a/typed-racket-test/succeed/issue-598.rkt
+++ b/typed-racket-test/succeed/issue-598.rkt
@@ -1,0 +1,22 @@
+#lang typed/racket/base
+
+(module u racket/base
+  (define (f b)
+    (set-box! b "hello"))
+  (provide f))
+
+(define-type Maybe-Box (U #f (Boxof Integer)))
+
+(require/typed 'u (f (-> Maybe-Box Void)))
+
+(define b : Maybe-Box (box 4))
+
+(module+ test
+  (require typed/rackunit)
+
+  (check-exn exn:fail:contract?
+    (λ () (f b)))
+
+  (check-equal?
+    (if (box? b) (+ 1 (unbox b)) (error 'deadcode))
+    5))


### PR DESCRIPTION
Closes #598 . 

Update: generalized the optimizer's notion of a `side` so that `or/sc` can say "I'm on the positive side, but don't optimize my immediate children, but do optimize my children's children (if any)"