### PR TITLE
Annotate optional keyword arguments based on immediateness.

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
+++ b/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
@@ -195,13 +195,20 @@
            #:attr default #f
            #:attr type #f)
   (pattern (~seq kw:keyword [id:id default:expr])
-           #:with form #'(kw [id default])
+           #:with i-id (if (immediate-default? #'default)
+                           (optional-immediate-arg-property #'id #true)
+                           (optional-non-immediate-arg-property #'id #true))
+           #:with form #`(kw [i-id default])
            #:attr type #f)
   (pattern (~seq kw:keyword [id:id : type:expr])
            #:with form #`(kw #,(type-label-property #'id #'type))
            #:attr default #f)
   (pattern (~seq kw:keyword [id:id : type:expr default:expr])
-           #:with form #`(kw [#,(type-label-property #'id #'type) default])))
+           #:with t-id (type-label-property #'id #'type)
+           #:with i-id (if (immediate-default? #'default)
+                           (optional-immediate-arg-property #'t-id #true)
+                           (optional-non-immediate-arg-property #'t-id #true))
+           #:with form #`(kw [i-id default])))
 
 (define-splicing-syntax-class mand-formal
   #:description "lambda argument"

--- a/typed-racket-test/succeed/opt-arg-test.rkt
+++ b/typed-racket-test/succeed/opt-arg-test.rkt
@@ -54,6 +54,12 @@
 (unless (equal? 42 (foo))
   (error "oops! a bug!"))
 
+(define (foo2 #:kw [n : Integer (unbox b)])
+  (+ n 0))
+
+(unless (equal? 42 (foo2))
+  (error "oops! a bug!"))
+
 
 (require (prefix-in r: racket/base))
 ;; This expression below either needs to fail to type check


### PR DESCRIPTION
Fixes #740. Follows the approach of #733.