### PR TITLE
Adapt to a new expansion for optional arguments

### DIFF
--- a/typed-racket-lib/info.rkt
+++ b/typed-racket-lib/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '(("base" #:version "6.7.0.4")
+(define deps '(("base" #:version "6.90.0.29")
                "source-syntax"
                "compatibility-lib" ;; to assign types
                "string-constants-lib"))

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1208,6 +1208,8 @@
 [void (->* '() Univ -Void)]
 [void? (make-pred-ty -Void)]
 
+[unsafe-undefined -Unsafe-Undefined]
+
 ;; Section 5.2 (Structure Types)
 [make-struct-type
  (->opt -Symbol
@@ -3320,8 +3322,8 @@
  (-poly
   (a b)
   (cl->*
-   (->key (-lst a) (-> a a -Boolean) #:key (-> a a) #f #:cache-keys? -Boolean #f (-lst a))
-   (->key (-lst a) (-> b b -Boolean) #:key (-> a b) #f #:cache-keys? -Boolean #f (-lst a)))))
+   (->key (-lst a) (-> a a -Boolean) #:key (-opt (-> a a)) #f #:cache-keys? -Boolean #f (-lst a))
+   (->key (-lst a) (-> b b -Boolean) #:key (-opt (-> a b)) #f #:cache-keys? -Boolean #f (-lst a)))))
 (check-duplicates
  (-poly
   (a b c)
@@ -3344,8 +3346,8 @@
  (-poly
   (a b)
   (cl->*
-   (->optkey (-lst a) ((-> a a Univ)) #:key (-> a a) #f (-lst a))
-   (->optkey (-lst a) ((-> b b Univ)) #:key (-> a b) #f (-lst a)))))
+   (->optkey (-lst a) ((-> a a Univ)) #:key (-opt (-> a a)) #f (-lst a))
+   (->optkey (-lst a) ((-> b b Univ)) #:key (-opt (-> a b)) #f (-lst a)))))
 (open-input-file (->key -Pathlike
                         #:mode (one-of/c 'binary 'text) #f
                         #:for-module? Univ #f

--- a/typed-racket-lib/typed-racket/base-env/base-types.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-types.rkt
@@ -93,6 +93,7 @@
 
 [Void -Void]
 [Undefined -Undefined] ; initial value of letrec bindings
+;; [Unsafe-Undefined -Unsafe-Undefined] ; not clear that it makes sense to export this
 [Boolean -Boolean]
 [Symbol -Symbol]
 [String -String]

--- a/typed-racket-lib/typed-racket/rep/base-types.rkt
+++ b/typed-racket-lib/typed-racket/rep/base-types.rkt
@@ -6,6 +6,7 @@
 (require "../utils/utils.rkt"
          (rep rep-utils base-type-rep type-mask core-rep)
          racket/undefined
+         racket/unsafe/undefined
          (types numeric-predicates)
          racket/extflonum
          ;; for base type contracts and predicates
@@ -14,6 +15,7 @@
            racket/base
            racket/contract/base
            racket/undefined
+           racket/unsafe/undefined
            racket/extflonum
            (only-in racket/pretty pretty-print-style-table?)
            (only-in racket/udp udp?)
@@ -192,6 +194,10 @@
    Undefined
    #'(λ (x) (eq? x undefined))
    (λ (x) (eq? x undefined))]
+  [-Unsafe-Undefined
+   Unsafe-Undefined
+   #'(λ (x) (eq? x unsafe-undefined))
+   (λ (x) (eq? x unsafe-undefined))]
   [-ExtFlVector ExtFlVector #'extflvector? extflvector?]
   ;; 80-bit floating-point numbers
   ;; +nan.t is included in all 80-bit floating-point types

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -23,6 +23,7 @@
          syntax/id-table
          racket/contract
          racket/lazy-require
+         racket/unsafe/undefined
          (for-syntax racket/base
                      racket/syntax
                      syntax/parse))
@@ -695,6 +696,7 @@
      [(? void?) -Void]
      [0 -Zero]
      [1 -One]
+     [(? (lambda (x) (eq? x unsafe-undefined))) -Unsafe-Undefined]
      [_ (make-Value val)])])
 
 

--- a/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -249,8 +249,9 @@
            #:with props-core
                   (let* ([prop-val (attribute opt.value)]
                          [mand (add1 (car prop-val))]
-                         [opt  (cadr prop-val)])
-                    (opt-lambda-property #'opt-core (list mand opt)))
+                         [opt  (cadr prop-val)]
+                         [opt-supplied? (caddr prop-val)])
+                    (opt-lambda-property #'opt-core (list mand opt opt-supplied?)))
            #:with plam-core
                   (cond [(plambda-property this-syntax)
                          => (λ (plam) (plambda-property #'props-core plam))]

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-eq.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-eq.rkt
@@ -3,7 +3,7 @@
 (require "../../utils/utils.rkt"
          "signatures.rkt"
          "utils.rkt"
-         syntax/parse syntax/stx racket/match
+         syntax/parse syntax/stx racket/match racket/unsafe/undefined
          (typecheck signatures tc-funapp)
          (types abbrev prop-ops utils match-expanders)
          (rep type-rep object-rep)
@@ -38,7 +38,7 @@
 ;; typecheck eq? applications
 ;; identifier expr expr -> tc-results
 (define (tc/eq comparator v1 v2)
-  (define (eq?-able e) (or (boolean? e) (keyword? e) (symbol? e) (eof-object? e)))
+  (define (eq?-able e) (or (boolean? e) (keyword? e) (symbol? e) (eof-object? e) (eq? e unsafe-undefined)))
   (define (eqv?-able e) (or (eq?-able e) (number? e) (char? e)))
   (define (equal?-able e) #t)
   (define (id=? a b)

--- a/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
@@ -272,9 +272,9 @@
        (define conv-type
          (match expected
            [(tc-result1: fun-type)
-            (match-define (list required-pos optional-pos)
+            (match-define (list required-pos optional-pos optional-supplied?)
                           (attribute opt.value))
-            (opt-convert fun-type required-pos optional-pos)]
+            (opt-convert fun-type required-pos optional-pos optional-supplied?)]
            [_ #f]))
        (if conv-type
            (begin (tc-expr/check/type #'fun conv-type) expected)

--- a/typed-racket-lib/typed-racket/types/kw-types.rkt
+++ b/typed-racket-lib/typed-racket/types/kw-types.rkt
@@ -11,8 +11,10 @@
 
 
 (define (convert keywords ; (listof Keyword?)
+                 kw-opts-supplied ; (listof Keyword?)
                  mandatory-arg-types ; (listof Type?)
                  optional-arg-types ; (listof Type?)
+                 pos-opts-supplied? ; (or/c (listof Boolean?) #f)
                  rng ; SomeValues?
                  maybe-rst ; (or/c #f Type? RestDots?)
                  split?) ; boolean?
@@ -35,31 +37,42 @@
           (for/list ([k (in-list sorted-kws)])
             (match k
               [(Keyword: _ t #t) t]
-              [(Keyword: _ t #f) (list (-opt t) -Boolean)]))
+              [(Keyword: kw t #f) (if (member kw kw-opts-supplied)
+                                      t
+                                      (Un t -Unsafe-Undefined))]))
           mandatory-arg-types
-          (for/list ([t (in-list optional-arg-types)]) (-opt t))
-          (for/list ([t (in-list optional-arg-types)]) -Boolean)
+          (for/list ([t (in-list optional-arg-types)]
+                     [supplied? (in-list pos-opts-supplied?)])
+            (if supplied?
+                t
+                (Un t -Unsafe-Undefined)))
           rst-type)))
+
       (list (-Arrow ts rng))]
      [else
-      ;; The keyword argument types including boolean flags for
+      ;; The keyword argument types, including undefined option for
       ;; optional keyword arguments
       (define kw-args
         (for/fold ([pos '()])
                   ([k (in-list (reverse sorted-kws))])
           (match k
-            ;; mandatory keyword arguments have no extra args
+            ;; mandatory keyword arguments have no extra type option
             [(Keyword: _ t #t) (cons t pos)]
-            ;; we can safely assume 't' and not (-opt t) here
-            ;; because if the keyword is not provided, the value
-            ;; will only appear in dead code (i.e. where the kw-flag arg is #f)
-            ;; within the body of the function
-            [(Keyword: _ t #f) (list* t -Boolean pos)])))
+            ;; optional keyword arguments might be always supplied
+            ;; in the expansion
+            [(Keyword: kw t #f)
+             (if (member kw kw-opts-supplied)
+                 (cons t pos) ; keyword always supplied by expansion, so no unsafe-undefined check
+                 (cons (Un t -Unsafe-Undefined) pos))])))
 
-      ;; Add boolean arguments for the optional type flaggs.
-      (define opt-flags (make-list (length optional-arg-types) -Boolean))
+      (define updated-optional-arg-types
+        (for/list ([t (in-list optional-arg-types)]
+                   [supplied? (in-list pos-opts-supplied?)])
+          (if supplied?
+              t
+              (Un t -Unsafe-Undefined))))
 
-      (list (-Arrow (append kw-args mandatory-arg-types optional-arg-types opt-flags rst-type)
+      (list (-Arrow (append kw-args mandatory-arg-types updated-optional-arg-types rst-type)
                     rng))])))
 
 ;; This is used to fix the props of keyword types.
@@ -88,7 +101,8 @@
 ;; keywords list. This allows the typechecker to check some branches of the
 ;; type that match the actual kws. Add extra actual keywords with Bottom type.
 (define (handle-extra-or-missing-kws kws actual-kws)
-  (match-define (lambda-kws actual-mands actual-opts) actual-kws)
+  (match-define (lambda-kws actual-mands actual-opts actual-opts-supplied actual-pos-opts-supplied?)
+    actual-kws)
   (define expected-kws (map Keyword-kw kws))
   (define missing-removed
     (filter
@@ -156,9 +170,16 @@
           (define kws* (if actual-kws
                            (handle-extra-or-missing-kws kws actual-kws)
                            kws))
+          (define kw-opts-supplied (if actual-kws
+                                       (lambda-kws-opt-supplied actual-kws)
+                                       '()))
           (convert kws*
+                   kw-opts-supplied
                    (take dom mand-arg-count)
                    (drop dom mand-arg-count)
+                   (if actual-kws
+                       (lambda-kws-pos-opt-supplied? actual-kws)
+                       (make-list (- (length dom) mand-arg-count) #f))
                    rng
                    rst
                    split?)]))))
@@ -203,32 +224,13 @@
       ;; if min and max both have rest args, then there cannot
       ;; have been any optional arguments
       [(_ _ non-kw:id ... . rst:id) 0]))
-  ;; counted twice since optionals expand to two arguments
-  (define non-kw-argc (+ raw-non-kw-argc opt-non-kw-argc))
-  (define mand-non-kw-argc (- non-kw-argc (* 2 opt-non-kw-argc)))
+  (define non-kw-argc raw-non-kw-argc)
+  (define mand-non-kw-argc (- non-kw-argc opt-non-kw-argc))
   (match ft
     [(Fun: arrs)
-     (cond [(= (length arrs) 1) ; no optional args (either kw or not)
-            (match-define (Arrow: doms _ _ rng) (car arrs))
-            (define kw-length
-              (- (length doms) (+ non-kw-argc (if rest? 1 0))))
-            (define-values (kw-args other-args) (split-at doms kw-length))
-            (define actual-kws
-              (for/list ([kw (in-list keywords)]
-                         [kw-type (in-list kw-args)])
-                (make-Keyword kw kw-type #t)))
-            (define rest-type
-              (and rest? (last other-args)))
-            (make-Fun
-             (list (-Arrow (take other-args non-kw-argc)
-                           (erase-props/Values rng)
-                           #:kws actual-kws
-                           #:rest rest-type)))]
-           [(and (even? (length arrs)) ; had optional args
-                 (>= (length arrs) 2))
+     (cond [(positive? (length arrs))
             ;; assumption: only one arr is needed, since the types for
-            ;; the actual domain are the same (the difference is in the
-            ;; second type for the optional keyword protocol)
+            ;; the actual domain are the same
             (match-define (Arrow: doms _ _ rng) (car arrs))
             (define kw-length
               (- (length doms) (+ non-kw-argc (if rest? 1 0))))
@@ -256,7 +258,8 @@
 ;; the type that we've given. Allows for better error messages than just
 ;; relying on tc-expr. Return #f if the function shouldn't be checked.
 (define (check-kw-arity kw-prop f-type)
-  (match-define (lambda-kws actual-mands actual-opts) kw-prop)
+  (match-define (lambda-kws actual-mands actual-opts actual-opts-supplied actual-pos-opts-supplied?)
+    kw-prop)
   (define arrs
     (match f-type
       [(AnyPoly-names: _ _ (Fun: arrs)) arrs]))
@@ -306,36 +309,39 @@
            (loop (cdr kw-args) (cdr keywords)
                  (cons (make-Keyword (car keywords) (car kw-args) #t)
                        kw-types))]
-          [else ; optional, so there are two arg types
-           (loop (cddr kw-args) (cdr keywords)
+          [else ; optional
+           (loop (cdr kw-args) (cdr keywords)
                  (cons (make-Keyword (car keywords) (car kw-args) #f)
                        kw-types))])))
 
-(define ((opt-convert-arr required-pos optional-pos) arr)
+(define (opt-convert-arr required-pos optional-pos optional-supplied? arr)
   (match arr
     [(Arrow: args #f '() result)
      (define num-args (length args))
-     (and (>= num-args required-pos)
-          (<= num-args (+ required-pos optional-pos))
+     (and (= num-args (+ required-pos optional-pos))
           (let* ([required-args (take args required-pos)]
-                 [opt-args (drop args required-pos)]
-                 [missing-opt-args (- (+ required-pos optional-pos) num-args)]
-                 [present-flags (map (λ (t) (-val #t)) opt-args)]
-                 [missing-args (make-list missing-opt-args (-val #f))])
+                 [opt-args (for/list ([arg (in-list (drop args required-pos))]
+                                      [supplied? (in-list optional-supplied?)])
+                             (if supplied?
+                                 arg
+                                 (Un -Unsafe-Undefined arg)))])
             (-Arrow (append required-args
-                            opt-args
-                            missing-args
-                            present-flags
-                            missing-args)
+                            opt-args)
                     result)))]
     [_ #f]))
 
-(define (opt-convert ft required-pos optional-pos)
+(define (opt-convert ft required-pos optional-pos optional-supplied?)
   (let loop ([ft ft])
     (match ft
       [(Fun: arrs)
-       (let ([arrs (map (opt-convert-arr required-pos optional-pos) arrs)])
-         (and (andmap values arrs)
+       ;; We expect only one of `arrs` to have all optional arguments, but
+       ;; accomodate multiple of them
+       (let ([arrs (for*/list ([arr (in-list arrs)]
+                               [new-arr (in-value
+                                         (opt-convert-arr required-pos optional-pos optional-supplied? arr))]
+                               #:when new-arr)
+                     new-arr)])
+         (and (pair? arrs)
               (make-Fun arrs)))]
       [(Poly-names: names f)
        (match (loop f)
@@ -374,7 +380,7 @@
   (define mand-argc (- argc (* 2 opt-argc)))
   (match ft
     [(Fun: arrs)
-     (cond [(and (even? (length arrs)) (>= (length arrs) 2))
+     (cond [(= 1 (length arrs))
             (match-define (Arrow: doms _ _ rng) (car arrs))
             (define-values (mand-args opt-and-rest-args)
               (split-at doms mand-argc))

--- a/typed-racket-lib/typed-racket/types/match-expanders.rkt
+++ b/typed-racket-lib/typed-racket/types/match-expanders.rkt
@@ -5,6 +5,7 @@
          racket/match
          syntax/parse/define
          racket/set
+         racket/unsafe/undefined
          (types resolve base-abbrev)
          (for-syntax racket/base syntax/parse))
 
@@ -44,6 +45,7 @@
     [(== -False) (box-immutable #f)]
     [(== -Zero) (box-immutable 0)]
     [(== -One) (box-immutable 1)]
+    [(== -Unsafe-Undefined) (box-immutable unsafe-undefined)]
     [_ #f]))
 
 ;; matches types that correspond to singleton values

--- a/typed-racket-test/unit-tests/keyword-expansion-test.rkt
+++ b/typed-racket-test/unit-tests/keyword-expansion-test.rkt
@@ -21,15 +21,15 @@
 
 (define-syntax-rule (t-opt ((req-arg ...) (opt-arg ...)) expected)
   (let ()
+    (define (get-false v) #f)
     (test-equal? (format "~a" '(opt-convert (->opt req-arg ... (opt-arg ...) result) expected))
                  (extract-arrs
                    (opt-convert (->opt req-arg ... (opt-arg ...) result)
                                 (length (list 'req-arg ...))
-                                (length (list 'opt-arg ...))))
+                                (length (list 'opt-arg ...))
+                                (list (get-false 'opt-arg) ...)))
                  (extract-arrs expected))))
 
-
-(define flag -Boolean)
 (define true (-val #t))
 (define false (-val #f))
 (define result (-val 'result))
@@ -37,6 +37,7 @@
 (define two (-val 'two))
 (define three (-val 'three))
 (define four (-val 'four))
+(define (-or-undefined t) (Un -Unsafe-Undefined t))
 
 (define tests
   (test-suite "Tests for keyword expansion"
@@ -47,11 +48,11 @@
     [t (-> one two three four result)
        (-> one two three four result)]
     [t (->opt (one) result)
-       (-> (-opt one) flag result)]
+       (-> (-or-undefined one) result)]
     [t (->opt (one two) result)
-       (-> (-opt one) (-opt two) flag flag result)]
+       (-> (-or-undefined one) (-or-undefined two) result)]
     [t (->opt one (two three) result)
-       (-> one (-opt two) (-opt three) flag flag result)]
+       (-> one (-or-undefined two) (-or-undefined three) result)]
 
     [t-opt (() ()) (-> result)]
     [t-opt ((one) ())
@@ -59,17 +60,9 @@
     [t-opt ((one two three four) ())
        (-> one two three four result)]
     [t-opt (() (one))
-           (cl->*
-             (-> one true result)
-             (-> false false result))]
+           (-> (-or-undefined one) result)]
     [t-opt (() (one two))
-           (cl->*
-             (-> one two true true result)
-             (-> one false true false result)
-             (-> false false false false result))]
+           (-> (-or-undefined one) (-or-undefined two) result)]
     [t-opt ((one) (two three))
-           (cl->*
-             (-> one two three true true result)
-             (-> one two false true false  result)
-             (-> one false false false false result))]
+           (-> one (-or-undefined two) (-or-undefined three) result)]
     ))


### PR DESCRIPTION
Goes with racket/racket#2060, and requires #705.