### PR TITLE
Improve contract-stronger for object/c-opaque

### DIFF
--- a/typed-racket-lib/typed-racket/utils/opaque-object.rkt
+++ b/typed-racket-lib/typed-racket/utils/opaque-object.rkt
@@ -39,6 +39,10 @@
 
 (provide object/c-opaque)
 
+(module+ for-testing
+  (provide restrict-typed->/c
+           restrict-typed-field/c))
+
 ;; projection for base-object/c-opaque
 (define ((object/c-opaque-late-neg-proj ctc) blame)
   (λ (obj neg-party)
@@ -172,7 +176,11 @@
         #:property prop:chaperone-contract
         (build-chaperone-contract-property
          #:name restrict-typed->-name
-         #:stronger equal?
+         #:stronger
+         (λ (this that)
+           (define this-name (restrict-typed->/c-name this))
+           (define that-name (restrict-typed->/c-name that))
+           (eq? this-name that-name))
          #:late-neg-projection restrict-typed->-late-neg-projection))
 
 (define (restrict-typed-field-late-neg-proj ctc)
@@ -198,5 +206,9 @@
         #:property prop:flat-contract
         (build-flat-contract-property
          #:name restrict-typed-field-name
-         #:stronger equal?
+         #:stronger
+         (λ (this that)
+           (define this-name (restrict-typed-field/c-name this))
+           (define that-name (restrict-typed-field/c-name that))
+           (eq? this-name that-name))
          #:late-neg-projection restrict-typed-field-late-neg-proj))

--- a/typed-racket-test/succeed/opaque-object-stronger.rkt
+++ b/typed-racket-test/succeed/opaque-object-stronger.rkt
@@ -1,5 +1,6 @@
 #lang racket
-(require typed-racket/utils/opaque-object)
+(require typed-racket/utils/opaque-object
+         (submod typed-racket/utils/opaque-object for-testing))
 
 ;; --------------------------------------------------------------------------------------------------
 ;; test helpers
@@ -183,4 +184,22 @@
       (field (x real?))
       (m1 (->m any/c any/c any/c))))
 
+)
+
+(let () ;; restrict-typed->/c and restrict-typed-field/c
+    (test-stronger?
+     (restrict-typed->/c 'foo)
+     (restrict-typed->/c 'foo))
+
+    (test-not-stronger?
+     (restrict-typed->/c 'foo)
+     (restrict-typed->/c 'bar))
+
+    (test-stronger?
+     (restrict-typed-field/c 'foo)
+     (restrict-typed-field/c 'foo))
+
+  (test-not-stronger?
+     (restrict-typed-field/c 'foo)
+     (restrict-typed-field/c 'bar))
 )

--- a/typed-racket-test/succeed/opaque-object-stronger.rkt
+++ b/typed-racket-test/succeed/opaque-object-stronger.rkt
@@ -203,3 +203,22 @@
      (restrict-typed-field/c 'foo)
      (restrict-typed-field/c 'bar))
 )
+
+(let ()
+  (define ctc
+    (object/c-opaque
+     (mtd (->m any/c any/c))))
+  (define (make-obj)
+    (new
+     (class object%
+       (super-new)
+       (define/public (mtd x) x)
+       (define/public (guts) #f))))
+  (define c1
+    (value-contract
+     (contract ctc (make-obj) 'p 'n)))
+  (define c2
+    (value-contract
+     (contract ctc (make-obj) 'p 'n)))
+  (test-stronger? c1 c2)
+  (test-stronger? c2 c1))


### PR DESCRIPTION
The previous implementation would never return #t since it would always be comparing two opaque structs. This version compares the names stored in the `restric-typed->/c` and `restrict-typed-field/c` structures and significantly improves performance in this program:

main.rkt

```
#lang typed/racket

(require/typed "automata.rkt"
  (make-random-automaton
    (-> (Instance Automaton))))

(define-type Automaton
  (Class
   [match-pair
    (-> (Instance Automaton) (Instance Automaton))]))

(for/fold ([a (make-random-automaton)])
          ([_ (in-range 7)])
  (send a match-pair a))
```

automata.rkt

```
#lang racket

(provide
 make-random-automaton)

(define (make-random-automaton)
  (new automaton%))

(define automaton%
  (class object%
    (super-new)

    (define/public (match-pair other) other)
      
    (define/public (guts) #f)
    ))
```

Before this commit running main.rkt takes  ~20 seconds, with this commit ~500ms