### PR TITLE
infer: make `cset-meet` lazy

### DIFF
--- a/typed-racket-lib/typed-racket/infer/constraint-structs.rkt
+++ b/typed-racket-lib/typed-racket/infer/constraint-structs.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require "../utils/utils.rkt" (contract-req))
+(require "../utils/utils.rkt" racket/stream (contract-req))
 
 (require-for-cond-contract (rep type-rep))
 
@@ -29,13 +29,13 @@
 ;; map : hash mapping index variables to dcons
 (define-struct/cond-contract dmap ([map (hash/c symbol? dcon/c)]) #:transparent)
 
-;; maps is a list of pairs of
+;; maps is a (lazy) sequence of pairs of
 ;;    - functional maps from vars to c's
 ;;    - dmaps (see dmap.rkt)
 ;; we need a bunch of mappings for each cset to handle case-lambda
 ;; because case-lambda can generate multiple possible solutions, and we
 ;; don't want to rule them out too early
-(define-struct/cond-contract cset ([maps (listof (cons/c (hash/c symbol? c? #:immutable #t) dmap?))]) #:transparent)
+(define-struct/cond-contract cset ([maps (stream/c (cons/c (hash/c symbol? c? #:immutable #t) dmap?))]) #:transparent)
 
 (define no-cset (make-cset '()))
 

--- a/typed-racket-lib/typed-racket/infer/constraints.rkt
+++ b/typed-racket-lib/typed-racket/infer/constraints.rkt
@@ -5,7 +5,8 @@
 	 racket/dict
      "fail.rkt" "signatures.rkt" "constraint-structs.rkt"
      racket/match
-     racket/list)
+     racket/set
+     racket/stream)
 
 (import intersect^ dmap^)
 (export constraints^)
@@ -67,14 +68,16 @@
     [(x y)
      (match* (x y)
       [((struct cset (maps1)) (struct cset (maps2)))
-       (define maps (for*/list ([(map1 dmap1) (in-dict (remove-duplicates maps1))]
-                                [(map2 dmap2) (in-dict (remove-duplicates maps2))]
-                                [v (in-value (% cons
-                                                (hash-union/fail map1 map2 #:combine c-meet)
-                                                (dmap-meet dmap1 dmap2)))]
-                                #:when v)
-                      v))
-       (cond [(null? maps)
+       (define maps
+         (for*/stream ([md1 (in-stream (stream-remove-duplicates maps1))]
+                       [md2 (in-stream (stream-remove-duplicates maps2))]
+                       [v (in-value
+                            (% cons
+                               (hash-union/fail (car md1) (car md2) #:combine c-meet)
+                               (dmap-meet (cdr md1) (cdr md2))))]
+                       #:when v)
+           v))
+       (cond [(stream-empty? maps)
               #f]
              [else (make-cset maps)])])]
     [(x . ys)
@@ -90,4 +93,12 @@
 ;; FIXME: should this call `remove-duplicates`?
 (define (cset-join l)
   (let ([mapss (map cset-maps l)])
-    (make-cset (apply append mapss))))
+    (make-cset (apply stream-append mapss))))
+
+(define (stream-remove-duplicates st)
+  (define seen (mutable-set))
+  (define (new-elem? elem)
+    (and (not (set-member? seen elem))
+         (set-add! seen elem)
+         #true))
+  (stream-filter new-elem? st))

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -27,7 +27,7 @@
          (for-syntax
            racket/base
            syntax/parse)
-         racket/hash racket/list)
+         racket/hash racket/list racket/stream)
 
 (import dmap^ constraints^)
 (export infer^)
@@ -103,7 +103,7 @@
 ;; (CMap DMap -> Pair<CMap, DMap>) CSet -> CSet
 ;; Map a function over a constraint set
 (define (map/cset f cset)
-  (% make-cset (for/list/fail ([cmap/dmap (in-list (cset-maps cset))])
+  (% make-cset (for/list/fail ([cmap/dmap (in-stream (cset-maps cset))])
                  (f (car cmap/dmap) (cdr cmap/dmap)))))
 
 ;; Symbol DCon -> DMap
@@ -908,8 +908,9 @@
          ;; verify that we got all the important variables
          (extend-idxs subst))]))
   (if multiple-substitutions?
-      (map build-subst (cset-maps C))
-      (build-subst (car (cset-maps C)))))
+      (for/list ([md (in-stream (cset-maps C))])
+        (build-subst md))
+      (build-subst (stream-first (cset-maps C)))))
 
 ;; context : the context of what to infer/not infer
 ;; S : a list of types to be the subtypes of T

--- a/typed-racket-test/unit-tests/infer-tests.rkt
+++ b/typed-racket-test/unit-tests/infer-tests.rkt
@@ -312,6 +312,13 @@
    ;; error tests
    [i2-f (-lst (-v a)) Univ]
    [i2-f (->* null B B) (-> (-v a) (-v b))]
+   [infer-t
+     ;; union of type variables vs. wide union type, has exponentially-many solutions
+     (Un (-pair -Rat (-val null))
+         (-vec -Rat))
+     (Un (-pair (Un (-v a) (-v b)) (-val null))
+         (-vec (Un (-v a) (-v b))))
+     #:vars '(a b)]
    ))
 
 


### PR DESCRIPTION
Use a stream to avoid eagerly computing `cset-meet`.

Good news:
- quickly passes the unit test in #743 
- fixes the slowdown for the mutable/immutable vectors PR (see #575 )

Bad news:
- does not fix the _program_ in #743 --- I'll make a note in that issue and work on that program after mutable/immutable vectors are done
- makes typechecking slower overall on the `tr-performance` programs:

```
Compile time ratio (old time = Racket 7.0 release / new time = Racket 7.0.0.10):
schml-specify-rep: 0.97 (i.e. slower, 7.95s (σ 0.06) to 8.21s (σ 0.03))
schml-interp-casts-help: 0.99 (i.e. slower, 17.91s (σ 0.2) to 18.12s (σ 0.11))
parser: 0.92 (i.e. slower, 2.01s (σ 0.01) to 2.19s (σ 0.01))
old-metrics: 0.92 (i.e. slower, 2.37s (σ 0.01) to 2.57s (σ 0.02))
new-metrics: 0.91 (i.e. slower, 3.21s (σ 0.01) to 3.54s (σ 0.05))
math-flonum: 0.95 (i.e. slower, 3.42s (σ 0.02) to 3.59s (σ 0.02))
fsm: 0.91 (i.e. slower, 4.51s (σ 0.02) to 4.96s (σ 0.03))
forth: 0.9 (i.e. slower, 4.36s (σ 0.04) to 4.87s (σ 0.02))
dungeon: 0.91 (i.e. slower, 7.81s (σ 0.06) to 8.54s (σ 0.05))
bernoulli: 0.91 (i.e. slower, 3.59s (σ 0.03) to 3.95s (σ 0.06))
acquire: 0.91 (i.e. slower, 14.14s (σ 0.09) to 15.52s (σ 0.07))
```

Full data (12 runs per file): 
[issue-743-lazy-perf.txt](https://github.com/racket/typed-racket/files/2263382/issue-743-lazy-perf.txt)


This PR is labeled "in-progress" because I think the `tr-performance` could be better in the common case. Maybe by using a generator instead of `for*/stream`, maybe by using lists normally and streams only when we know inference needs laziness.

- - - 

Edit: I tried debugging the performance today, and it turns out the current Racket+TR master has the same slowdown relative to Racket 7

```
Compile time ratio (old time = Racket 7 release / new time = Racket 7.0.0.10 @ 8deaa4cf91b with TR @ a3871e685a):
schml-specify-rep: 0.98 (i.e. slower, 7.94s (σ 0.09) to 8.09s (σ 0.1))
schml-interp-casts-help: 0.98 (i.e. slower, 17.81s (σ 0.17) to 18.19s (σ 0.14))
parser: 0.92 (i.e. slower, 1.98s (σ 0.02) to 2.16s (σ 0.01))
old-metrics: 0.93 (i.e. slower, 2.35s (σ 0.01) to 2.54s (σ 0.03))
new-metrics: 0.95 (i.e. slower, 3.2s (σ 0.02) to 3.38s (σ 0.02))
math-flonum: 0.95 (i.e. slower, 3.39s (σ 0.03) to 3.55s (σ 0.03))
fsm: 0.91 (i.e. slower, 4.45s (σ 0.03) to 4.9s (σ 0.05))
forth: 0.9 (i.e. slower, 4.29s (σ 0.02) to 4.77s (σ 0.04))
dungeon: 0.91 (i.e. slower, 7.72s (σ 0.06) to 8.48s (σ 0.06))
bernoulli: 0.88 (i.e. slower, 3.54s (σ 0.03) to 4.04s (σ 0.05))
acquire: 0.92 (i.e. slower, 14.03s (σ 0.13) to 15.29s (σ 0.15))
```

Full data: 
[racket7-vs-master.txt](https://github.com/racket/typed-racket/files/2279530/racket7-vs-master.txt)


This PR might still have a performance issue, but the two datasets above are not proof of that.