### PR TITLE
tc-hash: better inference for hashes in syntax objects

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/signatures.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/signatures.rkt
@@ -34,7 +34,7 @@
 
 (define-signature tc-literal^
   ([cond-contracted tc-literal (->* (syntax?) ((or/c Type? #f)) Type?)]
-   [cond-contracted tc-hash (-> (-> any/c (or/c Type? #f) Type?)
+   [cond-contracted tc-hash (-> (->* [any/c] [(or/c Type? #f)] Type?)
                                 hash?
                                 (or/c Type? #f)
                                 Type?)]

--- a/typed-racket-test/succeed/pr390-variation-7.rkt
+++ b/typed-racket-test/succeed/pr390-variation-7.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base
+(require (for-syntax racket/base))
+
+(define-syntax (mhash stx)
+  #`#'#,(make-hash '((a . a))))
+
+(define-syntax (ihash stx)
+  #`#'#,(make-immutable-hash))
+
+(define-syntax (whash stx)
+  #`#'#,(make-weak-hash '((a . a))))
+
+(void
+  (ann (mhash) (Syntaxof (Mutable-HashTable Symbol Symbol)))
+  (ann (ihash) (Syntaxof (Immutable-HashTable Symbol Symbol)))
+  (ann (whash) (Syntaxof (Weak-HashTable Symbol Symbol))))


### PR DESCRIPTION
Improve type inference for hash values embedded in syntax objects

- if embedded value is a weak hash, give a `Weak-HashTable` type
- if embedded value is not-immutable and not-weak, give a
  `Mutable-HashTable` type