### PR TITLE
fix parsing of refinements and type aliases

### DIFF
--- a/typed-racket-lib/typed-racket/env/type-alias-helper.rkt
+++ b/typed-racket-lib/typed-racket/env/type-alias-helper.rkt
@@ -111,15 +111,15 @@
   ;; recursive type aliases should be initialized.
   (define-values (type-alias-dependency-map type-alias-class-map)
     (for/lists (_1 _2)
-      ([entry (in-list type-alias-map)])
-      (match-define (cons name alias-info) entry)
+      ([(name alias-info) (in-assoc type-alias-map)])
       (define links-box (box null))
       (define class-box (box null))
-      (define type
-        (parameterize ([current-type-alias-name name]
-                       [current-referenced-aliases links-box]
-                       [current-referenced-class-parents class-box])
-          (parse-type (car alias-info))))
+      ;; parse types for effect
+      (parameterize ([current-type-alias-name name]
+                     [current-referenced-aliases links-box]
+                     [current-referenced-class-parents class-box]
+                     [check-type-invariants-while-parsing? #f])
+        (parse-type (car alias-info)))
       (define pre-dependencies
         (remove-duplicates (unbox links-box) free-identifier=?))
       (define (filter-by-type-alias-names names)

--- a/typed-racket-test/succeed/refinements-and-aliases.rkt
+++ b/typed-racket-test/succeed/refinements-and-aliases.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base #:with-refinements
+
+(define-type Pear (Pair Integer Integer))
+(define-type SomeVectorsInAPair (Pair (Vectorof String)
+                                      (Vectorof String)))
+
+(define-type Pear1
+  (Refine [p : Pear] (= (car p) 5)))
+
+(define-type Pear2
+  (Refine [p : Pear] (= (cdr p) 5)))
+
+(define-type Vec
+  (Refine [p : SomeVectorsInAPair]
+          (= (vector-length (car p))
+             (vector-length (cdr p)))))


### PR DESCRIPTION
Our current approach to parsing types parses them several times, first for effect and then again later.

I've added a parameter that allows us to turn off "invariant checking" while parsing, so that the initial parse isn't worrying about whether the propositions in refinements are well typed, etc.

These invariants are later enforced when we again parse the types w/o setting the parameter to false.

This fixes the issue @AlexKnauth  found and reported in #641.