### PR TITLE
Types for quasisyntax list splicing

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -290,12 +290,15 @@
   ;; check-in-port
   [(make-template-identifier 'check-in-port 'racket/private/for)
    (-> Univ Univ Univ)]
-  ;; from the expansion of `with-syntax'
+  ;; from the expansion of `with-syntax' or `quasisyntax'
   [(make-template-identifier 'apply-pattern-substitute 'racket/private/stxcase)
    (->* (list (-Syntax Univ) Univ) Univ (-Syntax Univ))]
   ;; same
   [(make-template-identifier 'with-syntax-fail 'racket/private/with-stx)
    (-> (-Syntax Univ) (Un))]
+  ; from `quasisyntax'
+  [(make-template-identifier 'check-splicing-list 'racket/private/qqstx)
+   (-> Univ (-Syntax Univ) (-Syntax Univ))]
   ;; more from with-syntax, a Guide is ...
   [(make-template-identifier 't-append 'racket/private/template)
    (-> (-lst (-Syntax Univ)) -Stxish -Stxish)]
@@ -313,7 +316,7 @@
    (-> Univ (-lst (-Syntax Univ)) (-Syntax Univ))]
   ;; ... or a Guide is ...
   [(make-template-identifier 'h-splice 'racket/private/template)
-   (-> Univ (Un (-val #f) (-Syntax Univ)) (Un (-val #f) (-Syntax Univ)) (-lst (-Syntax Univ)))]
+   (-> Univ (-pair -Symbol -Symbol) (Un (-val #f) (-Syntax Univ)) (-lst (-Syntax Univ)))]
   ;; ... or a Guide is ...
   [(make-template-identifier 't-subst 'racket/private/template)
    (->* (list (Un (-val #f) (-Syntax Univ)) (-Syntax Univ) Univ) Univ (-Syntax Univ))]

--- a/typed-racket-test/succeed/stx.rkt
+++ b/typed-racket-test/succeed/stx.rkt
@@ -56,3 +56,9 @@
 
 (module-or-top-identifier=? #'a #'b)
 
+(ann (let* ([ xs : (Listof Syntax) (list #'1 #'2)]
+            [ id : (-> Syntax Syntax) (λ (x) x)]
+            [ x  : (Syntaxof Any) #`(#,@(map id xs) #'foo)]
+            )
+       x)
+     (Syntaxof Any))


### PR DESCRIPTION
Corrects issue #703.

* Adds a type for check-splicing-list.
* Corrects an erroneous type for h-splice. It's called in exactly one place, where its 2nd argument looks like '(~@! . uqs5).