### PR TITLE
Fix type of parse-command-line

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -3082,15 +3082,34 @@
 
 ;; Section 15.9 (racket/cmdline)
 [parse-command-line
- (let ([mode-sym (one-of/c 'once-each 'once-any 'multi 'final 'help-labels)])
-   (-polydots (b a)
-              (cl->* (-Pathlike
-                      (Un (-lst -String) (-vec -String))
-                      (-lst (Un (-pair mode-sym (-lst (-lst Univ)))
-                                (-pair (-val 'ps) (-lst -String))))
-                      ((list Univ) [a a] . ->... . b)
-                      (-lst -String)
-                      . -> . b))))]
+ (let ([mode-sym (one-of/c 'once-each 'once-any 'multi 'final)]
+       [label-sym (one-of/c 'ps 'help-labels 'usage-help)])
+   (-polydots
+    (b a) 
+    (cl->* (->opt -Pathlike
+                  (Un (-lst -String) (-vec -String))
+                  (-lst (Un (-pair mode-sym
+                                   (-lst (-lst* (-lst -String)
+                                                ;; Accepts flags procedures that take 0-5 mandatory
+                                                ;; command-line arguments and (implicitly)
+                                                ;; flag procedures that consume all remaining
+                                                ;; command-line argumets.
+                                                (Un (-> -String Univ)
+                                                    (-> -String -String Univ)
+                                                    (-> -String -String -String Univ)
+                                                    (-> -String -String -String -String Univ)
+                                                    (-> -String -String -String -String -String Univ)
+                                                    (-> -String -String -String -String -String -String Univ))
+                                                (-pair (Un -String (-lst -String))
+                                                       (-lst -String)))))
+                            (-pair label-sym
+                                   (-lst -String))))
+                  (->... (list (-lst Univ)) [-String a] b)
+                  (-lst -String)
+                  [(-> -String Univ)
+                   ;; Still permits unknown-proc args that accept rest arguments
+                   (-> -String Univ)]
+                  b))))] 
 
 ;; Section 16.1 (Weak Boxes)
 [make-weak-box (-poly (a) (-> a (-weak-box a)))]

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -3089,19 +3089,10 @@
     (cl->* (->opt -Pathlike
                   (Un (-lst -String) (-vec -String))
                   (-lst (Un (-pair mode-sym
-                                   (-lst (-lst* (-lst -String)
-                                                ;; Accepts flags procedures that take 0-5 mandatory
-                                                ;; command-line arguments and (implicitly)
-                                                ;; flag procedures that consume all remaining
-                                                ;; command-line argumets.
-                                                (Un (-> -String Univ)
-                                                    (-> -String -String Univ)
-                                                    (-> -String -String -String Univ)
-                                                    (-> -String -String -String -String Univ)
-                                                    (-> -String -String -String -String -String Univ)
-                                                    (-> -String -String -String -String -String -String Univ))
-                                                (-pair (Un -String (-lst -String))
-                                                       (-lst -String)))))
+                                   ;; With the `command-line` macro, the typechecker
+                                   ;; can't figure out that a type specifying the shape of
+                                   ;; the flag specification list would be satisfied.
+                                   (-lst Univ))
                             (-pair label-sym
                                    (-lst -String))))
                   (->... (list (-lst Univ)) [-String a] b)


### PR DESCRIPTION
1. Fix incorrect type for `'help-labels` specification

2. Add type for `'usage-help` specification

3. Support optional "help-proc" and "unknown-proc" arguments

4. Use more specific types for "finish-proc" and the flag specs

Closes #692