### PR TITLE
repair problems with optional-argument handling

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
+++ b/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
@@ -11,8 +11,8 @@
 ;; ----------------
 ;;
 ;; A LambdaKeywords is a
-;;   (lambda-kws (Listof Keyword) (Listof Keyword) (Listof Keyword) (listof Boolean))
-(struct lambda-kws (mand opt opt-supplied pos-opt-supplied?))
+;;   (lambda-kws (Listof Keyword) (Listof Keyword) (Listof Keyword) Integer (listof Boolean))
+(struct lambda-kws (mand opt opt-supplied pos-mand-count pos-opt-supplied?))
 
 ;; interp.
 ;;   - the first list contains the mandatory keywords
@@ -276,6 +276,12 @@
                      (values (cons (syntax-e kw) mand-kws)
                              opt-kws
                              opt-kws-supplied))))
+             (define pos-mand-count
+               (for/sum ([kw (in-list kws)]
+                         [default (in-list defaults)]
+                         #:unless default
+                         #:unless kw)
+                 1))
              (define pos-opt-supplied?s
                (for/list ([kw (in-list kws)]
                           [default (in-list defaults)]
@@ -284,7 +290,7 @@
                  (immediate-default? default)))
              (and (or (not (null? mand-kws))
                       (not (null? opt-kws)))
-                  (lambda-kws mand-kws opt-kws opt-kws-supplied pos-opt-supplied?s)))
+                  (lambda-kws mand-kws opt-kws opt-kws-supplied pos-mand-count pos-opt-supplied?s)))
            #:attr opt-property
            (list (length (attribute mand))
                  (length (attribute opt))

--- a/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -13,6 +13,7 @@
          "signatures.rkt"
          (private parse-type syntax-properties)
          (env lexical-env tvar-env global-env type-alias-helper mvar-env)
+         (base-env annotate-classes)
          (types utils abbrev subtype resolve generalize)
          (typecheck check-below internal-forms)
          (utils tc-utils mutated-vars)
@@ -233,7 +234,11 @@
                  kw:kw-lambda^)
            #:do [(register/method #'meth-name)]
            #:with props-core
-                  (kw-lambda-property #'kw-core (attribute kw.value))
+                  (let ([kw-val (attribute kw.value)])
+                    (kw-lambda-property
+                     #'kw-core
+                     (struct-copy lambda-kws kw-val
+                                  [pos-mand-count (add1 (lambda-kws-pos-mand-count kw-val))])))
            #:with plam-core
                   (cond [(plambda-property this-syntax)
                          => (λ (plam) (plambda-property #'props-core plam))]

--- a/typed-racket-test/succeed/opt-arg-test.rkt
+++ b/typed-racket-test/succeed/opt-arg-test.rkt
@@ -16,3 +16,30 @@
 
 (add1 (f 0))
 (add1 (f))
+
+;; ----------------------------------------
+
+;; Can forget an optional argument:
+(: f2 (-> Integer Integer))
+(define (f2 x [y 0])
+  (+ x y))
+
+;; Same, with non-immediate default:
+(: f2/n (-> Integer Integer))
+(define (f2/n x [y (+ 1 0)])
+  (+ x y))
+
+;; Can forget an optional keyword argument:
+(: f3 (-> Integer Integer))
+(define (f3 x #:y [y 0])
+  (+ x y))
+
+;; Same, with non-immediate default:
+(: f3/n (-> Integer Integer))
+(define (f3/n x #:y [y (+ 1 0)])
+  (+ x y))
+
+;; Mix by-position, by-keyword, and [non-]immediate:
+(: f4 (-> Integer Integer))
+(define (f4 x [y1 0] [y2 (+ 1 0)] #:z1 [z1 0] #:z2 [z2 (+ 1 0)])
+  (+ x y1 y2 z1 z2))

--- a/typed-racket-test/unit-tests/keyword-expansion-test.rkt
+++ b/typed-racket-test/unit-tests/keyword-expansion-test.rkt
@@ -58,11 +58,19 @@
     [t-opt ((one) ())
            (-> one result)]
     [t-opt ((one two three four) ())
-       (-> one two three four result)]
+           (-> one two three four result)]
     [t-opt (() (one))
-           (-> (-or-undefined one) result)]
+           (cl->*
+            (-> -Unsafe-Undefined result)
+            (-> (-or-undefined one) result))]
     [t-opt (() (one two))
-           (-> (-or-undefined one) (-or-undefined two) result)]
+           (cl->*
+            (-> -Unsafe-Undefined -Unsafe-Undefined result)
+            (-> (-or-undefined one) -Unsafe-Undefined result)
+            (-> (-or-undefined one) (-or-undefined two) result))]
     [t-opt ((one) (two three))
-           (-> one (-or-undefined two) (-or-undefined three) result)]
+           (cl->*
+            (-> one -Unsafe-Undefined -Unsafe-Undefined result)
+            (-> one (-or-undefined two) -Unsafe-Undefined result)
+            (-> one (-or-undefined two) (-or-undefined three) result))]
     ))

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -4712,6 +4712,154 @@
           (void))
         #:ret (ret -Void #f #f)
         #:msg #rx"Bad arguments to function"]
+
+       ;; optional arg bad default non-immediate
+       [tc-err (let ()
+               (: f (-> Number Number))
+               (tr:define (f x [y (string-append "x" "y")])
+                 (+ x y))
+               (void))
+             #:ret (ret -Void #f #f)
+             #:msg #rx"expected: Number"]
+       ;; optional arg bad default immediate
+       [tc-err (let ()
+                 (: f (-> Number Number))
+                 (tr:define (f x [y 'y])
+                   (+ x y))
+                 (void))
+               #:ret (ret -Void #f #f)
+               #:msg #rx"expected: Number"]
+       ;; optional kw arg bad default non-immediate
+       [tc-err (let ()
+                 (: f (-> Number Number))
+                 (tr:define (f x #:y [y (string-append "x" "y")])
+                   (+ x y))
+                 (void))
+               #:ret (ret -Void #f #f)
+               #:msg #rx"expected: Number"]
+       ;; optional kw arg bad default immediate
+       [tc-err (let ()
+                 (: f (-> Number Number))
+                 (tr:define (f x #:y [y 'y])
+                   (+ x y))
+                 (void))
+               #:ret (ret -Void #f #f)
+               #:msg #rx"expected: Number"]
+       ;; type omits optional argument (immediate):
+       [tc-e
+        (let ()
+          (: foo (-> Number Number))
+          (tr:define (foo x [y 0])
+            (+ x y))
+          (void))
+        -Void]
+       ;; type omits optional argument (non-immediate):
+       [tc-e
+        (let ()
+          (: f (-> Number Number))
+          (tr:define (f x [y (+ 1 0)])
+            (+ x y))
+          (void))
+        -Void]
+       ;; type omits optional kw argument (immediate):
+       [tc-e
+        (let ()
+          (: f (-> Number Number))
+          (tr:define (f x #:y [y 0])
+            (+ x y))
+          (void))
+        -Void]
+       ;; type omits optional kw argument (non-immediate):
+       [tc-e
+        (let ()
+          (: f (-> Number Number))
+          (tr:define (f x #:y [y (+ 1 0)])
+            (+ x y))
+          (void))
+        -Void]
+       ;; Mix by-position, by-keyword, and [non-]immediate:
+       [tc-e
+        (let ()
+          (: f (-> Number Number))
+          (tr:define (f x
+                     [y1 0]
+                     [y2 (+ 1 0)]
+                     #:z1 [z1 0]
+                     #:z2 [z2 (+ 1 0)])
+            (+ x y1 y2 z1 z2))
+          (void))
+        -Void]
+       [tc-e
+        (let ()
+          (: f (-> Number Number Number))
+          (tr:define (f x
+                     [y1 0]
+                     [y2 (+ 1 0)]
+                     #:z1 [z1 0]
+                     #:z2 [z2 (+ 1 0)])
+            (+ x y1 y2 z1 z2))
+          (void))
+        -Void]
+       [tc-e
+        (let ()
+          (: f (-> Number Number Number Number))
+          (tr:define (f x
+                     [y1 0]
+                     [y2 (+ 1 0)]
+                     #:z1 [z1 0]
+                     #:z2 [z2 (+ 1 0)])
+            (+ x y1 y2 z1 z2))
+          (void))
+        -Void]
+       [tc-e
+        (let ()
+          (: f (->* (Number) (#:z1 Number) Number))
+          (tr:define (f x
+                     [y1 0]
+                     [y2 (+ 1 0)]
+                     #:z1 [z1 0]
+                     #:z2 [z2 (+ 1 0)])
+            (+ x y1 y2 z1 z2))
+          (void))
+        -Void]
+       [tc-e
+        (let ()
+          (: f (->* (Number) (Number #:z1 Number) Number))
+          (tr:define (f x
+                     [y1 0]
+                     [y2 (+ 1 0)]
+                     #:z1 [z1 0]
+                     #:z2 [z2 (+ 1 0)])
+            (+ x y1 y2 z1 z2))
+          (void))
+        -Void]
+       [tc-e
+        (let ()
+          (: f (->* (Number)
+                    (Number
+                     Number
+                     #:z1 Number
+                     #:z2 Number)
+                    Number))
+          (tr:define (f x
+                     [y1 0]
+                     [y2 (+ 1 0)]
+                     #:z1 [z1 0]
+                     #:z2 [z2 (+ 1 0)])
+            (+ x y1 y2 z1 z2))
+          (void))
+        -Void]
+       [tc-e
+        (let ()
+          (: f (-> Number Number))
+          (tr:define (f x
+                     [y1 0]
+                     [y2 (+ 1 0)]
+                     #:z1 [z1 0]
+                     #:z2 [z2 (+ 1 0)])
+            (+ x y1 y2 z1 z2))
+          (void))
+        -Void]
        )
 
   (test-suite


### PR DESCRIPTION
Intended as a repair for #710.

The last definition in the updated "opt-arg-test.rkt" does not typecheck in v6.12, but I'm pretty sure it should (as it now does).