### PR TITLE
lift some work out ahead of the blame application in the opaque-object

### DIFF
--- a/typed-racket-lib/typed-racket/utils/opaque-object.rkt
+++ b/typed-racket-lib/typed-racket/utils/opaque-object.rkt
@@ -155,23 +155,17 @@
 ;; method is typed (assuming that the caller is untyped or the receiving
 ;; object went through untyped code)
 (define (((restrict-typed->-late-neg-projection ctc) blame) val neg-party)
-  (define blame+neg-party (cons blame neg-party))
-  (chaperone-procedure val
-                       (make-keyword-procedure
-                        (λ (_ kw-args . rst)
-                          (with-contract-continuation-mark
-                           blame+neg-party
-                           (when (typed-method? val)
+  (cond
+    [(typed-method? val)
+     (chaperone-procedure val
+                          (make-keyword-procedure
+                           (λ (_ kw-args . rst)
                              (raise-blame-error (blame-swap blame) val #:missing-party neg-party
                                                 "cannot call uncontracted typed method"))
-                           (apply values kw-args rst)))
-                        (λ args
-                          (with-contract-continuation-mark
-                           blame+neg-party
-                           (when (typed-method? val)
+                           (λ args
                              (raise-blame-error (blame-swap blame) val #:missing-party neg-party
-                                                "cannot call uncontracted typed method"))
-                           (apply values args))))))
+                                                "cannot call uncontracted typed method"))))]
+    [else val]))
 
 ;; Returns original method name
 (define (restrict-typed->-name ctc)


### PR DESCRIPTION
contract combinator

Combined with recent other improvements in racket/contract
(https://github.com/racket/racket/commit/bff0c4113d41ab35d8a7b5f7a4f19c3b453f79f7 and https://github.com/racket/racket/commit/2a1c8a78a59515d9f68bd1f98c1a26dec91ab6bf)
this change is about a 1.4x speedup on configuration 01000
of dungeon and about a 1.3x speedup on configuration 100000000
of acquire