### PR TITLE
fix: improve 'no type' error message for format strings

### DIFF
--- a/typed-racket-lib/typed-racket/types/type-table.rkt
+++ b/typed-racket-lib/typed-racket/types/type-table.rkt
@@ -79,7 +79,7 @@
 
 (define (type-of e)
   (hash-ref type-table e
-            (lambda () (int-err (format "no type for ~a at: ~a line ~a col ~a"
+            (lambda () (int-err (format "no type for ~s at: ~a line ~a col ~a"
                                         (syntax->datum e)
                                         (syntax-source e)
                                         (syntax-line e)

--- a/typed-racket-lib/typed-racket/utils/tc-utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/tc-utils.rkt
@@ -272,7 +272,7 @@ don't depend on any other portion of the system
   (raise (make-exn:fail:tc
           (string-append
            "Internal Typechecker Error: "
-           (apply format msg args)
+           (if (null? args) msg (apply format msg args))
            (let ([stx (current-orig-stx)])
              (format "\nwhile typechecking:\n~a\noriginally:\n~a"
                      (and stx (syntax->datum stx))


### PR DESCRIPTION
Fix the error message for when a string containing format characters
hits the 'type-of' function.

Before: the error was from applying format to a string containing the bad value.

Now: the error reports the bad string

Example program:

```
#lang racket/base

(require typed-racket/types/type-table)

(type-of #'"hello ~e world")
```

Old error:
```
format: format string requires 1 arguments, given 0; arguments were: "no type for hello ~e world 
```

New error:
```
Internal Typechecker Error: no type for "hello ~e world" 
```