### PR TITLE
use tc-res when checking args are of correct type

### DIFF
--- a/typed-racket-test/succeed/refinements-quicksort.rkt
+++ b/typed-racket-test/succeed/refinements-quicksort.rkt
@@ -1,0 +1,103 @@
+#lang typed/racket/base #:with-refinements
+
+(: safe-vector-ref
+   (All (A) (-> ([v : (Vectorof A)]
+                 [n : Integer])
+                #:pre (v n) (<= 0 n (- (vector-length v) 1))
+                A)))
+(define safe-vector-ref vector-ref)
+
+(: safe-vector-set!
+   (All (A) (-> ([v : (Vectorof A)]
+                 [n : Natural]
+                 [a : A])
+                #:pre (v n) (< n (vector-length v))
+                Void)))
+(define safe-vector-set! vector-set!)
+
+
+(: quicksort! (-> (Vectorof Real) Void))
+(define (quicksort! A)
+  (quicksort-helper! A 0 (- (vector-length A) 1)))
+
+(: quicksort-helper! (-> ([A : (Vectorof Real)]
+                   [lo : Natural]
+                   [hi : Integer])
+                  #:pre (A lo hi)
+                  (and (<= lo (vector-length A))
+                       (< hi (vector-length A)))
+                  Void))
+(define (quicksort-helper! A lo hi)
+  (when (< lo hi)
+    (define pivot (partition! A lo hi))
+    (quicksort-helper! A lo (- pivot 1))
+    (quicksort-helper! A (+ pivot 1) hi)))
+
+
+(: swap! (-> ([A : (Vectorof Real)]
+              [i : Natural]
+              [j : Natural])
+             #:pre (A i j)
+             (and (< i (vector-length A))
+                  (< j (vector-length A)))
+             Void))
+(define (swap! A i j)
+  (define tmp (safe-vector-ref A i))
+  (safe-vector-set! A i (safe-vector-ref A j))
+  (safe-vector-set! A j tmp)) 
+
+
+
+(: partition! (-> ([A : (Vectorof Real)]
+                   [lo : Natural]
+                   [hi : Natural])
+                  #:pre (A lo hi)
+                  (< lo hi (vector-length A))
+                  (Refine [pivot : Natural]
+                          (<= lo pivot hi))))
+(define (partition! A lo hi)
+  (define pivot (safe-vector-ref A lo))
+  (let outer-loop!
+    ([i : (Refine [n : Natural] (< lo n))
+        (+ 1 lo)]
+     [j : (Refine [n : Natural] (and (<= n hi)
+                                     (<= lo n))) hi])
+    (let i-loop!
+      ([i : (Refine [n : Natural] (< lo n))
+          i])
+      (cond
+        [(and (<= i j)
+              (< (safe-vector-ref A i) pivot))
+         (i-loop! (+ i 1))]
+        [else
+         (let j-loop!
+           ([j : (Refine [n : Natural] (and (<= n hi)
+                                            (<= lo n))) j])
+           (cond
+             [(and (>= (safe-vector-ref A j) pivot)
+                   (>= j i))
+              (j-loop! (- j 1))]
+             [(> i j) (swap! A lo j)
+                      j]
+             [else
+              (swap! A i j)
+              (outer-loop! i j)]))]))))
+
+
+(: random-reals (-> Integer (Listof Real)))
+(define (random-reals n)
+  (build-list n (λ _ (ann (random 10000) Real))))
+
+(for ([_ (in-range 10000)])
+  (for ([size (in-range 23)])
+    (define l (random-reals size))
+    (define v (list->vector l))
+    (quicksort! v)
+    (define l* (vector->list v))
+    (unless (equal? (sort l <) l*)
+      (error "bad sort!: \n  expected: ~a\n  got: ~a\n\n"
+             l l*))))
+
+(define v : (Vectorof Real) (vector 0 5 9 12 3 0 4 6 3))
+(quicksort! v)
+v


### PR DESCRIPTION
while writing a version of quicksort w/ refinement types I hit a case where a recursive call to a loop was failing because it could not see that its arguments were well typed... even though it seemed _clear_ that the types were correct.

This change fixed that. However, now going back to the example (which has changed some) I cannot reproduce the error and confirm this fixes it =(

This still seems like a reasonable (i.e. sound, sensible) modification -- but I'm annoyed I don't have a code snippet that breaks without this commit and works with it.

May spend a little more time trying to recreate....