### PR TITLE
tc-app: add special case for 'hash' functions

### DIFF
--- a/typed-racket-test/succeed/issue-605.rkt
+++ b/typed-racket-test/succeed/issue-605.rkt
@@ -1,0 +1,2 @@
+#lang typed/racket/base
+(hash 0 1 2 3 4 5 6 7 8 9)


### PR DESCRIPTION
For #605. Recognize `hash` `hasheq` `hasheqv` and give precise types.

This PR works for the 1 example.

TODO
- [ ] more tests
- [ ] better error message for odd number of arguments
- [ ] really want `restrict` and not `intersect` ?