### PR TITLE
unsafe-provide: unsafely provide other modules' exports

### DIFF
--- a/typed-racket-compatibility/info.rkt
+++ b/typed-racket-compatibility/info.rkt
@@ -11,4 +11,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.7")
+(define version "1.8")

--- a/typed-racket-doc/info.rkt
+++ b/typed-racket-doc/info.rkt
@@ -24,4 +24,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.7")
+(define version "1.8")

--- a/typed-racket-doc/typed-racket/scribblings/reference/unsafe.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/unsafe.scrbl
@@ -41,7 +41,9 @@ behavior and may even crash Typed Racket.
 
   Unlike @racket[provide], this form is unsafe and Typed Racket will not generate
   any contracts that correspond to the specified types. This means that uses of the
-  exports in other modules may circumvent the type system's invariants.
+  exports in other modules may circumvent the type system's invariants. In
+  particular, one typed module may unsafely provide identifiers imported from
+  another typed module.
 
   Additionally, importing an identififer that is exported with
   @racket[unsafe-provide] into another typed module, and then
@@ -70,7 +72,8 @@ behavior and may even crash Typed Racket.
     (eval:error (require 'u))
   ]
 
-  @history[#:added "1.3"]
+  @history[#:added "1.3"
+           #:changed "1.8" "Added support for re-provided typed variables"]
 }
 
 @defform[(unsafe-require/typed/provide m rt-clause ...)]{

--- a/typed-racket-lib/info.rkt
+++ b/typed-racket-lib/info.rkt
@@ -11,4 +11,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.7")
+(define version "1.8")

--- a/typed-racket-test/info.rkt
+++ b/typed-racket-test/info.rkt
@@ -28,7 +28,7 @@
 
 (define pkg-authors '(samth stamourv endobson asumu "andmkent@iu.edu"))
 
-(define version "1.7")
+(define version "1.8")
 
 
 ;; Collection info

--- a/typed-racket-test/succeed/unsafe-reprovide.rkt
+++ b/typed-racket-test/succeed/unsafe-reprovide.rkt
@@ -1,0 +1,34 @@
+#lang racket/base
+
+;; Test that a typed modules can unsafely provide another typed module's export
+
+;; A : safely provide a typed value
+(module A typed/racket/base
+  (define b : (Boxof Natural) (box 1))
+  (provide b))
+
+;; B : unsafely provide the value from A
+(module B typed/racket/base
+  (require typed/racket/unsafe)
+  (require (submod ".." A))
+  (unsafe-provide b))
+
+;; C : check that modules A and B export different identifiers that expand to the same identifier
+(module C typed/racket
+  (require (prefix-in A (submod ".." A)))
+  (require (prefix-in B (submod ".." B)))
+  (define-syntax (check-ids stx)
+    (syntax-case stx ()
+     [(_ a-id b-id)
+      (with-syntax ([different-before? (not (free-identifier=? #'a-id #'b-id))]
+                    [same-after? (free-identifier=? (local-expand #'a-id 'expression #f) (local-expand #'b-id 'expression #f))])
+        #'(values different-before? same-after?))]))
+  (define-values [different-before? same-after?] (check-ids Ab Bb))
+  (provide different-before? same-after?))
+
+(require 'B 'C rackunit)
+
+(check-not-exn (lambda () (set-box! b -1)))
+(check-equal? -1 (unbox b))
+(check-true different-before?)
+(check-true same-after?)

--- a/typed-racket/info.rkt
+++ b/typed-racket/info.rkt
@@ -11,4 +11,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.7")
+(define version "1.8")


### PR DESCRIPTION
Change `unsafe-provide` to un-rename any rename transformers that its asked to provide.

This means one typed module can safely provide some identifiers and, later, another typed module can import those identifier and UNSAFELY provide them.