### PR TITLE
Fix location-info for rackunit

### DIFF
--- a/typed-racket-test/optimizer/known-bugs.rkt
+++ b/typed-racket-test/optimizer/known-bugs.rkt
@@ -30,11 +30,12 @@
      #`(test-case #,(format "~a" (syntax->datum #'exp))
          (define r-value (racket-eval #'exp))
          (define tr-value (tr-eval #'exp))
-         (with-check-info (['r-value r-value]
-                           ['tr-value tr-value]
-                           ['location (build-source-location-list (quote-syntax exp))])
-           (when (equal? r-value tr-value)
-             (fail-check "Known bug no longer exists."))))]))
+         (with-check-info* (list (make-check-info 'r-value r-value)
+                                 (make-check-info 'tr-value tr-value)
+                                 (make-check-location (build-source-location-list (quote-syntax exp))))
+           (λ ()
+             (when (equal? r-value tr-value)
+               (fail-check "Known bug no longer exists.")))))]))
 
 (define-syntax good-opt
   (syntax-parser

--- a/typed-racket-test/unit-tests/check-below-tests.rkt
+++ b/typed-racket-test/unit-tests/check-below-tests.rkt
@@ -41,33 +41,35 @@
     [(_ t1:expr t2:expr (~optional (~seq #:result expected-result:expr)
                                      #:defaults [(expected-result #'t2)]))
      #`(test-case (~a 't1 " <: " 't2)
-         (with-check-info (['location (build-source-location-list (quote-srcloc #,stx))]
-                           ['expected expected-result])
-           (define result (check-below t1 t2))
-           (with-check-info (['actual result])
-             (check-result result)
-             (unless (equal? expected-result result)
-               (fail-check "Check below did not return expected result.")))))]
+         (with-check-info* (list (make-check-location (build-source-location-list (quote-srcloc #,stx)))
+                                 (make-check-expected expected-result))
+           (λ ()
+             (define result (check-below t1 t2))
+             (with-check-info (['actual result])
+               (check-result result)
+               (unless (equal? expected-result result)
+                 (fail-check "Check below did not return expected result."))))))]
     [(_ #:fail (~optional message:expr #:defaults [(message #'#rx"type mismatch")])
         t1:expr t2:expr
         (~optional (~seq #:result expected-result:expr)
                      #:defaults [(expected-result #'t2)]))
      #`(test-case (~a 't1 " !<: " 't2)
-         (with-check-info (['location (build-source-location-list (quote-srcloc #,stx))]
-                           ['expected expected-result])
-           (define result
-             (parameterize ([delay-errors? #t])
-               (check-below t1 t2)))
-           (with-check-info (['actual result])
-             (define exn
-               (let/ec exit
-                 (with-handlers [(exn:fail? exit)]
-                   (report-all-errors)
-                   (fail-check "Check below did not fail."))))
-             (check-result result)
-             (unless (equal? expected-result result)
-               (fail-check "Check below did not return expected result."))
-             (check-regexp-match message (exn-message exn)))))]))
+         (with-check-info* (list (make-check-location (build-source-location-list (quote-srcloc #,stx)))
+                                 (make-check-expected expected-result))
+           (λ ()
+             (define result
+               (parameterize ([delay-errors? #t])
+                 (check-below t1 t2)))
+             (with-check-info (['actual result])
+               (define exn
+                 (let/ec exit
+                   (with-handlers [(exn:fail? exit)]
+                     (report-all-errors)
+                     (fail-check "Check below did not fail."))))
+               (check-result result)
+               (unless (equal? expected-result result)
+                 (fail-check "Check below did not return expected result."))
+               (check-regexp-match message (exn-message exn))))))]))
 
 
 (define tests

--- a/typed-racket-test/unit-tests/infer-tests.rkt
+++ b/typed-racket-test/unit-tests/infer-tests.rkt
@@ -145,20 +145,21 @@
     ([_ S:expr T:expr :vars :indices R:result :pass]
      (quasisyntax/loc stx
        (test-case (format "~a ~a~a" S T (if pass "" " should fail"))
-         (with-check-info (['location (build-source-location-list (quote-srcloc #,stx))])
-           (define substitution (infer vars indices S T R.v))
-           (define result (and substitution R.v (subst-all substitution R.v)))
-           (cond
-             [pass
-               (unless substitution
-                 (fail-check "Could not infer a substitution"))
-               (when result
-                 (with-check-info (['actual result] ['expected R.exp])
-                   (unless (equal? result R.exp)
-                     (fail-check "Did not infer the expected result."))))]
-             [fail
-               (when substitution
-                 (fail-check "Inferred an unexpected substitution."))])))))))
+         (with-check-info* (list (make-check-location (build-source-location-list (quote-srcloc #,stx))))
+           (λ ()
+             (define substitution (infer vars indices S T R.v))
+             (define result (and substitution R.v (subst-all substitution R.v)))
+             (cond
+               [pass
+                 (unless substitution
+                   (fail-check "Could not infer a substitution"))
+                 (when result
+                   (with-check-info (['actual result] ['expected R.exp])
+                     (unless (equal? result R.exp)
+                       (fail-check "Did not infer the expected result."))))]
+               [fail
+                 (when substitution
+                   (fail-check "Inferred an unexpected substitution."))]))))))))
 
 
 (define-syntax-rule (i2-t t1 t2 (a b) ...)

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -267,14 +267,15 @@
     ([_ name:expr body:expr ...]
      (quasisyntax/loc stx
        (test-case (format "~a ~a" (quote-line-number name) 'name)
-         (with-check-info (['location (build-source-location-list (quote-srcloc #,stx))])
-           (with-handlers ([cross-phase-failure?
-                            (λ (tf)
-                              (with-check-info*
-                                (cross-phase-failure-check-infos tf)
-                                (lambda ()
-                                  (fail-check (cross-phase-failure-message tf)))))])
-             (phase1-eval body ...))))))))
+         (with-check-info* (list (make-check-location (build-source-location-list (quote-srcloc #,stx))))
+           (λ ()
+             (with-handlers ([cross-phase-failure?
+                              (λ (tf)
+                                (with-check-info*
+                                  (cross-phase-failure-check-infos tf)
+                                  (lambda ()
+                                    (fail-check (cross-phase-failure-message tf)))))])
+               (phase1-eval body ...)))))))))
 
 
 ;;Constructs the syntax that calls eval and returns the answer to the user


### PR DESCRIPTION
Use `make-check-location` instead of building a `check-info` with a source location in it.

See the discussion under:
 https://github.com/racket/rackunit/pull/38

- - -

These are the only files in the main distribution + some packages that use `(with-check-info (('location ....)) ....)`

<details>
<summary>Packages:</summary>
<ul>
<li>PyonR</li>
<li>adjutor</li>
<li>alexis-util</li>
<li>anaphoric</li>
<li>aoc-racket</li>
<li>basedir</li>
<li>beautiful-racket</li>
<li>bnf</li>
<li>brag</li>
<li>colon-kw</li>
<li>compose-app</li>
<li>cover</li>
<li>css-tools</li>
<li>dan-scheme</li>
<li>debug-scopes</li>
<li>deinprogramm</li>
<li>draw</li>
<li>extensible-functions</li>
<li>frog</li>
<li>games</li>
<li>graph</li>
<li>gui</li>
<li>hackett</li>
<li>handin</li>
<li>htdp</li>
<li>intern</li>
<li>leibniz</li>
<li>macro-debugger</li>
<li>make</li>
<li>markdown</li>
<li>math</li>
<li>medic</li>
<li>megaparsack</li>
<li>msgpack</li>
<li>multi-file-lang</li>
<li>parsack</li>
<li>parser-tools</li>
<li>pfds</li>
<li>pict</li>
<li>plot</li>
<li>plt-web</li>
<li>pollen</li>
<li>ppict</li>
<li>r5rs</li>
<li>r6rs</li>
<li>racket-lang-org</li>
<li>racketscript</li>
<li>rackunit</li>
<li>raco-find-collection</li>
<li>rash</li>
<li>readline</li>
<li>redex</li>
<li>retry</li>
<li>sandbox-lib</li>
<li>scribble</li>
<li>scv</li>
<li>set-extras</li>
<li>shell-pipeline</li>
<li>sirmail</li>
<li>slideshow</li>
<li>sugar</li>
<li>sxml</li>
<li>syntax-warn</li>
<li>text-table</li>
<li>tr-performance</li>
<li>typed-racket</li>
<li>udelim</li>
<li>use.rkt</li>
<li>wrap</li>
<li>z3</li>
</ul>
</details>