### PR TITLE
flatten contract for union types (fix flat contract optimization)

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -471,7 +471,7 @@
            ;; - because `HashTableTop` is a union containing `(Immutable-HashTable Any Any)`
            ;; - and `Any` makes a chaperone contract
            hash?/sc]
-          [(Union-all: elems)
+          [(Union-all-flat: elems)
            (define-values [hash-elems other-elems] (partition hash/kv? elems))
            (define maybe-hash/sc (hash-types->sc hash-elems))
            (if maybe-hash/sc

--- a/typed-racket-lib/typed-racket/static-contracts/optimize.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/optimize.rkt
@@ -65,7 +65,8 @@
        ;; If this assumption is false, then the flattened contract might
        ;;  accept a value that the original contract failed for ---
        ;;  consider `(or/c (or/c procedure? (-> boolean?)) (-> integer?))`
-       ;;  and `(or/c procedure? (-> boolean?) (-> integer?))` any thunk
+       ;;  and `(or/c procedure? (-> boolean?) (-> integer?))`
+       ;;  and any thunk.
        (apply or/sc (set-union pre-scs mid-scs post-scs))]
       [else sc])]
 

--- a/typed-racket-lib/typed-racket/static-contracts/optimize.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/optimize.rkt
@@ -60,6 +60,13 @@
       [(? (λ (l) (member any/sc l))) any/sc]
       [(? (λ (l) (member none/sc l)))
        (apply or/sc (remove* (list none/sc) scs))]
+      [(list pre-scs ... (or/sc: mid-scs ...) post-scs ...)
+       ;; Assumes `sc->kind` is the same for all `mid-scs`.
+       ;; If this assumption is false, then the flattened contract might
+       ;;  accept a value that the original contract failed for ---
+       ;;  consider `(or/c (or/c procedure? (-> boolean?)) (-> integer?))`
+       ;;  and `(or/c procedure? (-> boolean?) (-> integer?))` any thunk
+       (apply or/sc (set-union pre-scs mid-scs post-scs))]
       [else sc])]
 
     ;; and/sc cases
@@ -214,6 +221,7 @@
         (arr/sc: _ _ _)
         (async-channel/sc: _)
         (box/sc: _)
+        (case->/sc: _)
         (channel/sc: _)
         (cons/sc: _ _)
         (continuation-mark-key/sc: _)
@@ -235,6 +243,7 @@
         (weak-hash/sc: _ _))
     #true]
    [_
+     ;; class/sc object/sc rec/sc ...
     #false]))
 
 (define (remove-unused-recursive-contracts sc)

--- a/typed-racket-test/unit-tests/contract-tests.rkt
+++ b/typed-racket-test/unit-tests/contract-tests.rkt
@@ -226,7 +226,9 @@
    (t-sc -Number number/sc)
    (t-sc -Integer integer/sc)
    (t-sc (-lst Univ) (listof/sc any-wrap/sc))
-   (t-sc (Un (-lst Univ) -Number) (or/sc number/sc (listof/sc any-wrap/sc)))
+   (t-sc (Un (-lst Univ) (-val #t)) (or/sc (flat/sc #''#t) (listof/sc any-wrap/sc)))
+   (t-sc (Un (-val #f) (-val #t) (-lst (-val #f)))
+         (or/sc (flat/sc #''#t) (flat/sc #''#f) (listof/sc (flat/sc #''#f))))
 
    (t-int Any-Syntax syntax? #'#'A #:typed) ;; GitHub issue #616
 

--- a/typed-racket-test/unit-tests/static-contract-optimizer-tests.rkt
+++ b/typed-racket-test/unit-tests/static-contract-optimizer-tests.rkt
@@ -166,6 +166,9 @@
     (check-optimize (or/sc set?/sc)
       #:pos any/sc
       #:neg set?/sc)
+    (check-optimize (or/sc (or/sc set?/sc list?/sc))
+      #:pos any/sc
+      #:neg (or/sc set?/sc list?/sc))
     (check-optimize (or/sc set?/sc any/sc)
       #:pos any/sc
       #:neg any/sc)

--- a/typed-racket-test/unit-tests/static-contract-optimizer-tests.rkt
+++ b/typed-racket-test/unit-tests/static-contract-optimizer-tests.rkt
@@ -359,6 +359,16 @@
       (or/sc cons?/sc (or/sc cons?/sc (box/sc cons?/sc)) (box/sc cons?/sc))
       #:pos (or/sc (box/sc cons?/sc) cons?/sc)
       #:neg (or/sc (box/sc cons?/sc) cons?/sc))
+    (check-optimize
+      ;; flatten multiple or/sc
+      (or/sc cons?/sc (or/sc set?/sc syntax?/sc) (or/sc list?/sc identifier?/sc))
+      #:pos any/sc
+      #:neg (or/sc identifier?/sc list?/sc syntax?/sc set?/sc cons?/sc))
+    (check-optimize
+      ;; flatten deeply-nested or/sc
+      (or/sc cons?/sc (or/sc set?/sc (or/sc syntax?/sc (or/sc list?/sc identifier?/sc))))
+      #:pos any/sc
+      #:neg (or/sc set?/sc identifier?/sc list?/sc syntax?/sc cons?/sc))
     (let ([rec-chaperone (recursive-sc (list #'x) (list cons?/sc) (box/sc (recursive-sc-use #'x)))])
       (check-optimize
         (or/sc cons?/sc rec-chaperone)

--- a/typed-racket-test/unit-tests/static-contract-optimizer-tests.rkt
+++ b/typed-racket-test/unit-tests/static-contract-optimizer-tests.rkt
@@ -355,10 +355,10 @@
 
     ;; more Or case
     (check-optimize
-      ;; flatten & de-duplicate nested or/sc
+      ;; do not flatten nested or/sc containing flat & chaperone contracts (must be all flat or all chaperone)
       (or/sc cons?/sc (or/sc cons?/sc (box/sc cons?/sc)) (box/sc cons?/sc))
-      #:pos (or/sc (box/sc cons?/sc) cons?/sc)
-      #:neg (or/sc (box/sc cons?/sc) cons?/sc))
+      #:pos (or/sc cons?/sc (or/sc cons?/sc (box/sc cons?/sc)) (box/sc cons?/sc))
+      #:neg (or/sc cons?/sc (or/sc cons?/sc (box/sc cons?/sc)) (box/sc cons?/sc)))
     (check-optimize
       ;; flatten multiple or/sc
       (or/sc cons?/sc (or/sc set?/sc syntax?/sc) (or/sc list?/sc identifier?/sc))


### PR DESCRIPTION
This is a fix for #713 

A similar program with the same issue as #713 is this:

```
#lang racket

(module t typed/racket
  (define-type T (U Bytes #f (Listof #f)))
  (: f :  -> T)
  (define (f) #f)
  (provide f))

(require 't)
(has-contract? f) ;; should be #false
```

The problem is that the static contract for `(U Bytes #f (Listof #f))` is basically:
- `(or/sc (or/sc Bytes #f) (Listof #f))`

and the static contract optimizer doesn't know to flatten the 2 layers of `or/sc`.

It might be ok to change the optimizer to flatten layers of `or/sc`, but this PR is simpler and seems like a good thing to do anyway.