### PR TITLE
add regression test for (Sequenceof T)

### DIFF
--- a/typed-racket-test/succeed/sequenceof-integer.rkt
+++ b/typed-racket-test/succeed/sequenceof-integer.rkt
@@ -13,7 +13,15 @@
   (require (submod ".." typed))
   (define (bar) (foo 0)))
 
+(module contract-test typed/racket/base
+  (define b* : (Sequenceof (Boxof Integer)) (list (box 0)))
+  (provide b*))
+
 (require 'typed
-         'other-typed)
-(foo 0)
-(bar)
+         'other-typed
+         'contract-test
+         rackunit)
+(check-equal? (foo 0) "I got an integer: 0")
+(check-equal? (bar) "I got an integer: 0")
+(check-exn exn:fail:contract?
+  (λ () (set-box! (car b*) 'NaN)))


### PR DESCRIPTION
Tiny change: just add a regression test to make sure `(Sequenceof T)` generates a contract when it should.

