### PR TITLE
add contract-equivalent? for sealing->/c

### DIFF
--- a/typed-racket-lib/typed-racket/utils/sealing-contract.rkt
+++ b/typed-racket-lib/typed-racket/utils/sealing-contract.rkt
@@ -7,6 +7,7 @@
 (require racket/class
          racket/contract
          racket/match
+         racket/set
          (for-syntax racket/base
                      syntax/parse))
 
@@ -19,6 +20,34 @@
                          (quote ((?i ...) (?f ...) (?m ...)))
                          (λ (?var) ?c))]))
 
+(define ((make-sealing-contract-<=? ctc-<=? member-name-<=?) this that)
+  (cond
+   [(sealing-contract? that)
+    (define this-unsealed (sealing-contract-unsealed this))
+    (define that-unsealed (sealing-contract-unsealed that))
+    (match-define (list this-inits this-fields this-methods) this-unsealed)
+    (match-define (list that-inits that-fields that-methods) that-unsealed)
+    (define that-<=-this?
+      (and (member-name-<=? this-inits that-inits)
+           (member-name-<=? this-fields that-fields)
+           (member-name-<=? this-methods that-methods)))
+    (cond [that-<=-this?
+           (define sealer/unsealer
+             (seal/unseal (gensym) #t that-unsealed))
+           ;; see if the instantiated contract is stronger
+           (ctc-<=? ((sealing-contract-proc this)
+                     sealer/unsealer)
+                    ((sealing-contract-proc that)
+                     sealer/unsealer))]
+          [else #f])]
+   [else #f]))
+
+(define sealing-contract-stronger?
+  (make-sealing-contract-<=? contract-stronger? (lambda (this that) (subset? that this))))
+
+(define sealing-contract-equivalent?
+  (make-sealing-contract-<=? contract-equivalent? set=?))
+
 ;; represents a sealing function contract
 ;; name     - a datum for the printed form of the contract
 ;; unsealed - init/field/method names left unsealed by sealers/unsealers
@@ -27,30 +56,8 @@
         #:property prop:contract
         (build-contract-property
          #:name (λ (ctc) (sealing-contract-name ctc))
-         #:stronger
-         (λ (this that)
-           (cond
-            [(sealing-contract? that)
-             (define this-unsealed (sealing-contract-unsealed this))
-             (define that-unsealed (sealing-contract-unsealed that))
-             (match-define (list this-inits this-fields this-methods) this-unsealed)
-             (match-define (list that-inits that-fields that-methods) that-unsealed)
-             (define (that-subset-of-this? this that)
-               (for/and ([that-member (in-list that)])
-                 (member that-member this)))
-             (that-subset-of-this? this-inits that-inits)
-             (that-subset-of-this? this-fields that-fields)
-             (that-subset-of-this? this-methods that-methods)
-             (cond [that-subset-of-this?
-                    (define sealer/unsealer
-                      (seal/unseal (gensym) #t that-unsealed))
-                    ;; see if the instantiated contract is stronger
-                    (contract-stronger? ((sealing-contract-proc this)
-                                         sealer/unsealer)
-                                        ((sealing-contract-proc that)
-                                         sealer/unsealer))]
-                   [else #f])]
-            [else #f]))
+         #:stronger sealing-contract-stronger?
+         #:equivalent sealing-contract-equivalent?
          #:late-neg-projection
          (λ (ctc)
            (define unsealed (sealing-contract-unsealed ctc))


### PR DESCRIPTION
- fix bug: stop ignoring 'subset?' checks in sealing-contract-stronger?
- add contract-equivalent? for sealing contracts
- add some unit tests