### PR TITLE
initial #:rest-star support

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -724,7 +724,8 @@ functions and continuation mark functions.
           [optional-dom type
                         (code:line keyword type)]
           [rest (code:line)
-                (code:line #:rest type)])]{
+                (code:line #:rest type)
+                (code:line #:rest-star (type ...))])]{
   Constructs the type of functions with optional or rest arguments. The first
   list of @racket[mandatory-dom]s correspond to mandatory argument types. The list
   @racket[optional-doms], if provided, specifies the optional argument types.
@@ -733,13 +734,29 @@ functions and continuation mark functions.
       (define (append-bar str [how-many 1])
         (apply string-append str (make-list how-many "bar")))]
 
-  If provided, the @racket[rest] expression specifies the type of
+  If provided, the @racket[#:rest type] specifies the type of
   elements in the rest argument list.
 
   @ex[(: +all (->* (Integer) #:rest Integer (Listof Integer)))
       (define (+all inc . rst)
         (map (λ ([x : Integer]) (+ x inc)) rst))
       (+all 20 1 2 3)]
+
+  A @racket[#:rest-star (type ...)] specifies the rest list is a sequence
+  of types which occurs 0 or more times (i.e. the Kleene closure of the
+  sequence).
+
+ @ex[(: print-name+ages (->* () #:rest-star (String Natural) Void))
+     (define (print-name+ages . names+ages)
+       (let loop ([names+ages : (Rec x (U Null (List* String Natural x))) names+ages])
+         (when (pair? names+ages)
+           (printf "~a is ~a years old!\n"
+                   (first names+ages)
+                   (second names+ages))
+           (loop (cddr names+ages))))
+       (printf "done printing ~a ages" (/ (length names+ages) 2)))
+     (print-name+ages)
+     (print-name+ages "Charlotte" 8 "Harrison" 5 "Sydney" 3)]
 
   Both the mandatory and optional argument lists may contain keywords paired
   with types.
@@ -783,8 +800,9 @@ functions and continuation mark functions.
  @ex[((λ #:forall (A) ([x : (∩ Symbol A)]) x) 'foo)]}
 
 @defform[(case-> fun-ty ...)]{is a function that behaves like all of
-  the @racket[fun-ty]s, considered in order from first to last.  The @racket[fun-ty]s must all be function
-  types constructed with @racket[->].
+  the @racket[fun-ty]s, considered in order from first to last.
+ The @racket[fun-ty]s must all be non-dependent function types (i.e. no
+ preconditions or dependencies between arguments are currently allowed).
   @ex[(: add-map : (case->
                      [(Listof Integer) -> (Listof Integer)]
                      [(Listof Integer) (Listof Integer) -> (Listof Integer)]))]

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -923,21 +923,9 @@
 [hash-eqv? (-> -HashTableTop B)]
 [hash-equal? (-> -HashTableTop B)]
 [hash-weak? (asym-pred -HashTableTop B (-PS (-is-type 0 -Weak-HashTableTop) (-not-type 0 -Weak-HashTableTop)))]
-[hash (-poly (a b) (cl->* (-> (-Immutable-HT a b))
-                          (a b . -> . (-Immutable-HT a b))
-                          (a b a b . -> . (-Immutable-HT a b))
-                          (a b a b a b . -> . (-Immutable-HT a b))
-                          (a b a b a b a b . -> . (-Immutable-HT a b))))]
-[hasheqv (-poly (a b) (cl->* (-> (-Immutable-HT a b))
-                             (a b . -> . (-Immutable-HT a b))
-                             (a b a b . -> . (-Immutable-HT a b))
-                             (a b a b a b . -> . (-Immutable-HT a b))
-                             (a b a b a b a b . -> . (-Immutable-HT a b))))]
-[hasheq (-poly (a b) (cl->* (-> (-Immutable-HT a b))
-                            (a b . -> . (-Immutable-HT a b))
-                            (a b a b . -> . (-Immutable-HT a b))
-                            (a b a b a b . -> . (-Immutable-HT a b))
-                            (a b a b a b a b . -> . (-Immutable-HT a b))))]
+[hash (-poly (a b) (->* (list) (make-Rest (list a b)) (-Immutable-HT a b)))]
+[hasheqv (-poly (a b) (->* (list) (make-Rest (list a b)) (-Immutable-HT a b)))]
+[hasheq (-poly (a b) (->* (list) (make-Rest (list a b)) (-Immutable-HT a b)))]
 [make-hash (-poly (a b) (->opt [(-lst (-pair a b))] (-Mutable-HT a b)))]
 [make-hasheq (-poly (a b) (->opt [(-lst (-pair a b))] (-Mutable-HT a b)))]
 [make-hasheqv (-poly (a b) (->opt [(-lst (-pair a b))] (-Mutable-HT a b)))]
@@ -949,7 +937,9 @@
 [make-immutable-hasheqv (-poly (a b) (->opt [(-lst (-pair a b))] (-Immutable-HT a b)))]
 
 [hash-set (-poly (a b) ((-HT a b) a b . -> . (-Immutable-HT a b)))]
+[hash-set* (-poly (a b) (->* (list (-HT a b)) (make-Rest (list a b)) (-Immutable-HT a b)))]
 [hash-set! (-poly (a b) ((-HT a b) a b . -> . -Void))]
+[hash-set*! (-poly (a b) (->* (list (-HT a b)) (make-Rest (list a b)) -Void))]
 [hash-ref (-poly (a b c)
                  (cl-> [((-HT a b) a) b]
                        [((-HT a b) a (-val #f)) (-opt b)]

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -264,7 +264,9 @@
      `(make-Opaque (quote-syntax ,pred))]
     [(Refinement: parent pred)
      `(make-Refinement ,(type->sexp parent) (quote-syntax ,pred))]
-    [(Mu-name: n b)
+    [(Mu-maybe-name: n (? Type? b))
+     `(make-Mu (quote ,n) ,(type->sexp b))]
+    [(Mu: n b)
      `(make-Mu (quote ,n) ,(type->sexp b))]
     [(Poly-names: ns b)
      `(make-Poly (list ,@(for/list ([n (in-list ns)])
@@ -324,6 +326,8 @@
        ,(and rest (type->sexp rest))
        (list ,@(map type->sexp kws))
        ,(type->sexp rng))]
+    [(Rest: tys )
+     `(make-Rest (list ,@(map type->sexp tys)))]
     [(RestDots: ty db)
      `(make-RestDots ,(type->sexp ty)
                      (quote ,db))]

--- a/typed-racket-lib/typed-racket/infer/promote-demote.rkt
+++ b/typed-racket-lib/typed-racket/infer/promote-demote.rkt
@@ -36,21 +36,21 @@
   ;; Returns the changed arr or #f if there is no arr above it
   (define (arr-change arr)
     (match arr
-      [(Arrow: dom rest kws rng)
+      [(Arrow: dom rst kws rng)
        (cond
          [(apply V-in? V (get-propsets rng))
           #f]
-         [(and (RestDots? rest)
-               (memq (RestDots-nm rest) V))
+         [(and (RestDots? rst)
+               (memq (RestDots-nm rst) V))
           (make-Arrow
            (map contra dom)
-           (contra (RestDots-ty rest))
+           (contra (RestDots-ty rst))
            (map contra kws)
            (co rng))]
          [else
           (make-Arrow
            (map contra dom)
-           (and rest (contra rest))
+           (and rst (contra rst))
            (map contra kws)
            (co rng))])]))
   (match cur

--- a/typed-racket-lib/typed-racket/infer/signatures.rkt
+++ b/typed-racket-lib/typed-racket/infer/signatures.rkt
@@ -50,7 +50,7 @@
                                    ;; domain
                                    (listof Type?)
                                    ;; rest
-                                   (or/c #f Type?)
+                                   (or/c #f Type? Rest?)
                                    ;; range
                                    (or/c #f Values/c ValuesDots?))
                                   ;; [optional] expected type

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -492,7 +492,7 @@
         (define prop
           (cond
             [(TrueProp? raw-prop) #f]
-            [else (define x (gen-pretty-id))
+            [else (define x (genid))
                   (define prop (Intersection-prop (-id-path x) type))
                   (define name (format "~a" `(λ (,(syntax->datum x)) ,prop)))
                   (flat-named-lambda/sc name
@@ -736,6 +736,8 @@
         (channel/sc (t->sc t))]
        [(Evt: t)
         (evt/sc (t->sc t))]
+       [(Rest: (list rst-t)) (listof/sc (t->sc rst-t))]
+       [(? Rest? rst) (t->sc (Rest->Type rst))]
        [(? Prop? rep) (prop->sc rep)]
        [_
         (fail #:reason "contract generation not supported for this type")]))))
@@ -812,7 +814,7 @@
              (values (map conv mand-kws)
                      (map conv opt-kws))))
          (define range (map t->sc rngs))
-         (define rest (and rst (listof/sc (t->sc/neg rst))))
+         (define rest (and rst (t->sc/neg rst)))
          (function/sc (from-typed? typed-side) (process-dom mand-args) opt-args mand-kws opt-kws rest range))
        (handle-arrow-range first-arrow convert-arrow)]
       [else
@@ -827,7 +829,7 @@
                                      " with optional keyword arguments")))
                 (if case->
                   (arr/sc (process-dom (map t->sc/neg dom))
-                          (and rst (listof/sc (t->sc/neg rst)))
+                          (and rst (t->sc/neg rst))
                           (map t->sc rngs))
                   (function/sc
                     (from-typed? typed-side)
@@ -836,7 +838,7 @@
                     (map conv mand-kws)
                     (map conv opt-kws)
                     (match rst
-                      [(? Type?) (listof/sc (t->sc/neg rst))]
+                      [(? Rest?) (t->sc/neg rst)]
                       [(RestDots: dty dbound)
                        (listof/sc
                         (t->sc/neg dty

--- a/typed-racket-lib/typed-racket/typecheck/check-subforms-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-subforms-unit.rkt
@@ -56,12 +56,12 @@
          (tc/funapp #'here #'(here) t (list (ret arg1)) #f)]
         [(Fun: (list _ ...
                      (Arrow: (list)
-                             (? Type? rst)
+                             (Rest: (list rst-t))
                              (list (Keyword: _ _ #f) ...)
                              _ )
                      _ ...))
-         #:when (subtype prop-type rst)
-         (tc/funapp #'here #'(here) t (list (ret rst)) #f)]
+         #:when (subtype prop-type rst-t)
+         (tc/funapp #'here #'(here) t (list (ret rst-t)) #f)]
         [(? resolvable? t)
          (loop (resolve t))]
         [(or (Poly: ns _) (PolyDots: (list ns ... _) _))

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-main.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-main.rkt
@@ -47,8 +47,6 @@
     [(#%plain-app . (~var v (tc/app-special-cases expected)))
      ((attribute v.check))]))
 
-
-
 ;; TODO: handle drest, and props/objects
 (define (arrow-matches? arr args)
   (match arr
@@ -59,10 +57,7 @@
                                      (PropSet: (TrueProp:) (TrueProp:))
                                      (Empty:))
                             ...)))
-     (cond
-       [(< (length domain) (length args)) rst]
-       [(= (length domain) (length args)) #t]
-       [else #f])]
+     (Arrow-includes-arity? domain rst args)]
     [_ #f]))
 
 (define (has-props? arr)
@@ -108,14 +103,11 @@
           (define arg-types
             (for/list ([arg-stx (in-list args*)]
                        [arg-idx (in-naturals)])
-              (define dom-ty (list-ref/default (car doms)
-                                               arg-idx
-                                               (car rsts)))
+              (define dom-ty (dom+rst-ref (car doms) (car rsts) arg-idx))
               (cond
-                [(for/and ([dom (in-list doms)]
-                           [rst (in-list rsts)])
-                   (equal? dom-ty
-                           (list-ref/default dom arg-idx rst)))
+                [(for/and ([dom (in-list (cdr doms))]
+                           [rst (in-list (cdr rsts))])
+                   (equal? dom-ty (dom+rst-ref dom rst arg-idx)))
                  (single-value arg-stx (ret dom-ty))]
                 [else (single-value arg-stx)])))
           (tc/funapp #'f #'args f-ty arg-types expected)]

--- a/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
@@ -46,7 +46,7 @@
     (match f-ty
       [(tc-result1:
          (and t (AnyPoly-names: _ _
-                                (Fun: (list (Arrow: doms  rests (list (Keyword: _ _ #f) ...) rngs) ..1)))))
+                                (Fun: (list (Arrow: doms rests (list (Keyword: _ _ #f) ...) rngs) ..1)))))
        (domain-mismatches f args t doms rests rngs arg-tres full-tail-ty #f
                           #:msg-thunk (lambda (dom)
                                         (string-append
@@ -64,7 +64,7 @@
       (for/or ([arrow (in-list arrows)])
         (match arrow
           [(Arrow: domain rst _ rng)
-           ;; Takes a possible substitution and comuptes
+           ;; Takes a possible substitution and computes
            ;; the substituted range type if it is not #f
            (define (finish substitution)
              (begin0
@@ -73,16 +73,7 @@
            (finish
             (infer vars dotted-vars
                    (list (-Tuple* arg-tys full-tail-ty))
-                   (list (-Tuple* domain
-                                  (match rst
-                                    ;; the actual work, when we have a * function
-                                    [(? Type?) (make-Listof rst)]
-                                    ;; ... function
-                                    [(RestDots: dty dbound)
-                                     (make-ListDots dty dbound)]
-                                    ;; the function has no rest argument,
-                                    ;; but provides all the necessary fixed arguments
-                                    [_ -Null])))
+                   (list (-Tuple* domain (Rest->Type rst)))
                    rng))]))
        (failure))]
     [(tc-result1: (AnyPoly: _ _ (Fun: '())))

--- a/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
@@ -151,10 +151,9 @@
          #:infer-when
          ;; only try inference if the argument lengths are appropriate
          (match rst
-           [(? Type?) (<= (length dom) (length argtys))]
            [(RestDots: _ dbound) (and (<= (length dom) (length argtys))
                                       (eq? dotted-var dbound))]
-           [_ (= (length dom) (length argtys))])
+           [_ (Arrow-includes-arity? dom rst argtys)])
          ;; Only try to infer the free vars of the rng (which includes the vars
          ;; in props/objects).
          #:maybe-inferred-substitution
@@ -162,7 +161,7 @@
            (extend-tvars
             fixed-vars
             (match rst
-              [(? Type?)
+              [(? Rest?)
                (infer/vararg
                 fixed-vars (list dotted-var) argtys dom rst rng
                 (and expected (tc-results->values expected))
@@ -197,7 +196,7 @@
          ;; and there's no mandatory kw
          #:infer-when
          (and (not (ormap Keyword-required? kws))
-              ((if rst <= =) (length dom) (length argtys)))
+              (Arrow-includes-arity? dom rst argtys))
          ;; Only try to infer the free vars of the rng (which includes the vars
          ;; in props/objects).
          #:maybe-inferred-substitution

--- a/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
@@ -83,23 +83,18 @@
 ;; expected: The expected type of the body forms.
 ;; body: The body of the lambda to typecheck.
 (define/cond-contract
-  (tc-lambda-body arg-names arg-types #:rest-arg+type [rest-arg+type #f] #:expected [expected #f] body)
+  (tc-lambda-body arg-names arg-types
+                  #:rest-id+type+body-type [rest-id+type+body-type #f]
+                  #:expected [expected #f] body)
   (->* ((listof identifier?) (listof Type?) syntax?)
-       (#:rest-arg+type (or/c #f (cons/c identifier? (or/c Type? RestDots?)))
+       (#:rest-id+type+body-type (or/c #f (list/c identifier? (or/c Rest? RestDots?) Type?))
         #:expected (or/c #f tc-results/c))
        Arrow?)
 
   (define-values (rst-id rst-type names types)
-    (match rest-arg+type
-      [(cons id rst)
-       (values id rst
-               (cons id arg-names)
-               (cons (match rst
-                       [(? Bottom?) -Null]
-                       [(? Type?) (-lst rst)]
-                       [(RestDots: dty dbound)
-                        (make-ListDots dty dbound)])
-                     arg-types))]
+    (match rest-id+type+body-type
+      [(list id rst body-type)
+       (values id rst (cons id arg-names) (cons body-type arg-types))]
       [_ (values #f #f arg-names arg-types)]))
 
   (-Arrow
@@ -117,28 +112,33 @@
 ;; rest-id: The identifier of the rest arg, or #f for no rest arg
 ;; body: The body of the lambda to typecheck.
 ;; arg-tys: The expected positional argument types.
-;; rst: #f, expected rest arg Type, or expected RestDots
+;; rst: #f, expected rest arg Rest, or expected RestDots
 ;; ret-ty: The expected type of the body of the lambda.
 (define/cond-contract (check-clause arg-list rest-id body arg-tys rst ret-ty)
   ((listof identifier?)
-   (or/c #f identifier?) syntax? (listof Type?) (or/c #f Type? RestDots?)
+   (or/c #f identifier?) syntax? (listof Type?) (or/c #f Rest? RestDots?)
    tc-results/c
    . -> .
    Arrow?)
   (let* ([arg-len (length arg-list)]
-         [tys-len (length arg-tys)]
+         [arg-tys-len (length arg-tys)]
+         [extra-arg-count (- arg-len arg-tys-len)]
          [arg-types
-          (if (andmap type-annotation arg-list)
-              (get-types arg-list #:default Univ)
-              (cond
-                [(= arg-len tys-len) arg-tys]
-                [(< arg-len tys-len) (take arg-tys arg-len)]
-                [(> arg-len tys-len)
-                 (append arg-tys
-                         (map (if (Type? rst)
-                                  (λ _ rst)
-                                  (λ _ -Bottom))
-                              (drop arg-list tys-len)))]))])
+          (cond
+            [(andmap type-annotation arg-list)
+             (get-types arg-list #:default Univ)]
+            [(zero? extra-arg-count) arg-tys]
+            [(negative? extra-arg-count) (take arg-tys arg-len)]
+            [else
+             (define tail-tys (match rst
+                                [(Rest: rst-tys)
+                                 (define rst-len (length rst-tys))
+                                 (for/list ([_ (in-range extra-arg-count)]
+                                            [rst-t (in-list-cycle rst-tys)])
+                                   rst-t)]
+                                [_ (for/list ([_ (in-range extra-arg-count)])
+                                     -Bottom)]))
+             (append arg-tys tail-tys)])])
 
     ;; Check that the number of formal arguments is valid for the expected type.
     ;; Thus it must be able to accept the number of arguments that the expected
@@ -146,42 +146,101 @@
     ;; enough arguments, or if it requires too many arguments.
     ;; This allows a form like (lambda args body) to have the type (-> Symbol
     ;; Number) with out a rest arg.
-    (when (or (and (< arg-len tys-len) (not rest-id))
-              (and (> arg-len tys-len) (not rst)))
-      (tc-error/delayed (expected-str tys-len rst arg-len rest-id)))
-    (define rest-type
+    (when (or (and (< arg-len arg-tys-len) (not rest-id))
+              (and (> arg-len arg-tys-len) (not rst)))
+      (tc-error/delayed (expected-str arg-tys-len rst arg-len rest-id)))
+
+    ;; rst-type - the type of the rest argument in the Arrow type
+    ;; rest-body-type - the type the rest argument id has in the body
+    ;;                  of the function
+    ;; e.g. for
+    ;; (: foo (->* () () #:rest String Number))
+    ;; (define (foo . rest-strings) ...)
+    ;; the caller can provide 0 or more Strings, so the Arrow's
+    ;; rest spec would be (make-Rest (list -String))
+    ;; and in the body of the function, the rest argument
+    ;; identifier (rest-strings) have type (Listof String)
+    (define-values (rst-type rest-body-type)
       (cond
-        [(not rest-id) #f]
-        [(RestDots? rst) rst]
+        ;; there's not a rest ident... easy
+        [(not rest-id) (values #f #f)]
+        ;; a dotted rest spec, so the body has a ListDots
+        [(RestDots? rst)
+         (match-define (RestDots: dty dbound) rst)
+         (values rst (make-ListDots dty dbound))]
+        ;; the rest-id is dotted?, lets go get its type
         [(dotted? rest-id)
-         => (λ (b) (make-RestDots (extend-tvars (list b) (get-type rest-id #:default Univ))
-                                  b))]
+         => (λ (dbound)
+              (define ty (extend-tvars (list dbound) (get-type rest-id #:default Univ)))
+              (values (make-RestDots ty dbound)
+                      (make-ListDots ty dbound)))]
         [else
-         (define base-rest-type
+         ;; otherwise let's get the sequence of types the rest argument would have
+         ;; and call it 'rest-types' (i.e. in our above example 'foo', this would
+         ;; be (list -String)
+         (define rest-types
            (cond
-             [(type-annotation rest-id) (get-type rest-id #:default Univ)]
-             [(Type? rst) rst]
-             [(not rst) -Bottom]
-             [else Univ]))
-         (define extra-types
-           (if (<= arg-len tys-len)
-               (drop arg-tys arg-len)
-               null))
-         (apply Un base-rest-type extra-types)]))
-    (tc-lambda-body arg-list arg-types
-                    #:rest-arg+type (and rest-type (cons rest-id rest-type))
-                    #:expected ret-ty
-                    body)))
+             [(type-annotation rest-id) (list (get-type rest-id #:default Univ))]
+             [else
+              (match rst
+                [#f (list -Bottom)]
+                [(? Type? t) (list t)]
+                [(Rest: rst-ts) rst-ts]
+                [_ (list Univ)])]))
+         ;; now that we have the list of types, we need to calculate, based on how many
+         ;; positional argument identifiers there are, how the rest should look
+         ;; i.e. if our rest was (Num Str)* (i.e. an even length rest arg of numbers
+         ;; followed by strings) and there was 1 more positional argument that positional
+         ;; domain types, then that extra positional arg would be type Num (i.e. the type
+         ;; it gets since its type is coming from the rest type) and the rest id's type
+         ;; in the body of the function would (Pair Str (Num Str)*) (i.e. the rest arg
+         ;; would _have_ to have a Str in it, and then would have 0 or more Num+Strs
+         (cond
+           [(= arg-len arg-tys-len)
+            (values (make-Rest rest-types)
+                    (make-CyclicListof rest-types))]
+           ;; some of the args are _in_ the rst arg (i.e. they
+           ;; do not have argument names) ...
+           [(<= arg-len arg-tys-len)
+            (define extra-types (drop arg-tys arg-len))
+            (define rst-type (apply Un (append extra-types rest-types)))
+            (values (make-Rest (list rst-type))
+                    (make-Listof rst-type))]
+           ;; there are named args whose type came from the rst argument
+           ;; i.e. we need to pull there types out of the rst arg
+           [else
+            (define rest-remainder (drop rest-types (remainder extra-arg-count
+                                                               (length rest-types))))
+            (values (make-Rest rest-types)
+                    (-Tuple* rest-remainder
+                             (make-CyclicListof rest-types)))])]))
+
+    (tc-lambda-body
+     arg-list
+     arg-types
+     #:rest-id+type+body-type (and rst-type (list rest-id rst-type rest-body-type))
+     #:expected ret-ty
+     body)))
 
 ;; typecheck a single lambda, with argument list and body
 ;; drest-ty and drest-bound are both false or not false
 (define/cond-contract (tc/lambda-clause/check f body arg-tys ret-ty rst)
-  (-> formals? syntax? (listof Type?) (or/c tc-results/c #f) (or/c #f Type? RestDots?)
+  (-> formals?
+      syntax?
+      (listof Type?)
+      (or/c tc-results/c #f)
+      (or/c #f Rest? RestDots?)
       Arrow?)
-  (check-clause (formals-positional f) (formals-rest f) body arg-tys rst ret-ty))
+  (check-clause (formals-positional f)
+                (formals-rest f)
+                body
+                arg-tys
+                rst
+                ret-ty))
 
 ;; typecheck a single opt-lambda clause with argument list and body
-(define/cond-contract (tc/opt-lambda-clause arg-list body aux-table flag-table)
+(define/cond-contract
+  (tc/opt-lambda-clause arg-list body aux-table flag-table)
   (-> (listof identifier?) syntax? free-id-table? free-id-table?
       (listof Arrow?))
   ;; arg-types: Listof[Type?]
@@ -262,8 +321,10 @@
             (make-RestDots (extend-tvars (list bound) (get-type rest-id #:default Univ))
                            bound))]
          ;; Lambda with regular rest argument
-         [rest-id
-          (get-type rest-id #:default Univ)]
+         [rest-id (match (get-type rest-id #:default Univ)
+                    [(? Type? t) (make-Rest (list t))]
+                    [(? Rest? rst) rst]
+                    [(? RestDots? rst) rst])]
          ;; Lambda with no rest argument
          [else #f]))
      (cond 
@@ -290,10 +351,17 @@
          (register-ignored! (car (syntax-e body)))
          x)]
       [else
+       (define rest-body-type
+         (match rest-type
+           [#f #f]
+           [(Rest: ts) (make-CyclicListof ts)]
+           [(RestDots: dty dbound) (make-ListDots dty dbound)]))
        (list
-        (tc-lambda-body arg-list (map (lambda (v) (or v Univ)) arg-types)
-                        #:rest-arg+type (and rest-type (cons rest-id rest-type))
-                        body))])]))
+        (tc-lambda-body
+         arg-list
+         (map (λ (v) (or v Univ)) arg-types)
+         #:rest-id+type+body-type (and rest-type (list rest-id rest-type rest-body-type))
+         body))])]))
 
 
 
@@ -379,7 +447,7 @@
               #:unless (in-arities? seen arrow)
               #:when (cond
                        [formals-rest?
-                        (or (Type? rst) (>= (length dom) pos-count))]
+                        (or (Rest? rst) (>= (length dom) pos-count))]
                        [rst (<= (length dom) pos-count)]
                        [else (= (length dom) pos-count)]))
     arrow))

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -44,8 +44,12 @@
 (define/decl -Null (-val null))
 
 ;; Char type and List type (needed because of how sequences are checked in subtype)
-(define (make-Listof elem) (-mu list-rec (Un -Null (make-Pair elem list-rec))))
-(define (make-MListof elem) (-mu list-rec (Un -Null (make-MPair elem list-rec))))
+(define (make-Listof elem) (unsafe-make-Mu  (Un -Null (make-Pair elem (make-B 0)))))
+(define (make-MListof elem) (unsafe-make-Mu (Un -Null (make-MPair elem (make-B 0)))))
+(define (make-CyclicListof cycle)
+  (cond
+    [(ormap Bottom? cycle) -Null]
+    [else (unsafe-make-Mu (Un -Null (-Tuple* cycle (make-B 0))))]))
 
 ;; -Tuple Type is needed by substitute for ListDots
 (define -pair make-Pair)
@@ -128,13 +132,13 @@
                               #:props [props -tt-propset]
                               #:object [obj -empty-obj])
   (c:->* ((c:listof Type?) (c:or/c SomeValues? Type?))
-         (#:rest (c:or/c #f Type? RestDots?)
+         (#:rest (c:or/c #f Type? RestDots? Rest?)
           #:kws (c:listof Keyword?)
           #:props PropSet?
           #:object OptObject?)
          Arrow?)
   (make-Arrow dom
-              rst
+              (if (Type? rst) (make-Rest (list rst)) rst)
               (sort kws Keyword<?)
               (match rng
                 [(? SomeValues?) rng]

--- a/typed-racket-lib/typed-racket/types/kw-types.rkt
+++ b/typed-racket-lib/typed-racket/types/kw-types.rkt
@@ -2,7 +2,7 @@
 
 (require "../utils/utils.rkt"
          (utils tc-utils)
-         (types abbrev tc-result)
+         (types abbrev tc-result utils)
          (rep core-rep type-rep values-rep)
          (base-env annotate-classes)
          racket/list racket/set racket/match
@@ -16,9 +16,10 @@
                  rng ; SomeValues?
                  maybe-rst ; (or/c #f Type? RestDots?)
                  split?) ; boolean?
-  (when (RestDots? maybe-rst) (int-err "RestDots passed to kw-convert"))
-  ;; the kw function protocol passes rest args as an explicit list
-  (define rst-type (if maybe-rst (list (-lst maybe-rst)) empty))
+  (define rst-type (match maybe-rst
+                     [#f '()]
+                     [(? Rest?) (list (Rest->Type maybe-rst))]
+                     [_ (int-err "Invalid rest kind passed to kw-convert")]))
 
   ;; the kw protocol puts the arguments in keyword-sorted order in the
   ;; function header, so we need to sort the types to match

--- a/typed-racket-lib/typed-racket/types/prop-ops.rkt
+++ b/typed-racket-lib/typed-racket/types/prop-ops.rkt
@@ -409,14 +409,14 @@
 ;; useful to express properties of the form: if this function returns at all,
 ;; we learn this about its arguments (like fx primitives, or car/cdr, etc.)
 (define/match (add-unconditional-prop-all-args arr type)
-  [((Fun: (list (Arrow: dom rest kws rng))) type)
+  [((Fun: (list (Arrow: dom rst kws rng))) type)
    (match rng
      [(Values: (list (Result: tp (PropSet: p+ p-) op)))
       (let ([new-props (apply -and (build-list (length dom)
                                                (lambda (i)
                                                  (-is-type i type))))])
         (make-Fun
-         (list (make-Arrow dom rest kws
+         (list (make-Arrow dom rst kws
                            (make-Values
                             (list (-result tp
                                            (-PS (-and p+ new-props)

--- a/typed-racket-lib/typed-racket/types/substitute.rkt
+++ b/typed-racket-lib/typed-racket/types/substitute.rkt
@@ -100,7 +100,7 @@
          (let ([expanded (sub dty)])
            (map (λ (img) (substitute img name expanded))
                 images)))
-        rimage
+        (if (Type? rimage) (make-Rest (list rimage)) rimage)
         (map sub kws)
         (sub rng))]
       [_ (Rep-fmap target sub)])))

--- a/typed-racket-test/succeed/apply-dots.rkt
+++ b/typed-racket-test/succeed/apply-dots.rkt
@@ -12,7 +12,6 @@
           (apply (lambda: ([x : Number] . [y : Number *]) x)
                  1 w))
 
-
 ; the next lambda fails currently because we are incomplete in our
 ; checking of case-lambdas. Specifically, since it is unannotated
 ; we check each clause and get an arrow type:

--- a/typed-racket-test/succeed/rest-star-hash-examples.rkt
+++ b/typed-racket-test/succeed/rest-star-hash-examples.rkt
@@ -1,0 +1,52 @@
+#lang typed/racket/base
+
+(provide my-hash my-hash-set*)
+
+(require racket/match)
+
+(define-type (KV-List K V) (Rec T (U Null (List* K V T))))
+
+(: my-hash (All (K V) (->* () #:rest-star (K V) (Immutable-HashTable K V))))
+(define (my-hash . k/v-list)
+  (let loop ([h : (Immutable-HashTable K V) (hash)]
+             [to-add : (KV-List K V) k/v-list])
+    (match to-add
+      [(cons k (cons v rst)) 
+       (loop (hash-set h k v) rst)]   
+      [_ h])))
+
+(: my-mutable-hash (All (K V) (->* () #:rest-star (K V) (Mutable-HashTable K V))))
+(define (my-mutable-hash . k/v-list)
+  (define h : (Mutable-HashTable K V) (make-hash))
+  (let loop! ([to-add : (KV-List K V) k/v-list])
+    (match to-add
+      [(cons k (cons v rst))
+       (hash-set! h k v)
+       (loop! rst)]
+      [_ h])))
+
+
+(: my-hash-set* (All (K V) (->* ((Immutable-HashTable K V)) #:rest-star (K V) (Immutable-HashTable K V))))
+(define (my-hash-set* orig . k/v-list)
+  (let loop ([h : (Immutable-HashTable K V) orig]
+             [to-add : (KV-List K V) k/v-list])
+    (match to-add
+      [(cons k (cons v rst))
+       (loop (hash-set h k v) rst)]
+      [_ h])))
+
+(: my-hash-set*! (All (K V) (->* ((Mutable-HashTable K V)) #:rest-star (K V) Void)))
+(define (my-hash-set*! orig . k/v-list)
+  (let loop! ([to-add : (KV-List K V) k/v-list])
+    (match to-add
+      [(cons k (cons v rst))
+       (hash-set! orig k v)
+       (loop! rst)]
+      [_ (void)])))
+
+
+(define h (my-hash "Hello" 'world "How" 'are "you" 'today?))
+(my-hash-set* h "one" 'more)
+
+(define mh (my-mutable-hash "Hello" 'world "How" 'are "you" 'today?))
+(my-hash-set*! mh "one" 'more)

--- a/typed-racket-test/unit-tests/contract-tests.rkt
+++ b/typed-racket-test/unit-tests/contract-tests.rkt
@@ -724,5 +724,83 @@
                (λ (x y) #f)
                #:untyped
                #:msg #rx"promised:.*#t.*produced:.*#f")
-   
+
+   ;; #:rest-star args
+   (t (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean))
+   (t (->* (list -Zero) (make-Rest (list -Zero -Zero)) -Zero))
+   (t (->* (list) (make-Rest (list -Boolean -String -Boolean -String -Boolean -String)) -Zero))
+   (t (->optkey [-Zero] #:rest Univ -Boolean))
+   (t-int (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+          (λ (c) (c 0))
+          (case-lambda
+            [(zero) #t]
+            [(zero . rst) #f])
+          #:untyped)
+   (t-int (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+          (λ (c) (c 0))
+          (case-lambda
+            [(zero) #t]
+            [(zero . rst) #f])
+          #:typed)
+   (t-int (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+          (λ (c) (c 0 0 'zero))
+          (case-lambda
+            [(zero) #t]
+            [(zero . rst) #f])
+          #:untyped)
+   (t-int (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+          (λ (c) (c 0 0 'zero 0 'zero))
+          (case-lambda
+            [(zero) #t]
+            [(zero . rst) #f])
+          #:untyped)
+   (t-int (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+          (λ (c) (c 0 0 'zero 0 'zero))
+          (case-lambda
+            [(zero) #t]
+            [(zero . rst) #f])
+          #:typed)
+   ;; shouldn't error since we should trust the typed side, right?
+   ;(t-int/fail (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+   ;       (λ (c) (c 'zero 'zero))
+   ;       (case-lambda
+   ;         [(zero) #t]
+   ;         [(zero . rst) #f])
+   ;       #:untyped
+   ;       #:msg #rx"given: '(zero)")
+   (t-int/fail (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+               (λ (c) (c 0))
+               (case-lambda
+                 [(zero) 'true]
+                 [(zero . rst) 'false])
+               #:untyped
+               #:msg #rx"produced: 'true")
+   (t-int/fail (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+               (λ (c) (c 0))
+               (case-lambda
+                 [(zero) 'true]
+                 [(zero . rst) 'false])
+               #:untyped
+               #:msg #rx"produced: 'true")
+   (t-int/fail (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+          (λ (c) (c 0 'zero))
+          (case-lambda
+            [(zero) #t]
+            [(zero . rst) #f])
+          #:typed
+          #:msg #rx"contract violation")
+   (t-int/fail (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+          (λ (c) (c 0 0 0))
+          (case-lambda
+            [(zero) #t]
+            [(zero . rst) #f])
+          #:typed
+          #:msg #rx"contract violation")
+   (t-int/fail (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+          (λ (c) (c 0 0 'zero 0))
+          (case-lambda
+            [(zero) #t]
+            [(zero . rst) #f])
+          #:typed
+          #:msg #rx"contract violation")
    ))

--- a/typed-racket-test/unit-tests/parse-type-tests.rkt
+++ b/typed-racket-test/unit-tests/parse-type-tests.rkt
@@ -5,6 +5,7 @@
            racket/base
            racket/dict
            racket/set
+           racket/list
            syntax/parse
            (base-env base-structs)
            (env tvar-env type-alias-env mvar-env)
@@ -151,6 +152,24 @@
                                                                  [(N N) N])]
    [(case-> (Number -> Boolean) (-> Number Number Number)) (cl-> [(N) B]
                                                                  [(N N) N])]
+   [(case-> (Boolean -> Boolean)
+            (-> Boolean Boolean Boolean)
+            (-> Boolean String * Boolean)
+            (->* (Boolean) #:rest String Boolean)
+            (->* (Boolean) #:rest-star (String Symbol) Boolean)
+            (->* (Boolean) (Boolean) #:rest-star (String Symbol) Boolean)
+            (->* (Boolean Boolean) #:rest-star (String Symbol) Boolean))
+    (make-Fun
+     (remove-duplicates
+      (list (-Arrow (list -Boolean) -Boolean)
+            (-Arrow (list -Boolean -Boolean) -Boolean)
+            (-Arrow (list -Boolean) #:rest -String -Boolean)
+            (-Arrow (list -Boolean)
+                    #:rest (make-Rest (list -String -Symbol))
+                    -Boolean)
+            (-Arrow (list -Boolean -Boolean)
+                    #:rest (make-Rest (list -String -Symbol))
+                    -Boolean))))]
    [1 (-val 1)]
    [#t (-val #t)]
    [#f (-val #f)]
@@ -293,6 +312,25 @@
     (->optkey -String [] #:rest -String #:a -String #t -String)]
    [(String [#:a String] String * -> String)
     (->optkey -String [] #:rest -String #:a -String #f -String)]
+
+   ;; #:rest-star tests
+   [(->* () #:rest-star () String)
+    (->optkey () -String)]
+   [(->* () (Symbol) #:rest-star (String Symbol) String)
+    (->optkey (-Symbol) #:rest (make-Rest (list -String -Symbol)) -String)]
+   [(->* () #:rest-star (String) String)
+    (->optkey () #:rest (make-Rest (list -String)) -String)]
+   [(->* () #:rest-star (String Symbol) String)
+    (->optkey () #:rest (make-Rest (list -String -Symbol)) -String)]
+   [(->* (String) #:rest-star (String Symbol) String)
+    (->optkey -String () #:rest (make-Rest (list -String -Symbol)) -String)]
+   [(->* (String) (Symbol) #:rest-star (String Symbol) String)
+    (->optkey -String (-Symbol) #:rest (make-Rest (list -String -Symbol)) -String)]
+   [(->* (String) (Symbol) #:rest-star () String)
+    (->optkey -String (-Symbol) -String)]
+   [FAIL (->* (String) #:rest-star Number String)]
+   [FAIL (->* (String) (Symbol) #:rest-star Number String)]
+   [FAIL (->* (String) (Symbol) #:rest-star (Not-A-Real-Type-Should-Fail) String)]
 
    ;;; Prefab structs
    [(Prefab foo String) (-prefab 'foo -String)]

--- a/typed-racket-test/unit-tests/subtype-tests.rkt
+++ b/typed-racket-test/unit-tests/subtype-tests.rkt
@@ -384,6 +384,67 @@
    [FAIL (->* (list -Number) -Number -Boolean) (->* (list -Number -Number -Number) -Number)]
    [(->* (list -Number -Number) -Boolean -Number) (->* (list -Number -Number -Boolean -Boolean) -Number)]
 
+   ;; #:rest-star
+   [(->* (list -Zero) Univ -Boolean)
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)]
+   [(->optkey [-Zero] #:rest Univ -Boolean)
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)]
+   [FAIL
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+    (->* (list -Zero) Univ -Boolean)]
+   [(->* (list Univ) (Un -Zero -Symbol) -Boolean)
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)]
+   [FAIL
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+    (->* (list Univ) (Un -Zero -Symbol) -Boolean)]
+   [(->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) Univ)]
+   [FAIL
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) Univ)
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Boolean)]
+   [FAIL
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Zero)
+    (->* (list -Zero -Zero) -Zero)]
+   [FAIL
+    (->* (list -Zero -Zero) -Zero)
+    (->* (list -Zero) (make-Rest (list -Zero -Symbol)) -Zero)]
+   [(->* (list -Zero) (make-Rest (list -Zero -Zero)) -Zero)
+    (->* (list -Zero -Zero -Zero) -Zero)]
+   [FAIL
+    (->* (list -Zero -Zero -Zero) -Zero)
+    (->* (list -Zero) (make-Rest (list -Zero -Zero)) -Zero)]
+   [FAIL
+    (->* (list -Zero) (make-Rest (list -Zero -Zero -Zero)) -Zero)
+    (->* (list -Zero -Zero -Zero) -Zero)]
+   [(->* (list -Zero -Zero) (make-Rest (list -Boolean -Symbol)) -Zero)
+    (->* (list -Zero -Zero) -Zero)]
+   [(->* (list -Zero -Zero) (make-Rest (list -Boolean -Boolean)) -Zero)
+    (->* (list -Zero -Zero -Boolean -Boolean) -Zero)]
+   [(->* (list) (make-Rest (list -Boolean)) -Zero)
+    (->* (list) (make-Rest (list -Boolean -Boolean)) -Zero)]
+   [FAIL
+    (->* (list) (make-Rest (list -Boolean -Boolean)) -Zero)
+    (->* (list) (make-Rest (list -Boolean)) -Zero)]
+   [(->* (list) (make-Rest (list (Un -Boolean -String))) -Zero)
+    (->* (list) (make-Rest (list -Boolean -String)) -Zero)]
+   [(->* (list) (make-Rest (list -Boolean -String)) -Zero)
+    (->* (list) (make-Rest (list -Boolean -String -Boolean -String -Boolean -String)) -Zero)]
+   [(->* (list) (make-Rest (list -Boolean -String)) -Zero)
+    (->* (list) (make-Rest (list -True -String -False -String -True -String)) -Zero)]
+   [FAIL
+    (->* (list) (make-Rest (list -Boolean -String -Boolean)) -Zero)
+    (->* (list) (make-Rest (list -Boolean -String -Boolean -String -Boolean -String)) -Zero)]
+   [(-poly (a) (->* (list -Zero a) (make-Rest (list -Boolean -Boolean)) a))
+    (->* (list -Zero -Zero -Boolean -Boolean) -Zero)]
+   [(-poly (a) (->* (list -Zero -Zero) (make-Rest (list -Boolean a)) -Zero))
+    (->* (list -Zero -Zero -Boolean -Boolean) -Zero)]
+   [(-poly (a) (->* (list a) (make-Rest (list -Zero -Zero)) a))
+    (->* (list -Zero -Zero -Zero) -Zero)]
+   [(-poly (a) (->* (list -Byte) (make-Rest (list a -Zero)) a))
+    (->* (list -Zero -Zero -Zero) -Zero)]
+   [(-poly (a) (->* (list a) (make-Rest (list a -Zero)) a))
+    (->* (list -Zero -Zero -Zero) -Zero)]
+
    [(-poly (a) (cl-> [() a]
                      [(-Number) a]))
     (cl-> [() (-pair -Number (-v b))]
@@ -766,6 +827,57 @@
                                 (-eq (-lexp (-id-path n))
                                      (-lexp (-id-path x))))])
            -Int)]
+   [(->* (list) -Int -Int)
+    (dep-> ([x : -Int]
+            [y : (-refine/fresh n -Int
+                                (-eq (-lexp (-id-path n))
+                                     (-lexp (-id-path x))))])
+           -Int)]
+   [(->* (list -Int) -Int -Int)
+    (dep-> ([x : -Int]
+            [y : (-refine/fresh n -Int
+                                (-eq (-lexp (-id-path n))
+                                     (-lexp (-id-path x))))])
+           -Int)]
+   [(->* (list -Int -Int) -Int -Int)
+    (dep-> ([x : -Int]
+            [y : (-refine/fresh n -Int
+                                (-eq (-lexp (-id-path n))
+                                     (-lexp (-id-path x))))])
+           -Int)]
+   [FAIL
+    (dep-> ([x : -Int]
+            [y : (-refine/fresh n -Int
+                                (-eq (-lexp (-id-path n))
+                                     (-lexp (-id-path x))))])
+           -Int)
+    (->* (list -Int) -Int -Int)]
+   [(->* (list) (make-Rest (list -Int -Int)) -Int)
+    (dep-> ([x : -Int]
+            [y : (-refine/fresh n -Int
+                                (-eq (-lexp (-id-path n))
+                                     (-lexp (-id-path x))))])
+           -Int)]
+   [FAIL
+    (dep-> ([x : -Int]
+            [y : (-refine/fresh n -Int
+                                (-eq (-lexp (-id-path n))
+                                     (-lexp (-id-path x))))])
+           -Int)
+    (->* (list) (make-Rest (list -Int -Int)) -Int)]
+   [(->* (list -Int -Int) (make-Rest (list -Int -Int)) -Int)
+    (dep-> ([x : -Int]
+            [y : (-refine/fresh n -Int
+                                (-eq (-lexp (-id-path n))
+                                     (-lexp (-id-path x))))])
+           -Int)]
+   [FAIL
+    (->* (list -Int) (make-Rest (list -Int -Int)) -Int)
+    (dep-> ([x : -Int]
+            [y : (-refine/fresh n -Int
+                                (-eq (-lexp (-id-path n))
+                                     (-lexp (-id-path x))))])
+           -Int)]
    [FAIL
     (dep-> ([x : -Int]
             [y : (-refine/fresh n -Int
@@ -786,6 +898,19 @@
                       (-lexp (-id-path x)))
            -Int)
     (-> -Int -Int -Int)]
+   [(->* (list) (make-Rest (list -Int -Int)) -Int)
+    (dep-> ([x : -Int]
+            [y : -Int])
+           #:pre (-eq (-lexp (-id-path y))
+                      (-lexp (-id-path x)))
+           -Int)]
+   [FAIL
+    (->* (list -Int) (make-Rest (list -Int -Int)) -Int)
+    (dep-> ([x : -Int]
+            [y : -Int])
+           #:pre (-eq (-lexp (-id-path y))
+                      (-lexp (-id-path x)))
+           -Int)]
    [(-> -Int -Int -Int)
     (dep-> ([x : -Int]
             [y : -Int])

--- a/typed-racket-test/unit-tests/type-printer-tests.rkt
+++ b/typed-racket-test/unit-tests/type-printer-tests.rkt
@@ -55,6 +55,7 @@
     (check-prints-as? (make-Mu 'x (Un -Null (-pair -Nat (make-F 'x))))
                       "(Listof Nonnegative-Integer)")
     (check-prints-as? (-lst* -String -Symbol) "(List String Symbol)")
+    (check-prints-as? (-Tuple* (list -String -Symbol) -String) "(List* String Symbol String)")
 
     ;; next three cases for PR 14552
     (check-prints-as? (-mu x (Un (-pair x x) -Null))
@@ -152,10 +153,20 @@
                       "(->* (Any #:x String) (String) Void)")
     (check-prints-as? (->optkey Univ [-String] #:rest -String #:x -String #t -Void)
                       "(->* (Any #:x String) (String) #:rest String Void)")
+    (check-prints-as? (->optkey Univ [] #:rest (make-Rest (list -String -Symbol))
+                                -String)
+                      "(->* (Any) #:rest-star (String Symbol) String)")
+    (check-prints-as? (->optkey Univ [-String] #:rest (make-Rest (list -String -Symbol))
+                                #:x -String #t -Void)
+                      "(->* (Any #:x String) (String) #:rest-star (String Symbol) Void)")
     (check-prints-as? (cl->* (->opt -Pathlike [-String] -Void)
                              (->optkey Univ [-String] #:rest -String #:x -String #t -Void))
                       (string-append "(case-> (->* (Path-String) (String) Void) "
                                      "(->* (Any #:x String) (String) #:rest String Void))"))
+    (check-prints-as? (cl->* (->opt -Pathlike [-String] -Void)
+                             (->optkey Univ [-String] #:rest (make-Rest (list -String -Symbol)) #:x -String #t -Void))
+                      (string-append "(case-> (->* (Path-String) (String) Void) "
+                                     "(->* (Any #:x String) (String) #:rest-star (String Symbol) Void))"))
     (check-prints-as? (make-Unit null null null (-values (list -String)))
                       "(Unit (import) (export) (init-depend) String)")
     ;; Setup for slightly more complex unit printing test


### PR DESCRIPTION
This PR adds support for rest specifications that are the Kleene closure of some sequence.

e.g. functions like `hash` or `hash-set*` which require a cyclic rest argument with alternating key and value types will be able to be specified with something like the following:

```racket
(: hash-set* (All (K V) (->* ((HashTable K V)) () #:rest-star (K V)
                             (HashTable K V))))
(define (hash-set* h . k+vs)
  ...)
```

Thanks for comments/suggestions from @AlexKnauth, @bennn, and @samth; also thanks to @takikawa for previous work exploring some of these features.

If we later at more general rest argument support, this will simply be subsumed by that and hopefully add some tests and use cases that can help prove a more general implementation is correct and behaves as expected.