### PR TITLE
fix #:rest and optional args

### DIFF
--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -194,15 +194,15 @@
              ,(type->sexp t)
              (list ,@(map path-elem->sexp pth)))]
     [(Fun: (? has-optional-args? arrs))
-     (match-define (Arrow: fdoms rest *kws rng) (first arrs))
-     (match-define (Arrow: ldoms _ _ _) (last arrs))
+     (match-define (Arrow: fdoms _ kws rng) (first arrs))
+     (match-define (Arrow: ldoms rst _ _) (last arrs))
      (define opts (drop ldoms (length fdoms)))
-     (define kws (map type->sexp *kws))
-     `(opt-fn (list ,@(map type->sexp fdoms))
-              (list ,@(map type->sexp opts))
-              ,(type->sexp rng)
-              ,@(if rest `(#:rest ,rest) '())
-              ,@(if (null? kws) '() `(#:kws (list ,@kws))))]
+     `(opt-fn
+       (list ,@(map type->sexp fdoms))
+       (list ,@(map type->sexp opts))
+       ,(type->sexp rng)
+       ,@(if rst `(#:rest ,(type->sexp rst)) '())
+       ,@(if (null? kws) '() `(#:kws (list ,@(map type->sexp kws)))))]
     [(Fun: arrs) `(make-Fun (list ,@(map type->sexp arrs)))]
     [(DepFun: dom pre rng)
      `(make-DepFun (list ,@(map type->sexp dom))

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -549,6 +549,14 @@
    (for-each f kws)
    (f rng)])
 
+(define/provide (Arrow-min-arity a)
+  (length (Arrow-dom a)))
+
+(define/provide (Arrow-max-arity a)
+  (if (Type? (Arrow-rst a))
+      +inf.0
+      (length (Arrow-dom a))))
+
 ;; a standard function
 ;; + all functions are case-> under the hood (i.e. see 'arrows')
 ;; + each Arrow in 'arrows' may have a dependent range

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -168,8 +168,9 @@
 (define (opt-fn args opt-args result #:rest [rest #f] #:kws [kws null])
   (apply cl->* (for/list ([i (in-range (add1 (length opt-args)))])
                  (make-Fun (list (-Arrow (append args (take opt-args i))
-                                         result
-                                         #:rest rest #:kws kws))))))
+                                         result ;; only the LAST arrow gets the rest arg
+                                         #:rest (and (= i (length opt-args)) rest)
+                                         #:kws kws))))))
 
 (define-syntax-rule (->opt args ... [opt ...] res)
   (opt-fn (list args ...) (list opt ...) res))

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -235,7 +235,9 @@
        (with-syntax ([((extra ...) ...)
                       (for/list ([i (in-range (add1 (length l)))])
                         (take l i))]
-                     [(rst ...) (for/list ([i (in-range (add1 (length l)))]) #'rst)])
+                     ;; only the LAST arrow gets a #:rest arg
+                     [(rst ...) (for/list ([i (in-range (add1 (length l)))])
+                                  (if (< i (length l)) #'#f #'rst))])
          (syntax/loc stx
            (make-Fun
             (list

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -370,8 +370,8 @@
   ;; see type-contract.rkt, which does something similar and this code
   ;; was stolen from/inspired by/etc.
   (match* ((first arrs) (last arrs))
-    [((Arrow: first-dom rst kws rng)
-      (Arrow: last-dom _ _ _))
+    [((Arrow: first-dom _ kws rng)
+      (Arrow: last-dom rst _ _))
      (define-values (mand-kws opt-kws) (partition-kws kws))
      (define opt-doms (drop last-dom (length first-dom)))
      `(->*

--- a/typed-racket-lib/typed-racket/utils/utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/utils.rkt
@@ -384,14 +384,14 @@ at least theoretically.
         [else default]))))
 
 (define (assoc-set d key val)
-  (let loop ([xd d])
+  (let loop ([entries d])
     (cond
-      [(null? xd) (list (cons key val))]
+      [(null? entries) (list (cons key val))]
       [else
-       (let ([a (car xd)])
-         (if (equal? (car a) key)
-             (cons (cons key val) (cdr xd))
-             (cons a (loop (cdr xd)))))])))
+       (let ([entry (car entries)])
+         (if (equal? (car entry) key)
+             (cons (cons key val) (cdr entries))
+             (cons entry (loop (cdr entries)))))])))
 
 (define (assoc-remove d key)
   (let loop ([xd d])

--- a/typed-racket-test/unit-tests/parse-type-tests.rkt
+++ b/typed-racket-test/unit-tests/parse-type-tests.rkt
@@ -218,7 +218,24 @@
 
 
    ;; ->* types
-   [(->* (String Symbol) Void) (t:-> -String -Symbol -Void)]
+   [(->* (String Symbol) Void)
+    (make-Fun (list (-Arrow (list -String -Symbol) -Void)))]
+   [(->* () (String) #:rest Symbol Void)
+    (make-Fun (list (-Arrow (list) -Void)
+                    (-Arrow (list -String)
+                            #:rest -Symbol
+                            -Void)))]
+   [(->* (Number) (String) #:rest Symbol Void)
+    (make-Fun (list (-Arrow (list -Number) -Void)
+                    (-Arrow (list -Number -String)
+                            #:rest -Symbol
+                            -Void)))]
+   [(->* (Number) (String Void) #:rest Symbol Any)
+    (make-Fun (list (-Arrow (list -Number) Univ)
+                    (-Arrow (list -Number -String) Univ)
+                    (-Arrow (list -Number -String -Void)
+                            #:rest -Symbol
+                            Univ)))]
    [(->* (String Symbol) (String) Void)
     (->opt -String -Symbol [-String] -Void)]
    [(->* (String Symbol) (String Symbol) Void)

--- a/typed-racket-test/unit-tests/type-printer-tests.rkt
+++ b/typed-racket-test/unit-tests/type-printer-tests.rkt
@@ -132,11 +132,18 @@
     (check-prints-as? (-AnyValues (-is-type '(0 . 0) -String))
                       "(AnyValues : (: (0 0) String))")
 
+    (check-prints-as?
+     (make-Fun (list (-Arrow (list Univ) #:rest Univ -String)
+                     (-Arrow (list Univ -String) #:rest Univ -String)))
+     ;; NOT (->* (Any) (String) #:rest Any String)
+     "(case-> (-> Any Any * String) (-> Any String Any * String))")
     (check-prints-as? (->opt Univ [] -Void) "(-> Any Void)")
     (check-prints-as? (->opt [-String] -Void) "(->* () (String) Void)")
     (check-prints-as? (->opt Univ [-String] -Void) "(->* (Any) (String) Void)")
     (check-prints-as? (->opt Univ -Symbol [-String] -Void)
                       "(->* (Any Symbol) (String) Void)")
+    (check-prints-as? (->optkey Univ [-String] #:rest -Symbol -Void)
+                      "(->* (Any) (String) #:rest Symbol Void)")
     (check-prints-as? (->optkey Univ [-String] #:x -String #f -Void)
                       "(->* (Any) (String #:x String) Void)")
     (check-prints-as? (->optkey Univ [-String] #:x -String #t -Void)


### PR DESCRIPTION
Since we don't explicitly represent optional arguments in TR (i.e. we just use case-> for everything) we have converted this function type:

```racket
(->* (A) (B) #:rest C D)
```

into this function type:

```racket
(case-> (-> A C * D)
        (-> A B C * D))
```

which is incorrect and unsound (see https://github.com/racket/typed-racket/issues/614). This combined with some other subtle (probably related) decisions in our handling of type checking `case-lambda` forms has been needing some work for a while.

This PR aims to fix these issues. Now the function type

```racket
(->* (A) (B) #:rest C D)
```

will be converted internally into

```racket
(case-> (-> A D)
        (-> A B C * D))
```

I've been working to touch up all of the code affected by this so we no longer have issues with optional and rest args and case-lambdas. Things seem to be going well: I have a bunch of new test cases for what should and should not work, and all of these new tests are now passing. I just need to do more investigation to see if anything else is broken w/ these changes before this is ready to merge.

As always, feedback and comments welcome =)