### PR TITLE
more general linear exp stx for props

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/experimental.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/experimental.scrbl
@@ -72,11 +72,10 @@ on the values of terms.
            (linear-comp symbolic-object symbolic-object)]
           [linear-comp < <= = >= >]
           [symbolic-object exact-integer
-           linear-term
-           (+ linear-term linear-term ...)
-           (- linear-term linear-term ...)]
-          [linear-term symbolic-path
-           (* exact-integer symbolic-path)]
+           symbolic-path
+           (+ symbolic-object ...)
+           (- symbolic-object ...)
+           (* exact-integer symbolic-object)]
           [symbolic-path id
            (path-elem symbolic-path)]
           [path-elem car

--- a/typed-racket-test/unit-tests/parse-type-tests.rkt
+++ b/typed-racket-test/unit-tests/parse-type-tests.rkt
@@ -497,6 +497,10 @@
    [(Refine [x : Integer] (> x 42))
     (-refine/fresh x -Int (-leq (-lexp 43)
                                 (-lexp x)))]
+   [(Refine [n : Integer] (<= (- (+ n n) (* 1 (+ n)))
+                              (+ 2 (- 80 (* 2 (+ 9 9 (+) (-) 2))))))
+    (-refine/fresh x -Int (-leq (-lexp x)
+                                (-lexp 42)))]
    ;; id shadowing
    [(Refine [x : Any] (: x (Refine [x : Integer] (<= x 42))))
     (-refine/fresh x -Int (-leq (-lexp x)


### PR DESCRIPTION
The previous syntax for linear expressions in propositions/objects was too restrictive -- this makes it much more relaxed, which will allow users more freedom to naturally express constraints in types.