### PR TITLE
fix #569

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-let-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-let-unit.rkt
@@ -312,7 +312,7 @@
 ;; say that this binding is only called in tail position
 (define ((tc-expr-t/maybe-expected expected) e)
   (syntax-parse e #:literal-sets (kernel-literals)
-    [(~and (#%plain-lambda (fmls:type-annotation^ ...) _) _:tail-position^)
+    [(~and _:tail-position^ (#%plain-lambda (fmls:type-annotation^ ...) _))
      #:when expected
      (define arg-tys (attribute fmls.type))
      (tc-expr/check e (ret (t:->* arg-tys (tc-results->values expected))))]

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -5097,6 +5097,16 @@
               (void)
               (void (+ "1" "2"))))
         #:ret (ret -Void #f #f))
+
+       (tc-e
+        (let ([id (tr:lambda #:forall (t) ([x : t]) x)])
+          id)
+        #:ret (tc-ret (-poly (A)
+                          (t:-> A A
+                                : (-PS (-not-type (cons 0 0) (-val #f))
+                                       (-is-type (cons 0 0) (-val #f)))
+                                : (make-Path null (cons 0 0))))
+                        -true-propset))
        )
 
   (test-suite


### PR DESCRIPTION
This fixed #569 , I think there are more ideal ways to fix it, such as check the `typechecker:plambda` syntax properties before syntax-parse, but the tail-position^ looks like just a hack for racket/match, so I make this pull request.