### PR TITLE
fix numeric comparisons for NaN

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -598,51 +598,51 @@
   ;; As explained below, this is because props don't do intersections.
   ;; Cases that may include NaN don't learn anything when a comparison returns
   ;; false, because anything at all compared to NaN is always false.
-  (define (<-type-pattern base pos non-neg neg non-pos [zero -RealZero]
+  (define (<-type-pattern base pos non-neg neg non-pos [zero -RealZeroNoNan]
                           #:no-false-props? [no-false-props? #f])
     (define (-PS* t f) (-PS t (if no-false-props? -tt f)))
     (list (-> base zero B : (-PS* (-is-type 0 neg) (-is-type 0 non-neg)))
           (-> zero base B : (-PS* (-is-type 1 pos) (-is-type 1 non-pos)))
-          (-> base -PosReal B : (-PS* -tt (-is-type 0 pos)))
-          (-> base -NonNegReal B : (-PS* -tt (-is-type 0 non-neg)))
+          (-> base -PosRealNoNan B : (-PS* -tt (-is-type 0 pos)))
+          (-> base -NonNegRealNoNan B : (-PS* -tt (-is-type 0 non-neg)))
           (-> -NonNegReal base B : (-PS* (-is-type 1 pos) -tt))
           (-> base -NonPosReal B : (-PS* (-is-type 0 neg) -tt))
-          (-> -NegReal base B : (-PS* -tt (-is-type 1 neg)))
-          (-> -NonPosReal base B : (-PS* -tt (-is-type 1 non-pos)))))
-  (define (>-type-pattern base pos non-neg neg non-pos [zero -RealZero]
+          (-> -NegRealNoNan base B : (-PS* -tt (-is-type 1 neg)))
+          (-> -NonPosRealNoNan base B : (-PS* -tt (-is-type 1 non-pos)))))
+  (define (>-type-pattern base pos non-neg neg non-pos [zero -RealZeroNoNan]
                           #:no-false-props? [no-false-props? #f])
     (define (-PS* t f) (-PS t (if no-false-props? -tt f)))
     (list (-> base zero B : (-PS* (-is-type 0 pos) (-is-type 0 non-pos)))
           (-> zero base B : (-PS* (-is-type 1 neg) (-is-type 1 non-neg)))
           (-> base -NonNegReal B : (-PS* (-is-type 0 pos) -tt))
-          (-> -PosReal base B : (-PS* -tt (-is-type 1 pos)))
-          (-> -NonNegReal base B : (-PS* -tt (-is-type 1 non-neg)))
+          (-> -PosRealNoNan base B : (-PS* -tt (-is-type 1 pos)))
+          (-> -NonNegRealNoNan base B : (-PS* -tt (-is-type 1 non-neg)))
           (-> -NonPosReal base B : (-PS* (-is-type 1 neg) -tt))
-          (-> base -NegReal B : (-PS* -tt (-is-type 0 neg)))
-          (-> base -NonPosReal B : (-PS* -tt (-is-type 0 non-pos)))))
+          (-> base -NegRealNoNan B : (-PS* -tt (-is-type 0 neg)))
+          (-> base -NonPosRealNoNan B : (-PS* -tt (-is-type 0 non-pos)))))
   ;; this is > with flipped props
-  (define (<=-type-pattern base pos non-neg neg non-pos [zero -RealZero]
+  (define (<=-type-pattern base pos non-neg neg non-pos [zero -RealZeroNoNan]
                            #:no-false-props? [no-false-props? #f])
     (define (-PS* t f) (-PS t (if no-false-props? -tt f)))
     (list (-> base zero B : (-PS* (-is-type 0 non-pos) (-is-type 0 pos)))
           (-> zero base B : (-PS* (-is-type 1 non-neg) (-is-type 1 neg)))
-          (-> base -NonNegReal B : (-PS* -tt (-is-type 0 pos)))
+          (-> base -NonNegRealNoNan B : (-PS* -tt (-is-type 0 pos)))
           (-> -PosReal base B : (-PS* (-is-type 1 pos) -tt))
           (-> -NonNegReal base B : (-PS* (-is-type 1 non-neg) -tt))
-          (-> -NonPosReal base B : (-PS* -tt (-is-type 1 neg)))
+          (-> -NonPosRealNoNan base B : (-PS* -tt (-is-type 1 neg)))
           (-> base -NegReal B : (-PS* (-is-type 0 neg) -tt))
           (-> base -NonPosReal B : (-PS* (-is-type 0 non-pos) -tt))))
-  (define (>=-type-pattern base pos non-neg neg non-pos [zero -RealZero]
+  (define (>=-type-pattern base pos non-neg neg non-pos [zero -RealZeroNoNan]
                            #:no-false-props? [no-false-props? #f])
     (define (-PS* t f) (-PS t (if no-false-props? -tt f)))
     (list (-> base zero B : (-PS* (-is-type 0 non-neg) (-is-type 0 neg)))
           (-> zero base B : (-PS* (-is-type 1 non-pos) (-is-type 1 pos)))
           (-> base -PosReal B : (-PS* (-is-type 0 pos) -tt))
           (-> base -NonNegReal B : (-PS* (-is-type 0 non-neg) -tt))
-          (-> -NonNegReal base B : (-PS* -tt (-is-type 1 pos)))
-          (-> base -NonPosReal B : (-PS* -tt (-is-type 0 neg)))
+          (-> -NonNegRealNoNan base B : (-PS* -tt (-is-type 1 pos)))
+          (-> base -NonPosRealNoNan B : (-PS* -tt (-is-type 0 neg)))
           (-> -NegReal base B : (-PS* (-is-type 1 neg) -tt))
-          (-> -NonPosReal base B : (-PS* (-is-type 1 non-pos) -tt))))
+          (-> -NonPosRealNoNan base B : (-PS* (-is-type 1 non-pos) -tt))))
 
   (define (negation-pattern pos neg non-neg non-pos)
     (list (-> pos neg)

--- a/typed-racket-lib/typed-racket/types/numeric-tower.rkt
+++ b/typed-racket-lib/typed-racket/types/numeric-tower.rkt
@@ -22,6 +22,7 @@
          -InexactRealPosZero -InexactRealNegZero -InexactRealZero -InexactRealNan
          -PosInexactReal -NonNegInexactReal -NegInexactReal -NonPosInexactReal -InexactReal
          -RealZero -RealZeroNoNan -PosReal -NonNegReal -NegReal -NonPosReal -Real
+         -RealZeroNoNan -PosRealNoNan -NonNegRealNoNan -NegRealNoNan -NonPosRealNoNan -RealNoNan
          -PosInfinity -NegInfinity
          -ExactImaginary -FloatImaginary -SingleFlonumImaginary -InexactImaginary -Imaginary
          -ExactNumber -ExactComplex -FloatComplex -SingleFlonumComplex -InexactComplex -Number
@@ -80,8 +81,8 @@
 (define/decl -InexactRealPosZero (Un -SingleFlonumPosZero -FlonumPosZero))
 (define/decl -InexactRealNegZero (Un -SingleFlonumNegZero -FlonumNegZero))
 (define/decl -InexactRealZero    (Un -InexactRealPosZero
-                                 -InexactRealNegZero
-                                 -InexactRealNan))
+                                     -InexactRealNegZero
+                                     -InexactRealNan))
 
 
 (define/decl -PosSingleFlonum    (Un -PosSingleFlonumNoNan -SingleFlonumNan))
@@ -98,12 +99,19 @@
 
 ;; Reals
 (define/decl -RealZero      (Un -Zero -InexactRealZero))
-(define/decl -RealZeroNoNan (Un -Zero -InexactRealPosZero -InexactRealNegZero))
 (define/decl -PosReal       (Un -PosRat -PosInexactReal))
 (define/decl -NonNegReal    (Un -NonNegRat -NonNegInexactReal))
 (define/decl -NegReal       (Un -NegRat -NegInexactReal))
 (define/decl -NonPosReal    (Un -NonPosRat -NonPosInexactReal))
 (define/decl -Real          (Un -Rat -InexactReal))
+
+;; Reals sans NaN (used for comparison specifications)
+(define/decl -RealZeroNoNan      (Un -Zero -InexactRealPosZero -InexactRealNegZero))
+(define/decl -PosRealNoNan       (Un -PosRat -PosFlonumNoNan -PosSingleFlonumNoNan))
+(define/decl -NonNegRealNoNan    (Un -RealZeroNoNan -PosRealNoNan))
+(define/decl -NegRealNoNan       (Un -NegRat -NegFlonumNoNan -NegSingleFlonumNoNan))
+(define/decl -NonPosRealNoNan    (Un -RealZeroNoNan -NegRealNoNan))
+(define/decl -RealNoNan          (Un -NegRealNoNan -RealZeroNoNan -PosRealNoNan))
 
 (define/decl -ExactNumber (Un -ExactImaginary -ExactComplex -Rat))
 (define/decl -InexactImaginary (Un -FloatImaginary -SingleFlonumImaginary))

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -4897,6 +4897,206 @@
           (foo v 0)
           (void))
         #:ret (ret -Void #f #f)]
+       
+       ;; comparisons must correctly account for if the
+       ;; #false result was caused by a NaN (see TR Github issue #747)
+       ;; less-than
+       (tc-err
+        (let ([x : Positive-Real +nan.0]
+              [y : Negative-Fixnum -42])
+          (if (< y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Positive-Real +nan.0]
+              [y : Negative-Integer -42])
+          (if (< y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Byte 0]
+              [y : Negative-Real +nan.0])
+          (if (< y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Index 0]
+              [y : Negative-Real +nan.0])
+          (if (< y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Nonnegative-Fixnum 0]
+              [y : Negative-Real +nan.0])
+          (if (< y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Natural 0]
+              [y : Negative-Real +nan.0])
+          (if (< y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+
+
+       ;; less-than-or-equal-to
+       (tc-err
+        (let ([x : Positive-Real +nan.0]
+              [y : Negative-Fixnum -42])
+          (if (<= y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Positive-Real +nan.0]
+              [y : Negative-Integer -42])
+          (if (<= y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Byte 0]
+              [y : Negative-Real +nan.0])
+          (if (<= y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Index 0]
+              [y : Negative-Real +nan.0])
+          (if (<= y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Nonnegative-Fixnum 0]
+              [y : Negative-Real +nan.0])
+          (if (<= y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Natural 0]
+              [y : Negative-Real +nan.0])
+          (if (<= y x)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       ;; greater-than-or-equal-to
+       (tc-err
+        (let ([x : Positive-Real +nan.0]
+              [y : Negative-Fixnum -42])
+          (if (>= x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Positive-Real +nan.0]
+              [y : Negative-Integer -42])
+          (if (>= x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Byte 0]
+              [y : Negative-Real +nan.0])
+          (if (>= x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Index 0]
+              [y : Negative-Real +nan.0])
+          (if (>= x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Nonnegative-Fixnum 0]
+              [y : Negative-Real +nan.0])
+          (if (>= x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Natural 0]
+              [y : Negative-Real +nan.0])
+          (if (>= x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       ;; greater-than
+       (tc-err
+        (let ([x : Positive-Real +nan.0]
+              [y : Negative-Fixnum -42])
+          (if (> x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Positive-Real +nan.0]
+              [y : Negative-Integer -42])
+          (if (> x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Byte 0]
+              [y : Negative-Real +nan.0])
+          (if (> x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Index 0]
+              [y : Negative-Real +nan.0])
+          (if (> x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Nonnegative-Fixnum 0]
+              [y : Negative-Real +nan.0])
+          (if (> x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
+
+       (tc-err
+        (let ([x : Natural 0]
+              [y : Negative-Real +nan.0])
+          (if (> x y)
+              (void)
+              (void (+ "1" "2"))))
+        #:ret (ret -Void #f #f))
        )
 
   (test-suite


### PR DESCRIPTION
Fixes https://github.com/racket/typed-racket/issues/747 in the way that is least likely to break any programs (I think).

Basically, any comparison which has a non-trivial negative proposition needs to not include `NaN` in the argument types (since `NaN` in a comparison always produces `#false`).

Still need to add some tests specific to the issue.