### PR TITLE
add unsafe-undef to opt args types when no expected type exists

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
+++ b/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
@@ -223,11 +223,18 @@
   #:attributes (form id default type kw)
   #:literal-sets (colon)
   (pattern [id:id default:expr]
-           #:with form #'([id default])
+           #:with form #`([#,(if (immediate-default? #'default)
+                                 (optional-immediate-arg-property #'id #t)
+                                 (optional-non-immediate-arg-property #'id #t))
+                           default])
            #:attr type #f
            #:attr kw #f)
   (pattern [id:id : type:expr default:expr]
-           #:with form #`([#,(type-label-property #'id #'type) default])
+           #:with form #`([#,(let ([t-id (type-label-property #'id #'type)])
+                               (if (immediate-default? #'default)
+                                   (optional-immediate-arg-property t-id #t)
+                                   (optional-non-immediate-arg-property t-id #t)))
+                           default])
            #:attr kw #f)
   (pattern :kw-formal))
 

--- a/typed-racket-lib/typed-racket/private/syntax-properties.rkt
+++ b/typed-racket-lib/typed-racket/private/syntax-properties.rkt
@@ -59,6 +59,8 @@
   (type-inst type-inst)
   (row-inst row-inst)
   (type-label type-label)
+  (optional-non-immediate-arg optional-non-immediate-arg)
+  (optional-immediate-arg optional-immediate-arg)
   (type-dotted type-dotted)
   (exn-predicate typechecker:exn-predicate)
   (exn-handler typechecker:exn-handler)

--- a/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
@@ -243,9 +243,13 @@
     (for/list ([a (in-list arg-list)])
       (get-type a #:default (lambda ()
                               (define id (free-id-table-ref aux-table a #f))
-                              (if id
-                                  (get-type id #:default Univ)
-                                  Univ)))))
+                              (cond
+                                [id
+                                 (define ty (get-type id #:default Univ))
+                                 (if (optional-non-immediate-arg-property id)
+                                     (Un -Unsafe-Undefined ty)
+                                     ty)]
+                                [else Univ])))))
 
   (list (tc-lambda-body arg-list arg-types body)))
 

--- a/typed-racket-test/succeed/opt-arg-test.rkt
+++ b/typed-racket-test/succeed/opt-arg-test.rkt
@@ -43,3 +43,13 @@
 (: f4 (-> Integer Integer))
 (define (f4 x [y1 0] [y2 (+ 1 0)] #:z1 [z1 0] #:z2 [z2 (+ 1 0)])
   (+ x y1 y2 z1 z2))
+
+
+(define b (box 42))
+;; make sure Unsafe-Undefined is added to the core-lambda
+;; argument type when a partial type annotation exists
+(define (foo [n : Integer (unbox b)])
+  (+ n 0))
+
+(unless (equal? 42 (foo))
+  (error "oops! a bug!"))


### PR DESCRIPTION
Fixes https://github.com/racket/typed-racket/issues/729.