### PR TITLE
static-contract: improve `or/sc` optimization

### DIFF
--- a/typed-racket-test/unit-tests/static-contract-instantiate-tests.rkt
+++ b/typed-racket-test/unit-tests/static-contract-instantiate-tests.rkt
@@ -22,7 +22,7 @@
          #`(let () #,@(car defs+ctc) #,(cadr defs+ctc))))]))
 
 (define tests
-  (test-suite "Conversion Tests"
+  (test-suite "Instantiate Tests"
     (let ([nat-ctc (sc->contract (flat/sc #'exact-nonnegative-integer?))])
       (check-true (nat-ctc 4))
       (check-false (nat-ctc -4)))


### PR DESCRIPTION
Improve the static contract optimizer so a contract like:

```
(or/c struct-predicate-procedure? (-> any/c boolean?))
```

is optimized to a flat contract.

```
(or/c struct-predicate-procedure? (-> any/c any))
```

Closes #712 

