### PR TITLE
avoid infinite looping in subtyping and when extending an environment

### DIFF
--- a/typed-racket-test/succeed/refinements-quicksort.rkt
+++ b/typed-racket-test/succeed/refinements-quicksort.rkt
@@ -101,3 +101,16 @@
 (define v : (Vectorof Real) (vector 0 5 9 12 3 0 4 6 3))
 (quicksort! v)
 v
+
+
+
+
+
+
+
+(: misc-inf-loop (-> (Refine [n : Natural] (<= n 11))
+                     (Listof (Refine [n : Natural] (<= n 11)))))
+(define (misc-inf-loop x)
+  (cond
+    [(or (= x 1) (= x 6)) (list x)]
+    [else (list)]))


### PR DESCRIPTION
I was tinkering with refinements yesterday and hit an infinite loop in subtyping and environment extension. Basically the `env+` metafunction recurs when it sees that new info has been derived, and it was getting into a loop where it kept "learning" the same "new" info over and over. These changes fixed it, BUT, I can't find the snippet that was causing the bug >_<.

So... here's the fix... I'll see if I can find the test case again...