### PR TITLE
add contract-equivalent to restrict-typed->/c and restrict-typed-field/c

### DIFF
--- a/typed-racket-lib/typed-racket/utils/opaque-object.rkt
+++ b/typed-racket-lib/typed-racket/utils/opaque-object.rkt
@@ -172,15 +172,17 @@
   (define name (restrict-typed->/c-name ctc))
   (build-compound-type-name 'restrict-typed->/c name))
 
+(define (restrict-typed->/c-equivalent? this that)
+  (and (restrict-typed->/c? that)
+       (eq? (restrict-typed->/c-name this)
+            (restrict-typed->/c-name that))))
+
 (struct restrict-typed->/c (name)
         #:property prop:chaperone-contract
         (build-chaperone-contract-property
          #:name restrict-typed->-name
-         #:stronger
-         (λ (this that)
-           (and (restrict-typed->/c? that)
-                (eq? (restrict-typed->/c-name this)
-                     (restrict-typed->/c-name that))))
+         #:stronger restrict-typed->/c-equivalent?
+         #:equivalent restrict-typed->/c-equivalent?
          #:late-neg-projection restrict-typed->-late-neg-projection))
 
 (define (restrict-typed-field-late-neg-proj ctc)
@@ -202,13 +204,15 @@
   (define name (restrict-typed-field/c-name ctc))
   (build-compound-type-name 'restrict-typed-field/c name))
 
+(define (restrict-typed-equivalent? this that)
+  (and (restrict-typed-field/c? that)
+       (equal? (restrict-typed-field/c-name this)
+               (restrict-typed-field/c-name that))))
+
 (struct restrict-typed-field/c (name)
         #:property prop:flat-contract
         (build-flat-contract-property
          #:name restrict-typed-field-name
-         #:stronger
-         (λ (this that)
-           (and (restrict-typed-field/c? that)
-                (eq? (restrict-typed-field/c-name this)
-                     (restrict-typed-field/c-name that))))
+         #:stronger restrict-typed-equivalent?
+         #:equivalent restrict-typed-equivalent?
          #:late-neg-projection restrict-typed-field-late-neg-proj))

--- a/typed-racket-test/succeed/opaque-object-stronger.rkt
+++ b/typed-racket-test/succeed/opaque-object-stronger.rkt
@@ -19,6 +19,16 @@
            (contract-name ctc-stronger)
            (contract-name ctc-weaker))))
 
+(define (test-equivalent? c1 c2)
+  (unless (contract-equivalent? c1 c2)
+    (error 'opaque-object-equivalent
+           "contract ~s is unexpectedly weaker than ~s" c1 c2)))
+
+(define (test-not-equivalent? c1 c2)
+  (when (contract-equivalent? c1 c2)
+    (error 'opaque-object-equivalent
+           "contract ~s is unexpectedly stronger than ~s" c1 c2)))
+
 ;; --------------------------------------------------------------------------------------------------
 ;; stronger? tests
 
@@ -202,6 +212,23 @@
   (test-not-stronger?
      (restrict-typed-field/c 'foo)
      (restrict-typed-field/c 'bar))
+
+  (test-equivalent?
+   (restrict-typed->/c 'foo)
+   (restrict-typed->/c 'foo))
+
+  (test-not-equivalent?
+   (restrict-typed->/c 'foo)
+   (restrict-typed->/c 'bar))
+
+  (test-equivalent?
+   (restrict-typed-field/c 'foo)
+   (restrict-typed-field/c 'foo))
+
+  (test-not-equivalent?
+   (restrict-typed-field/c 'foo)
+   (restrict-typed-field/c 'bar))
+
 )
 
 (let ()


### PR DESCRIPTION
In https://github.com/racket/racket/commit/8ec3edaa9597223f152f5ca12799c8c669e471bb, `contract-equivalent?` was added to `racket/contract` but the methods haven't been implemented yet for typed racket. This commit has some easy ones that happen to make a big difference in the @bennn's gradual typing benchmark suite.