### PR TITLE
static-contracts: improve optimizer's test for flat scs

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -17,7 +17,7 @@
  racket/format
  syntax/flatten-begin
  (only-in (types abbrev) -Bottom -Boolean)
- (static-contracts instantiate optimize structures combinators constraints)
+ (static-contracts instantiate structures combinators constraints)
  (only-in (submod typed-racket/static-contracts/instantiate internals) compute-constraints)
  ;; TODO make this from contract-req
  (prefix-in c: racket/contract)
@@ -287,15 +287,14 @@
                         #:sc-cache [sc-cache (make-hash)])
   (let/ec escape
     (define (fail #:reason [reason #f]) (escape (init-fail #:reason reason)))
-    (instantiate
-     (optimize
-      (type->static-contract ty #:typed-side typed-side fail
-                             #:cache sc-cache)
-      #:trusted-positive typed-side
-      #:trusted-negative (not typed-side))
+    (instantiate/optimize
+     (type->static-contract ty #:typed-side typed-side fail
+                            #:cache sc-cache)
      fail
      kind
-     #:cache cache)))
+     #:cache cache
+     #:trusted-positive typed-side
+     #:trusted-negative (not typed-side))))
 
 (define any-wrap/sc (chaperone/sc #'any-wrap/c))
 

--- a/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
@@ -15,6 +15,7 @@
   "combinators/case-lambda.rkt"
   "combinators/parametric.rkt"
   "kinds.rkt"
+  "optimize.rkt"
   "parametric-check.rkt"
   "structures.rkt"
   "constraints.rkt"
@@ -23,12 +24,15 @@
 (provide static-contract-may-contain-free-ids?)
 
 (provide/cond-contract
+ [instantiate/optimize
+     (parametric->/c (a) ((static-contract? (-> #:reason (or/c #f string?) a))
+                          (contract-kind? #:cache hash? #:trusted-positive boolean? #:trusted-negative boolean?)
+                          . ->* . (or/c a (list/c (listof syntax?) syntax?))))]
  [instantiate
      (parametric->/c (a) ((static-contract? (-> #:reason (or/c #f string?) a))
-                          (contract-kind? #:cache hash?)
+                          (contract-kind? #:cache hash? #:recursive-kinds (or/c hash? #f))
                           . ->* . (or/c a (list/c (listof syntax?) syntax?))))]
  [should-inline-contract? (-> syntax? boolean?)])
-
 
 ;; Providing these so that tests can work directly with them.
 (module* internals #f
@@ -36,20 +40,37 @@
            compute-recursive-kinds
            instantiate/inner))
 
+(define (instantiate/optimize sc fail [kind 'impersonator] #:cache [cache #f] #:trusted-positive [trusted-positive #f] #:trusted-negative [trusted-negative #f])
+  (define recursive-kinds
+    (with-handlers [(exn:fail:constraint-failure?
+                    (lambda (exn)
+                      ;; Even if the constraints for `sc` are unsolvable,
+                      ;;  the optimizer might be able to reduce parts of
+                      ;;  `sc` to give a contract with solvable constraints.
+                      ;; This currently happens for the `Any-Syntax` type;
+                      ;;  eventually that won't happen for `Any-Syntax`,
+                      ;;  and at that point maybe we can fail here. -- Ben G.
+                      #f))]
+      (compute-recursive-kinds
+        (contract-restrict-recursive-values (compute-constraints sc kind)))))
+  (define sc/opt (optimize sc #:trusted-positive trusted-positive #:trusted-negative trusted-negative #:recursive-kinds recursive-kinds))
+  (instantiate sc/opt fail kind #:cache cache #:recursive-kinds recursive-kinds))
+
 ;; kind is the greatest kind of contract that is supported, if a greater kind would be produced the
 ;; fail procedure is called.
 ;;
 ;; The cache is used to share contract definitions across multiple calls to
 ;; type->contract in a given contract fixup pass. If it's #f then that means don't
 ;; do any sharing (useful for testing).
-(define (instantiate sc fail [kind 'impersonator] #:cache [cache #f])
+(define (instantiate sc fail [kind 'impersonator] #:cache [cache #f] #:recursive-kinds [recursive-kinds #f])
   (if (parametric-check sc)
       (fail #:reason "multiple parametric contracts are not supported")
       (with-handlers [(exn:fail:constraint-failure?
                         (lambda (exn) (fail #:reason (exn:fail:constraint-failure-reason exn))))]
         (instantiate/inner sc
-          (compute-recursive-kinds
-            (contract-restrict-recursive-values (compute-constraints sc kind)))
+          (or recursive-kinds
+              (compute-recursive-kinds
+                (contract-restrict-recursive-values (compute-constraints sc kind))))
           cache))))
 
 ;; computes the definitions that are in / used by `sc`

--- a/typed-racket-test/succeed/issue-628.rkt
+++ b/typed-racket-test/succeed/issue-628.rkt
@@ -1,0 +1,22 @@
+#lang racket/base
+
+;; Test that the `Spec` type can be converted to a contract that
+;;  successfully **runs**
+
+(module t typed/racket/base
+  (provide f g)
+
+  (define-type Spec
+    (-> (U Spec String)))
+
+  (: f (-> Spec))
+  (define (f)
+    (λ () "hello"))
+
+  (: g (-> (Rec T (-> (U T String)))))
+  (define (g)
+    (λ () "hello")))
+
+(require 't)
+
+(void f g)


### PR DESCRIPTION
This is one idea for fixing #628 .

I'm not happy about re-computing `recursive-kinds` in the optimizer,
but I don't see how to tell whether a `name/sc` is flat without it,
and I didn't see an easy way to share the optimizer's `recursive-kinds` with `instantiate.rkt`

- - -

Improve the static contract optimizer's ability to recognize flat contracts:

1. get the kind of all recursive, named contracts
2. any `name/sc` with `'flat` kind is a flat contract

Step 1 is repeated later in the `instantiate` pass.