### PR TITLE
static-contract: temporarily fix for incoming syntax

### DIFF
--- a/typed-racket-lib/typed-racket/static-contracts/optimize.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/optimize.rkt
@@ -109,7 +109,7 @@
     [else sc]))
 
 
-;; Reduce a static contract assuming that we trusted the current positive side
+;; Reduce a static contract assuming that we trusted the current side
 (define (trusted-side-reduce sc)
   (match sc
     [(->/sc: mand-args opt-args mand-kw-args opt-kw-args rest-arg (list (any/sc:) ...))
@@ -119,6 +119,11 @@
     [(none/sc:) any/sc]
     [(or/sc: (? flat-terminal-kind?) ...) any/sc]
     [(? flat-terminal-kind?) any/sc]
+    [(syntax/sc: (? recursive-sc?))
+     ;;bg; _temporary_ case to allow contracts from the `Syntax` type.
+     ;;    This is temporary until TR has types for immutable-vector
+     ;;    and box-immutable & changes the definition of the `Syntax` type.
+     any/sc]
     [else sc]))
 
 (define (flat-terminal-kind? sc)

--- a/typed-racket-test/unit-tests/contract-tests.rkt
+++ b/typed-racket-test/unit-tests/contract-tests.rkt
@@ -228,6 +228,8 @@
    (t-sc (-lst Univ) (listof/sc any-wrap/sc))
    (t-sc (Un (-lst Univ) -Number) (or/sc number/sc (listof/sc any-wrap/sc)))
 
+   (t-int Any-Syntax syntax? #'#'A #:typed) ;; GitHub issue #616
+
    ;; Github pull request #226
    (let ([ctc (-> Univ -Boolean)])
      ;; Ordinary functions should have a contract


### PR DESCRIPTION
Closes #616 

Add a case to the static contract optimizer so that contracts
 generated from the `Syntax` type disappear in trusted positions.

This restores the "old" behavior for the `Syntax` type --- the behavior
 before fixing the 'or/c' unsoundness in issue 598.

<https://github.com/racket/typed-racket/issues/598>

Note: this fix is temporary, until the definition of `Syntax` can
 be in terms of _immutable_ vectors & boxes.