### PR TITLE
static-contracts: functions always make chaperone contracts

### DIFF
--- a/typed-racket-lib/typed-racket/static-contracts/combinators/function.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/function.rkt
@@ -165,9 +165,9 @@
       ;; arity-0 functions end up being flat contracts when they're
       ;; from the typed side and the result is flat
       (if range-args
-          (merge-restricts* 'flat (map f range-args))
+          (merge-restricts* 'chaperone (map f range-args))
           (merge-restricts* 'flat null))
-      (merge-restricts* 'chaperone (map f args))))
+      (merge-restricts* 'chaperone (map f (append (or range-args '()) args)))))
 
 (define (function-sc-equal? a b recur)
   (match-define (function-combinator a-args a-indices a-mand-kws a-opt-kws a-typed-side?) a)

--- a/typed-racket-test/succeed/issue-628.rkt
+++ b/typed-racket-test/succeed/issue-628.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+
+;; Test that the `Spec` type can be converted to a contract that
+;;  successfully **runs**
+
+(module t typed/racket/base
+  (provide f)
+
+  (define-type Spec
+    (-> (U Spec String)))
+
+  (: f (-> Spec))
+  (define (f)
+    (λ () "hello")))
+
+(require 't)
+
+(void f)


### PR DESCRIPTION
This is one idea for fixing #628 

- - -

change `sc->constraints` for `function/sc` to always add a `chaperone` constraint,
because 0-arity functions with flat ranges do not always make flat contracts

(the contracts are only flat when the function contract is optimized to any/c)