### PR TITLE
fix case lambda

### DIFF
--- a/typed-racket-test/fail/apply-dots.rkt
+++ b/typed-racket-test/fail/apply-dots.rkt
@@ -7,7 +7,7 @@
                  w))
 
 (plambda: (a ...) ([z : String] . [w : Number *])
-          (apply (case-lambda: (([x : Number] . [y : Number ... a]) x)
+          (apply (case-lambda: (([x : Number] . [y : Number ... a]) 0)
                                (([x : String] [y : String] . [z : String *]) 0)
                                ([y : String *] 0))
                  w))

--- a/typed-racket-test/fail/apply-dots.rkt
+++ b/typed-racket-test/fail/apply-dots.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred 2)
+(exn-pred 3)
 #lang typed-scheme
 
 (plambda: (a ...) ([z : String] . [w : Number *])
@@ -7,7 +7,7 @@
                  w))
 
 (plambda: (a ...) ([z : String] . [w : Number *])
-          (apply (case-lambda: (([x : Number] . [y : Number ... a]) 0)
+          (apply (case-lambda: (([x : Number] . [y : Number ... a]) x)
                                (([x : String] [y : String] . [z : String *]) 0)
                                ([y : String *] 0))
                  w))

--- a/typed-racket-test/succeed/apply-dots.rkt
+++ b/typed-racket-test/succeed/apply-dots.rkt
@@ -12,12 +12,6 @@
           (apply (lambda: ([x : Number] . [y : Number *]) x)
                  1 w))
 
-(plambda: (a ...) ([z : String] . [w : Number *])
-          (apply (case-lambda: (([x : Number] . [y : Number ... a]) x)
-                               (([x : String] [y : String] . [z : String *]) 0)
-                               ([y : Number *] 0))
-                 w))
-
 ;; */*/poly
 (plambda: (a ...) ([z : String] . [w : Number *])
           (apply (plambda: (b) ([x : b] . [y : Number *]) x)

--- a/typed-racket-test/succeed/apply-dots.rkt
+++ b/typed-racket-test/succeed/apply-dots.rkt
@@ -12,6 +12,22 @@
           (apply (lambda: ([x : Number] . [y : Number *]) x)
                  1 w))
 
+
+; the next lambda fails currently because we are incomplete in our
+; checking of case-lambdas. Specifically, since it is unannotated
+; we check each clause and get an arrow type:
+; (-> Number Number ... a Number)
+; (-> String String String * Zero)
+; (-> Number * Zero)
+; and we cannot _naively_ intersect these (i.e. just put them in a
+; case->), we would need to intersect them in a more complex way
+; that ensured soundness.
+;(plambda: (a ...) ([z : String] . [w : Number *])
+;  (apply (case-lambda: (([x : Number] . [y : Number ... a]) x)
+;                       (([x : String] [y : String] . [z : String *]) 0)
+;                       ([y : Number *] 0))
+;         w))
+
 ;; */*/poly
 (plambda: (a ...) ([z : String] . [w : Number *])
           (apply (plambda: (b) ([x : b] . [y : Number *]) x)

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -4324,6 +4324,40 @@
           (void))
         #:ret (ret -Void #f #f)
         #:msg #rx"given: String"]
+       [tc-err
+        (let ()
+          (ann ((tr:case-lambda (([x : Number] . [y : Number *]) x)
+                                (([x : String] [y : String] . [z : String *]) 0)
+                                ([y : Number *] 0))
+                42)
+               Zero)  ;; ==> actually returns 42
+          (void))
+        #:ret (ret -Void #f #f)
+        #:msg #rx"type mismatch"]
+       [tc-err
+        (let ()
+          (ann ((plambda: (a ...) ([z : String] . [w : Number *])
+                  (apply (case-lambda: (([x : Number] . [y : Number ... a]) x)
+                                       (([x : String] [y : String] . [z : String *]) 0)
+                                       ([y : Number *] 0))
+                         w))
+                "Hello" 42)
+               Zero) ;; ==> actually returns 42
+          (void))
+         #:ret (ret -Void #f #f)
+        #:msg #rx"type mismatch"]
+       [tc-err
+        (let ()
+          (ann ((tr:case-lambda
+                 #:∀ (A)
+                 [([a : A])
+                  (ann a A)]
+                 [[rest : A *]
+                  (ann rest (Listof A))]) 1)
+               (Listof One))  ;; ==> actually returns 1
+          (void))
+        #:ret (ret -Void #f #f)
+        #:msg #rx"type mismatch"]
        )
 
   (test-suite


### PR DESCRIPTION
## Summary

This adds to (i.e. __depends on__) the changes in https://github.com/racket/typed-racket/pull/618 by:

+ cleaning up our lambda checking code more
+ fixing some case-lambda issues we've had (in particular how we handle giving types to case lambdas that have no expected type (i.e. that we are checking entirely in type synthesis mode))

This fixes https://github.com/racket/typed-racket/issues/413 (possibly more).

## Detailed description of general approach

In general, whenever we have a `case->` expected type we ensure that the body of the function checks successfully __at each type__ in the `case->`.

This also needs to happen when we are checking a `case-lambda`, however as we analyze each case, we may see that certain arrow types in the `case->` type are "unreachable" for a particular case-lambda clause (i.e. the arrow's domain would have been handled by a previous `case-lambda` clause already), and we thus need not verify that clause at that arrow type.

## Detailed description of the problem

Previously (i.e. until this PR), when we saw a `case-lambda` _without_ an annotation we would just check each `case-lambda` clause (each producing an arrow type) and then we would throw all the resulting arrows into a `case->` and be done with it.

That approach, however, does not do the aforementioned checking that is required. i.e. we __must__ check that all of the arrows in the resulting `case->` are valid arrow types for this `case-lambda`.

This PR fixes this, by going back and checking clauses at any arrow types they might be used at. It is careful not to re-check clauses at types they are already known to be (i.e. we make sure not to do the work twice for a given clause).