### PR TITLE
fix overlap bug for Distinctions

### DIFF
--- a/typed-racket-lib/typed-racket/types/overlap.rkt
+++ b/typed-racket-lib/typed-racket/types/overlap.rkt
@@ -50,6 +50,7 @@
    [((or (B: _) (F: _)) _) #:no-order #t]
    [((Opaque: _) _) #:no-order #t]
    [((Name/simple: n) (Name/simple: n*)) #:when (free-identifier=? n n*) #t]
+   [((Distinction: _ _ t1) t2) #:no-order (overlap? t1 t2)]
    [(t1 (or (? Name? t2)
             (? App? t2)))
     #:no-order

--- a/typed-racket-test/fail/new-subtype-overlap.rkt
+++ b/typed-racket-test/fail/new-subtype-overlap.rkt
@@ -1,0 +1,11 @@
+#;
+(exn-pred 2)
+#lang typed/racket/base
+
+(define-new-subtype New-Int (new-int Integer))
+
+;; checks that the intersection of Int and New-Int is non-empty
+;; see https://github.com/racket/typed-racket/issues/662
+(ann (integer? (new-int 42)) Nothing)
+(ann (exact-integer? (new-int 42)) Nothing)
+ 


### PR DESCRIPTION
Fix `overlap?` so it recurs into Distinctions (see https://github.com/racket/typed-racket/issues/662).