### PR TITLE
Modify type and contract serialization to reduce expanded code size.

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/extra-env-lang.rkt
+++ b/typed-racket-lib/typed-racket/base-env/extra-env-lang.rkt
@@ -78,6 +78,11 @@
 
 (define-syntax (-#%module-begin stx)
   (syntax-parse stx
+    [(mb e0 e ...)
+     #:when (eq? '#:no-add-mod (syntax-e #'e0))
+     #'(#%plain-module-begin
+        (require (for-syntax typed-racket/env/env-req))
+        e ...)]
     [(mb e ...)
      #'(#%plain-module-begin
         (require (for-syntax typed-racket/env/env-req))

--- a/typed-racket-lib/typed-racket/env/env-req.rkt
+++ b/typed-racket-lib/typed-racket/env/env-req.rkt
@@ -1,4 +1,5 @@
 #lang racket/base
+(require syntax/modresolve syntax/modcollapse (for-template racket/base))
 (define to-require null)
 (define (add-mod! m)
   (set! to-require (cons m to-require)))
@@ -10,4 +11,16 @@
       (dynamic-require (module-path-index-join '(submod "." #%type-decl) m)
                        #f))))
 
-(provide add-mod! do-requires)
+(define (get-requires)
+  (for/list ([m (in-list to-require)]
+             #:when m)
+    ;; FIXME: is this really the right code?
+    #`(require (only-in #,(collapse-module-path-index (module-path-index-join '(submod "." #%type-decl) m))))))
+
+(define (get-contract-requires)
+  (for/list ([m (in-list to-require)]
+             #:when m)
+    ;; FIXME: is this really the right code?
+    #`(require (only-in #,(collapse-module-path-index (module-path-index-join '(submod "." #%contract-defs) m))))))
+
+(provide add-mod! do-requires get-requires get-contract-requires)

--- a/typed-racket-lib/typed-racket/env/env-req.rkt
+++ b/typed-racket-lib/typed-racket/env/env-req.rkt
@@ -2,12 +2,14 @@
 (require syntax/modresolve syntax/modcollapse (for-template racket/base))
 (define to-require null)
 (define (add-mod! m)
+  (printf "add-mod ~s\n"  m)
   (set! to-require (cons m to-require)))
 
 (define (do-requires [ns (current-namespace)])
   (parameterize ([current-namespace ns])
     (for ([m (in-list to-require)]
           #:when m)
+      (eprintf "do-require ~s\n" m)
       (dynamic-require (module-path-index-join '(submod "." #%type-decl) m)
                        #f))))
 
@@ -17,10 +19,19 @@
     ;; FIXME: is this really the right code?
     #`(require (only-in #,(collapse-module-path-index (module-path-index-join '(submod "." #%type-decl) m))))))
 
+(define (do-contract-requires [ns (current-namespace)])
+  (parameterize ([current-namespace ns])
+    (for ([m (in-list to-require)]
+          #:when m)
+      (dynamic-require
+       (module-path-index-join '(submod "." #%contract-defs) m)
+       #f))))
+
 (define (get-contract-requires)
   (for/list ([m (in-list to-require)]
              #:when m)
     ;; FIXME: is this really the right code?
     #`(require (only-in #,(collapse-module-path-index (module-path-index-join '(submod "." #%contract-defs) m))))))
 
-(provide add-mod! do-requires get-requires get-contract-requires)
+(provide add-mod! do-requires get-requires
+         get-contract-requires do-contract-requires)

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -84,7 +84,7 @@
                  [(and (not (identifier? *res))
                        (popular? ty))
                   (define id (gensym))
-                  (enqueue! type-definitions #`(define #,id #,*res))
+                  (enqueue! type-definitions #`(define/decl #,id #,*res))
                   id]
                  [else *res]))
         (hash-set! type-cache ty res)

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -61,13 +61,15 @@
 ;; Compute for a given type how many times each type inside of it
 ;; is referenced
 (define (compute-popularity x)
+  (define v (hash-ref pop-table x 0))
   (when (Type? x)
-    (hash-update! pop-table x add1 0))
-  (when (Rep? x)
+    (hash-set! pop-table x (add1 v)))
+  (when (and (Rep? x) (zero? v))
     (Rep-for-each x compute-popularity)))
 
+;; types that are popular (referenced more than once) get their own definition
 (define (popular? ty)
-  (> (hash-ref pop-table ty 0) 5))
+  (> (hash-ref pop-table ty 0) 1))
 
 ;; Type -> S-Exp
 ;; Convert a type to an s-expression to evaluate
@@ -168,6 +170,15 @@
                                               (TrueProp:))
                                     (Empty:)))))))
      `(simple-> (list ,@(map type->sexp dom)) ,(type->sexp t))]
+    [(Fun: (list (Arrow: dom #f '()
+                         (Values:
+                          (list
+                           (Result: t
+                                    (PropSet: (TrueProp:)
+                                              (TrueProp:))
+                                    (Empty:))
+                           ...)))))
+     `(simple->values (list ,@(map type->sexp dom)) (list ,@(map type->sexp t)))]
     [(Fun: (list (Arrow: dom #f'()
                          (Values:
                           (list
@@ -197,7 +208,7 @@
      (match-define (Arrow: fdoms _ kws rng) (first arrs))
      (match-define (Arrow: ldoms rst _ _) (last arrs))
      (define opts (drop ldoms (length fdoms)))
-     `(opt-fn
+     `(opt-fn*
        (list ,@(map type->sexp fdoms))
        (list ,@(map type->sexp opts))
        ,(type->sexp rng)
@@ -275,10 +286,10 @@
                            `(quote ,n)))
                      ,(type->sexp b))]
     [(PolyRow-names: ns c b)
-     `(make-PolyRow (list ,@(for/list ([n (in-list ns)])
-                              `(quote ,n)))
-                    (quote ,c)
-                    ,(type->sexp b))]
+     `(make-PolyRow-simple (list ,@(for/list ([n (in-list ns)])
+                                     `(quote ,n)))
+                           (quote ,c)
+                           ,(type->sexp b))]
     [(Row: inits fields methods augments init-rest)
      `(make-Row (list ,@(convert-row-clause inits #t))
                 (list ,@(convert-row-clause fields))
@@ -292,6 +303,7 @@
                   (list ,@(convert-row-clause methods))
                   (list ,@(convert-row-clause augments))
                   ,(and init-rest (type->sexp init-rest)))]
+    [(Instance: (Name: n 0 #f)) `(simple-inst (quote-syntax ,n))]
     [(Instance: ty) `(make-Instance ,(type->sexp ty))]
     [(Signature: name extends mapping)
      (define (serialize-mapping m)
@@ -309,15 +321,9 @@
                  (list ,@(map type->sexp exports))
                  (list ,@(map type->sexp init-depends))
                  ,(type->sexp result))]
-    [(Arrow: dom #f '()
-             (Values: (list (Result: t (PropSet: (TrueProp:)
-                                                 (TrueProp:))
-                                     (Empty:)))))
-     `(-Arrow (list ,@(map type->sexp dom))
-              ,(type->sexp t))]
     [(Arrow: dom #f '() rng)
-     `(-Arrow (list ,@(map type->sexp dom))
-              ,(type->sexp rng))]
+     `(simple-arrow (list ,@(map type->sexp dom))
+                    ,(type->sexp rng))]
     [(Arrow: dom rest kws rng)
      `(make-Arrow
        (list ,@(map type->sexp dom))
@@ -460,7 +466,6 @@
      #`(add-struct-fn! (quote-syntax #,id)
                        #,(path-elem->sexp pe)
                        #,mut?))))
-
 ;; -> (Listof Syntax)
 ;; Construct syntax that does type environment serialization
 (define (make-env-init-codes)

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -399,8 +399,17 @@
         (if (from-typed? typed-side)
             (and/sc sc any-wrap/sc)
             sc))
+      (printf "predef: ~s ~s ~s\n" predef-contracts type typed-side)
       (cached-match
        sc-cache type typed-side
+       [(app (lambda (t) 
+               (hash-ref predef-contracts (cons t typed-side) #f))
+             (cons stx kind))
+        (printf "found a predefined-contract ~v\n" stx)
+        (case kind 
+          [(flat) (flat/sc stx)]
+          [(chaperone) (chaperone/sc stx)]
+          [(impersonator) (impersonator/sc stx)])]
        ;; Applications of implicit recursive type aliases
        ;;
        ;; We special case this rather than just resorting to standard
@@ -995,6 +1004,15 @@
   (define extflzero? (lambda (x) (extfl= x 0.0t0)))
   (define extflnonnegative? (lambda (x) (extfl>= x 0.0t0)))
   (define extflnonpositive? (lambda (x) (extfl<= x 0.0t0))))
+
+(module predefined-contracts racket/base
+  ;; this table maps (cons Type? typed-side?) -> (cons identifier? kind?)
+  ;; where the identifier can be used instead of generating a contract for the type
+  (define predef-contracts (make-hash))
+  (provide predef-contracts))
+
+(require (submod "." predefined-contracts))
+(hash-set! predef-contracts (cons Univ 'typed) (cons #'any/c 'flat))
 
 (module numeric-contracts racket/base
   (require

--- a/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
@@ -213,7 +213,7 @@
                 extra-defs
                 (for/list ([sc (in-list (reverse sc-queue))])
                   (match-define (cons id ctc) (hash-ref cache sc))
-                  #`(define/contract-decl #,id #,ctc '#,sc)))
+                  #`(define #,id #,ctc)))
         ctc))
 
 (module predefined-contracts racket/base
@@ -221,7 +221,7 @@
   ;; where the identifier can be used instead of generating a contract for the type
   (define predef-contracts (make-hash))
   (define-syntax-rule (define/contract-decl i ctc sc)
-    (begin #;(hash-set! predef-contracts sc #'i)
+    (begin (hash-set! predef-contracts sc #'i)
            (define i ctc)))
   (provide predef-contracts define/contract-decl))
 

--- a/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
@@ -27,6 +27,7 @@
      (parametric->/c (a) ((static-contract? (-> #:reason (or/c #f string?) a))
                           (contract-kind? #:cache hash?)
                           . ->* . (or/c a (list/c (listof syntax?) syntax?))))]
+ [function-contract? (-> syntax? boolean?)]
  [should-inline-contract? (-> syntax? boolean?)])
 
 
@@ -138,6 +139,8 @@
   ;; calls, which helps for inlining
   (define (recur sc [top-level? #f])
     (cond [(and cache (hash-ref cache sc #f)) => car]
+          ;; fixme: check for kind
+          [(hash-ref predef-contracts sc #f)]
           [(arr/sc? sc) (make-contract sc)]
           [(or (parametric->/sc? sc) (sealing->/sc? sc))
            (match-define (or (parametric->/sc: vars _)
@@ -152,14 +155,16 @@
           [(static-contract-may-contain-free-ids?) (make-contract sc)]
           [else
            (define ctc (make-contract sc))
-           (cond [(and ;; when a contract benefits from inlining
-                       ;; (e.g., ->) and this contract appears
-                       ;; directly in a define-module-boundary-contract
-                       ;; position (i.e, top-level? is #t) then
-                       ;; don't generate a new identifier for it
-                       (or (not (should-inline-contract? ctc))
-                           (not top-level?))
-                       cache)
+           (cond [(and
+                   cache
+                   ;; when a contract benefits from inlining
+                   ;; (e.g., ->) and this contract appears
+                   ;; directly in a define-module-boundary-contract
+                   ;; position (i.e, top-level? is #t) then
+                   ;; don't generate a new identifier for it
+                   (not (should-inline-contract? ctc))
+                   (or (not (function-contract? ctc))
+                       (not top-level?)))
                   (define fresh-id (generate-temporary))
                   (hash-set! cache sc (cons fresh-id ctc))
                   (set! sc-queue (cons sc sc-queue))
@@ -208,19 +213,40 @@
                 extra-defs
                 (for/list ([sc (in-list (reverse sc-queue))])
                   (match-define (cons id ctc) (hash-ref cache sc))
-                  #`(define #,id #,ctc)))
+                  #`(define/contract-decl #,id #,ctc '#,sc)))
         ctc))
+
+(module predefined-contracts racket/base
+  ;; this table maps (cons Type? typed-side?) -> (cons identifier? kind?)
+  ;; where the identifier can be used instead of generating a contract for the type
+  (define predef-contracts (make-hash))
+  (define-syntax-rule (define/contract-decl i ctc sc)
+    (begin #;(hash-set! predef-contracts sc #'i)
+           (define i ctc)))
+  (provide predef-contracts define/contract-decl))
+
+(require (submod "." predefined-contracts)
+         (for-template (submod "." predefined-contracts)))
 
 ;; Determine whether the given contract syntax should be inlined or not.
 (define (should-inline-contract? stx)
-  (or
-   ;; no need to generate an extra def for things that are already identifiers
-   (identifier? stx)
-   ;; ->* are handled specially by the contract system
-   (let ([sexp (syntax-e stx)])
-     (and (pair? sexp)
-          (or (free-identifier=? (car sexp) #'->)
-              (free-identifier=? (car sexp) #'->*))))))
+   (syntax-case stx (quote)
+     ;; no need to generate an extra def for things that are already identifiers
+     [i (identifier? #'i) #t]
+     [(quote i) (or (identifier? #'i)
+                    (boolean? (syntax-e #'i))
+                    (number? (syntax-e #'i)))
+      #t]
+      [_ #f]))
+
+(define (function-contract? stx)
+  (syntax-case stx ()
+    [(arr . _)
+     (and (identifier? #'arr)
+          (or (free-identifier=? #'arr #'->)
+              (free-identifier=? #'arr #'->*)))
+     #t]
+    [_ #f]))
 
 ;; determine if a given name is free in the sc
 (define (name-free-in? name sc)

--- a/typed-racket-lib/typed-racket/static-contracts/structures.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/structures.rkt
@@ -106,8 +106,13 @@
   ;; Returns the kind of contract that this represents
   ;; Returns #f if it is not a terminal contract
   [sc-terminal-kind sc]
+  ;; sc-type: static-contract? -> (or/c #f Type?)
+  ;; What type was this static contract generated from
+  ;; Produces #f if it wasn't directly from a type, or if not known
+  [sc-type sc]
   #:fallbacks
-  [(define (sc-terminal-kind v) #f)])
+  [(define (sc-terminal-kind v) #f)
+   (define (sc-type v) #f)])
 
 ;; Super struct of static contracts
 (struct static-contract ()
@@ -171,4 +176,5 @@
  [sc->constraints
   (static-contract? (static-contract? . -> . contract-restrict?) . -> . contract-restrict?)]
  [sc-terminal-kind (static-contract? . -> . (or/c #f contract-kind?))]
+ [sc-type (static-contract? . -> . any/c)]
  [sc? predicate/c])

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -479,6 +479,7 @@
       (define/with-syntax (new-defs ...) defs)
       (define/with-syntax (new-export-defs ...) export-defs)
       (define/with-syntax (new-provs ...) provs)
+      (do-contract-requires)
       (values
        #`(begin
            ;; This syntax-time submodule records all the types for all

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -498,6 +498,7 @@
                          typed-racket/env/global-env typed-racket/env/type-alias-env
                          typed-racket/types/struct-table typed-racket/types/abbrev
                          (rename-in racket/private/sort [sort raw-sort]))
+                #,@(get-requires)
                 #,@(make-env-init-codes)
                 #,@(for/list ([a (in-list aliases)])
                      (match-define (list from to) a)
@@ -554,6 +555,7 @@
            (module* #%contract-defs #f
              (#%plain-module-begin
               (#%declare #:empty-namespace) ;; avoid binding info from here
+              #,@(get-contract-requires)
               #,extra-requires
               new-defs ...)))
        #`(begin

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -41,6 +41,7 @@
 (define -evt make-Evt)
 (define -weak-box make-Weak-Box)
 (define -inst make-Instance)
+(define (simple-inst n) (make-Instance (make-Name n 0 #f)))
 (define (-prefab key . types)
   (make-Prefab (normalize-prefab-key key (length types)) types))
 (define -unit make-Unit)
@@ -136,6 +137,15 @@
 (define/decl -NonPosExtFlonum (Un -NegExtFlonum -ExtFlonumZero))
 (define/decl -ExtFlonum (Un -NegExtFlonumNoNan -ExtFlonumNegZero -ExtFlonumPosZero -PosExtFlonumNoNan -ExtFlonumNan))
 
+;; these decls are for popular types, putting them here means other modules
+;; don't have to define them
+(define/decl ->Void (-> -Void))
+(define/decl ->Bool (-> -Boolean))
+(define/decl ->String (-> -String))
+(define/decl ->Any (-> Univ))
+(define/decl ->Integer (-> -Int))
+(define/decl Any->Void (-> Univ -Void))
+
 ;; Type alias names
 (define (-struct-name name)
   (make-Name name 0 #t))
@@ -173,7 +183,18 @@
                                          #:kws kws))))))
 
 (define-syntax-rule (->opt args ... [opt ...] res)
-  (opt-fn (list args ...) (list opt ...) res))
+  (opt-fn* (list args ...) (list opt ...) res))
+
+;; these two definitions allow shorter expansion of types by avoid the keyword expansion
+(define (simple-opt-fn args opt-args result)
+  (opt-fn args opt-args result))
+
+(define-syntax opt-fn*
+  (syntax-rules ()
+    [(_ args opt-args result)
+     (simple-opt-fn args opt-args result)]
+    [(_ . args)
+     (opt-fn . args)]))
 
 ;; from define-new-subtype
 (define (-Distinction name sym ty)

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -197,6 +197,12 @@
 (define (simple-> doms rng)
   (->* doms rng))
 
+(define (simple-arrow doms rng)
+  (-Arrow doms rng))
+
+(define (simple->values doms rng)
+  (->* doms (make-Values (map -result rng))))
+
 (define (->acc dom rng path #:var [var (cons 0 0)])
   (define obj (-acc-path path (-id-path var)))
   (make-Fun
@@ -332,5 +338,9 @@
   (syntax-rules ()
     [(_ (var) consts ty)
      (let ([var (-v var)])
-       (make-PolyRow (list 'var) consts ty))]))
+       (make-PolyRow-simple (list 'var) consts ty))]))
+
+;; simplifies expansion
+(define (make-PolyRow-simple v c t)
+  (make-PolyRow v c t))
 

--- a/typed-racket-lib/typed-racket/utils/opaque-object.rkt
+++ b/typed-racket-lib/typed-racket/utils/opaque-object.rkt
@@ -129,14 +129,23 @@
             #:with method-names #'(list (quote name))
             #:with method-ctcs #'(list ctc))))
 
+(define-syntax static-append
+  (syntax-rules (list quote null)
+    [(_ (list (quote e) ...) ...) (quote (e ... ...))]
+    [(_ (list e ...) ...) (list e ... ...)]
+    [(_ (list) . rest) (static-append . rest)]
+    [(_ null . rest) (static-append . rest)]
+    [(_) '()]
+    [(_ . e) (append . e)]))
+
 (define-syntax (object/c-opaque stx)
   (syntax-parse stx
    [(_ ?clause:object/c-clause ...)
     (syntax/loc stx
-      (let ([names  (append ?clause.method-names ...)]
-            [ctcs   (append ?clause.method-ctcs ...)]
-            [fnames (append ?clause.field-names ...)]
-            [fctcs  (append ?clause.field-ctcs ...)])
+      (let ([names  (static-append ?clause.method-names ...)]
+            [ctcs   (static-append ?clause.method-ctcs ...)]
+            [fnames (static-append ?clause.field-names ...)]
+            [fctcs  (static-append ?clause.field-ctcs ...)])
         (base-object/c-opaque
          (dynamic-object/c names ctcs fnames fctcs)
          names ctcs fnames fctcs)))]))

--- a/typed-racket-lib/typed-racket/utils/tc-utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/tc-utils.rkt
@@ -280,7 +280,10 @@ don't depend on any other portion of the system
           (current-continuation-marks))))
 
 ;; are we currently expanding in a typed module (or top-level form)?
-(define typed-context? (box #f))
+(module typed-context '#%kernel
+  (#%provide typed-context?)
+  (define-values (typed-context?) (box #f)))
+(require (submod "." typed-context))
 
 ;; environment constructor
 (define-syntax (make-env stx)

--- a/typed-racket-more/typed/untyped-utils.rkt
+++ b/typed-racket-more/typed/untyped-utils.rkt
@@ -1,19 +1,26 @@
 #lang racket/base
 
+
+(module stxtime racket/base
+  (require (submod typed-racket/utils/tc-utils typed-context))
+  (define (syntax-local-typed-context?) (unbox typed-context?))
+  (provide syntax-local-typed-context?))
+
 (require (for-syntax racket/base
                      syntax/parse
                      syntax/stx
                      racket/syntax
                      typed-racket/utils/tc-utils
                      typed-racket/typecheck/renamer)
-         typed-racket/utils/tc-utils)
+         (submod "." stxtime)
+         (for-syntax (submod "." stxtime)))
 
 (provide syntax-local-typed-context?
+         (for-syntax syntax-local-typed-context?)
          define-typed/untyped-identifier
          require/untyped-contract)
 
-(define (syntax-local-typed-context?)
-  (unbox typed-context?))
+
 
 (define-syntax (define-typed/untyped-identifier stx)
   (syntax-parse stx


### PR DESCRIPTION
* Mark all multiply-referenced types as popular, but avoid
 extraneous popular types cause by them being contained in
 other popular types. Thanks to @mflatt for help with this.

* Create some more simple constructors to use in generated code.

* Define some popular types as pre-defined.

Together, this reduces the size of `framework-types.rkt`'s zo file by about
100k, and reduces its fully-expanded line count from 78k to 52k.