### PR TITLE
tc-app: add missing 'function' annotations

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-apply.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-apply.rkt
@@ -5,7 +5,7 @@
          "utils.rkt"
          syntax/parse racket/match
          (typecheck signatures)
-         (types abbrev utils)
+         (types abbrev type-table utils)
          (rep type-rep)
 
          (for-label
@@ -26,7 +26,9 @@
     (match (single-value #'e)
       [(tc-result1: (ListDots: dty dbound))
        (ret null null null dty dbound)]
-      [(tc-result1: (List: ts)) (ret ts)]
+      [(tc-result1: (List: ts))
+       (add-typeof-expr #'f (ret (->* ts (-values ts))))
+       (ret ts)]
       [_ (tc/apply #'f #'(e))]))
   (pattern ((~or apply k:apply) f . args)
     (tc/apply #'f #'args)))

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-list.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-list.rkt
@@ -6,7 +6,7 @@
          "utils.rkt"
          syntax/parse syntax/stx racket/match racket/sequence
          (typecheck signatures tc-funapp error-message)
-         (types abbrev utils substitute)
+         (types abbrev type-table utils substitute)
          (rep type-rep)
          (env tvar-env)
          (prefix-in i: (infer infer))
@@ -79,58 +79,79 @@
         [_ (tc/app-regular #'form expected)])))
   ;; special case for `list'
   (pattern
-   (list . args)
+   ((~and op-name list) . args)
    (let ([args-list (syntax->list #'args)])
-   (match expected
-     [(tc-result1: t)
-      (match t
-        [(List: ts)
-         (cond
-           [(= (length ts) (length args-list))
-            (for ([arg (in-list args-list)]
-                  [t (in-list ts)])
-              (tc-expr/check arg (ret t)))
-            (ret t)]
-           [else
-            (expected-but-got t (-Tuple (map tc-expr/t args-list)))
-            (ret t)])]
-        [_
-         (define vs (map (λ (_) (gensym)) args-list))
-         (define l-type (-Tuple (map make-F vs)))
-         ;; We want to infer the largest vs that are still under the element types
-         (define substs (i:infer vs null (list l-type) (list t) (-values (list (-> l-type Univ)))
-                                 #:multiple? #t))
-         (cond
-           [substs
-            (define result
-              (for*/first ([subst (in-list substs)]
-                           [argtys (in-value (for/list ([arg (in-list args-list)]
-                                                        [v (in-list vs)])
-                                               (tc-expr/check/t? arg (ret (subst-all subst (make-F v))))))]
-                           #:when (andmap values argtys))
-                (ret (-Tuple argtys))))
-            (or result
-                (begin (expected-but-got t (-Tuple (map tc-expr/t args-list)))
-                       (fix-results expected)))]
-           [else (ret (-Tuple (map tc-expr/t args-list)))])])]
-     [_ (ret (-Tuple (map tc-expr/t args-list)))])))
+     (match expected
+       [(tc-result1: t)
+        (match t
+          [(List: ts)
+           (cond
+             [(= (length ts) (length args-list))
+              (for ([arg (in-list args-list)]
+                    [t (in-list ts)])
+                (tc-expr/check arg (ret t)))
+              (add-typeof-expr #'op-name (ret (->* ts t)))
+              (ret t)]
+             [else
+              (expected-but-got t (-Tuple (map tc-expr/t args-list)))
+              (ret t)])]
+          [_
+           (define vs (map (λ (_) (gensym)) args-list))
+           (define l-type (-Tuple (map make-F vs)))
+           ;; We want to infer the largest vs that are still under the element types
+           (define substs (i:infer vs null (list l-type) (list t) (-values (list (-> l-type Univ)))
+                                   #:multiple? #t))
+           (cond
+             [substs
+              (define result
+                (for*/first ([subst (in-list substs)]
+                             [arg-tys (in-value (for/list ([arg (in-list args-list)]
+                                                           [v (in-list vs)])
+                                                  (tc-expr/check/t? arg (ret (subst-all subst (make-F v))))))]
+                             #:when (andmap values arg-tys))
+                  (define return-ty (-Tuple arg-tys))
+                  (add-typeof-expr #'op-name (ret (->* arg-tys return-ty)))
+                  (ret return-ty)))
+              (or result
+                  (begin (expected-but-got t (-Tuple (map tc-expr/t args-list)))
+                         (fix-results expected)))]
+             [else
+              (define arg-tys (map tc-expr/t args-list))
+              (define return-ty (-Tuple arg-tys))
+              (add-typeof-expr #'op-name (ret (->* arg-tys return-ty)))
+              (ret return-ty)])])]
+       [_
+        (define arg-tys (map tc-expr/t args-list))
+        (define return-ty (-Tuple arg-tys))
+        (add-typeof-expr #'op-name (ret (->* arg-tys return-ty)))
+        (ret return-ty)])))
   ;; special case for `list*'
-  (pattern (list* (~between args:expr 1 +inf.0) ...)
-    (match-let* ([(list tys ... last) (stx-map tc-expr/t #'(args ...))])
-      (ret (foldr -pair last tys))))
+  (pattern ((~and op-name list*) (~between args:expr 1 +inf.0) ...)
+    (match-let* ([(and arg-tys (list tys ... last)) (stx-map tc-expr/t #'(args ...))])
+      (define return-ty (foldr -pair last tys))
+      (add-typeof-expr #'op-name (ret (->* arg-tys return-ty)))
+      (ret return-ty)))
   ;; special case for `reverse' to propagate expected type info
   (pattern ((~and fun (~or reverse k:reverse)) arg)
     (match expected
-      [(tc-result1: (Listof: _))
-       (tc-expr/check #'arg expected)]
+      [(tc-result1: (and return-ty (Listof: _)))
+       (begin0
+         (tc-expr/check #'arg expected)
+         (add-typeof-expr #'fun (ret (-> return-ty return-ty))))]
       [(tc-result1: (List: ts))
-       (tc-expr/check #'arg (ret (-Tuple (reverse ts))))
-       (ret (-Tuple ts))]
+       (define arg-ty (-Tuple (reverse ts)))
+       (define return-ty (-Tuple ts))
+       (tc-expr/check #'arg (ret arg-ty))
+       (add-typeof-expr #'fun (ret (-> arg-ty return-ty)))
+       (ret return-ty)]
       [_
        (match (single-value #'arg)
-         [(tc-result1: (List: ts))
-          (ret (-Tuple (reverse ts)))]
+         [(tc-result1: (and arg-ty (List: ts)))
+          (define return-ty (-Tuple (reverse ts)))
+          (add-typeof-expr #'fun (ret (-> arg-ty return-ty)))
+          (ret return-ty)]
          [(tc-result1: (and r (Listof: t)))
+          (add-typeof-expr #'fun (ret (-> r r)))
           (ret r)]
          [arg-ty
           (tc/funapp #'fun #'(arg) (tc-expr/t #'fun) (list arg-ty) expected)])])))

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
@@ -51,10 +51,12 @@
                     (list (ret Univ) (single-value #'arg))
                     expected)]))
   ;; special-case for not - flip the props
-  (pattern ((~or false? not) arg)
+  (pattern ((~and op-name (~or false? not)) arg)
     (match (single-value #'arg)
       [(tc-result1: t (PropSet: p+ p-) _)
-       (ret -Boolean (make-PropSet p- p+))]))
+       (define new-prop (make-PropSet p- p+))
+       (add-typeof-expr #'op-name (ret (-> Univ -Boolean)))
+       (ret -Boolean new-prop)]))
   ;; special case for (current-contract-region)'s default expansion
   ;; just let it through without any typechecking, since module-name-fixup
   ;; is a private function from syntax/location, so this must have been

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-values.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-values.rkt
@@ -4,8 +4,9 @@
          "signatures.rkt"
          "utils.rkt"
          syntax/parse racket/match racket/sequence
-         (typecheck signatures tc-funapp)
-         (types base-abbrev utils)
+         (typecheck signatures tc-funapp tc-metafunctions)
+         (types base-abbrev abbrev type-table utils)
+         (rep values-rep)
 
          (for-label racket/base))
 
@@ -18,34 +19,51 @@
 (define-tc/app-syntax-class (tc/app-values expected)
   #:literal-sets (values-literals)
   ;; call-with-values
-  (pattern (call-with-values prod con)
-    (match (tc/funapp #'prod #'() (tc-expr/t #'prod) null #f)
+  (pattern ((~and op-name call-with-values) prod con)
+    #:do [(define prod-ty (tc-expr/t #'prod))]
+    (match (tc/funapp #'prod #'() prod-ty null #f)
       [(tc-results: tcrs #f)
-       (tc/funapp #'con #'(prod) (tc-expr/t #'con)
-                  (for/list ([tcr (in-list tcrs)])
-                    (-tc-results (list tcr) #f))
-                  expected)]
+       (define con-ty (tc-expr/t #'con))
+       (define r
+         (tc/funapp #'con #'(prod) con-ty
+                    (for/list ([tcr (in-list tcrs)])
+                      (-tc-results (list tcr) #f))
+                    expected))
+       (define return-ty (tc-results->values r))
+       (add-typeof-expr #'op-name (ret (-> prod-ty con-ty return-ty)))
+       r]
       [(tc-results: _ (? RestDots?))
        (tc-error/expr "`call-with-values` with ... is not supported")]
       [(tc-any-results: _)
        (tc/app-regular this-syntax expected)]))
   ;; special case for `values' with single argument
   ;; we just ignore the values, except that it forces arg to return one value
-  (pattern (values arg)
-    (match expected
-     [(or #f (tc-any-results: _)) (single-value #'arg)]
-     [(tc-result1: tp)
-      (single-value #'arg expected)]
-      ;; Type check the argument, to find other errors
-     [_ (single-value #'arg)]))
+  (pattern ((~and op-name values) arg)
+    (let ([tc-result
+           (match expected
+            [(or #f (tc-any-results: _))
+             (single-value #'arg)]
+            [(tc-result1: tp)
+             (single-value #'arg expected)]
+             ;; Type check the argument, to find other errors
+            [_ (single-value #'arg)])])
+      (define arg-ty
+        ;; match never fails; `single-value` always returns a tc-result1
+        (match tc-result [(tc-result1: t) t]))
+      (add-typeof-expr #'op-name (ret (-> arg-ty arg-ty)))
+      tc-result))
   ;; handle `values' specially
-  (pattern (values . args)
+  (pattern ((~and op-name values) . args)
     (match expected
       [(or (tc-results: tcrs #f)
            (bind tcrs '()))
-       (-tc-results
-        (for/list ([arg (in-syntax #'args)]
-                   [tcr (in-list/rest tcrs #f)])
-          (match (single-value arg (and tcr (-tc-results (list tcr) #f)))
-            [(tc-results: (list res) #f) res]))
-        #f)])))
+       (define res
+         (-tc-results
+           (for/list ([arg (in-syntax #'args)]
+                      [tcr (in-list/rest tcrs #f)])
+             (match (single-value arg (and tcr (-tc-results (list tcr) #f)))
+               [(tc-results: (list res) #f) res])) #f))
+       (define return-ty (tc-results->values res))
+       (define arg-tys (match return-ty [(Values: (list (Result: t* _ _) ...)) t*]))
+       (add-typeof-expr #'op-name (ret (->* arg-tys return-ty)))
+       res])))

--- a/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
@@ -3,7 +3,7 @@
 (require (rename-in "../utils/utils.rkt" [infer r:infer])
          racket/match racket/list
          (typecheck signatures tc-app-helper)
-         (types utils abbrev substitute)
+         (types utils abbrev substitute type-table)
          (utils tc-utils)
          (rep type-rep core-rep values-rep)
          (r:infer infer))
@@ -67,8 +67,9 @@
            ;; Takes a possible substitution and comuptes
            ;; the substituted range type if it is not #f
            (define (finish substitution)
-             (and substitution (do-ret (subst-all substitution rng))))
-
+             (begin0
+               (and substitution (do-ret (subst-all substitution rng)))
+               (add-typeof-expr f (ret (make-Fun (list arrow))))))
            (finish
             (infer vars dotted-vars
                    (list (-Tuple* arg-tys full-tail-ty))


### PR DESCRIPTION
Update the type-table with annotations for some identifiers that are handled specially by `tc-app`.

- - -

Are there any tests for this kind of thing --- for checking whether the `type-table` is updated correctly?
If not, I'll try calling `type-check` directly on some syntax objects, then checking that their components all have annotations.