### PR TITLE
move 'extract-props' function

### DIFF
--- a/typed-racket-lib/typed-racket/env/type-env-structs.rkt
+++ b/typed-racket-lib/typed-racket/env/type-env-structs.rkt
@@ -8,7 +8,7 @@
          ;; (e.g. performance is irrelevant)
          (only-in racket/dict dict->list dict-map)
          (rep core-rep object-rep)
-         (types numeric-tower)
+         (except-in (types abbrev) -> ->* one-of/c)
          (for-syntax racket/base syntax/parse))
 
 (require-for-cond-contract (rep type-rep prop-rep))

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -9,7 +9,7 @@
          racket/list
          racket/match
          (prefix-in c: (contract-req))
-         (rep rep-utils type-rep prop-rep object-rep values-rep)
+         (rep rep-utils type-rep type-mask prop-rep object-rep values-rep)
          (types numeric-tower)
          ;; Using this form so all-from-out works
          "base-abbrev.rkt" "match-expanders.rkt"
@@ -23,7 +23,6 @@
          (for-syntax racket/base syntax/parse))
 
 (provide (all-defined-out)
-         extract-props
          (all-from-out "base-abbrev.rkt" "match-expanders.rkt"))
 
 ;; Convenient constructors
@@ -248,3 +247,49 @@
      (syntax/loc stx
        (let ([x (genid (syntax->datum #'x))])
          (-refine t (abstract-obj p (list x)))))]))
+
+;; extract-props : Object Type -> (values Type (listof Prop?))
+;; given the fact that 'obj' is of type 'type',
+;; look inside of type trying to learn
+;; more info about obj
+(define (extract-props obj type)
+  (cond
+    [(Empty? obj) (values type '())]
+    [else
+     (define props '())
+     (define new-type
+       (let extract ([rep type]
+                     [obj obj])
+         (match rep
+           [(app int-type->known-bounds
+                 (cons maybe-lower-bound maybe-upper-bound))
+            #:when (with-refinements?)
+            (when maybe-lower-bound
+              (set! props (cons (-leq (-lexp maybe-lower-bound) (-lexp obj))
+                                props)))
+            (when maybe-upper-bound
+              (set! props (cons (-leq (-lexp obj) (-lexp maybe-upper-bound))
+                                props)))
+            rep]
+           [(Pair: t1 t2) (make-Pair (extract t1 (-car-of obj))
+                                     (extract t2 (-cdr-of obj)))]
+           [(Refine-obj: obj t prop)
+            (set! props (cons prop props))
+            (extract t obj)]
+           [(HeterogeneousVector: ts)
+            #:when (with-refinements?)
+            (set! props (cons (-eq (-vec-len-of obj) (-lexp (length ts)))
+                              props))
+            rep]
+           [_ #:when (and (with-refinements?)
+                          (eqv? mask:vector (mask rep)))
+              (set! props (cons (-leq (-lexp 0) (-vec-len-of obj))
+                                props))
+              rep]
+           [(Intersection: ts _)
+            (apply -unsafe-intersect
+                   (for/list ([t (in-list ts)])
+                     (extract t obj)))]
+           [_ rep])))
+     (values new-type props)]))
+

--- a/typed-racket-lib/typed-racket/types/numeric-tower.rkt
+++ b/typed-racket-lib/typed-racket/types/numeric-tower.rkt
@@ -2,7 +2,7 @@
 
 (require "../utils/utils.rkt"
          racket/match
-         (rep core-rep type-rep rep-utils type-mask
+         (rep core-rep type-rep rep-utils
               numeric-base-types base-union base-type-rep
               object-rep prop-rep)
          (types numeric-predicates)
@@ -28,7 +28,7 @@
          -ExactNumber -ExactComplex -FloatComplex -SingleFlonumComplex -InexactComplex -Number
          has-int-provable-range?
          int-type->provable-range
-         extract-props
+         int-type->known-bounds
          (rename-out (-Int -Integer)))
 
 ;;
@@ -175,7 +175,6 @@
      (hash-ref int-type-bounds-hash nbits #f)]
     [_ #f]))
 
-
 (define all-bounded-int-types
   ;; relies on numeric bits being eq?
   (for/hasheq ([t (in-list (list -Zero -One -PosByte -Byte>1 -Byte -PosIndex -Index
@@ -194,53 +193,3 @@
      (hash-ref all-bounded-int-types nbits #f)]
     [_ #f]))
 
-
-;; extract-props : Object Type -> (values Type (listof Prop?))
-;; given the fact that 'obj' is of type 'type',
-;; look inside of type trying to learn
-;; more info about obj
-;;
-;; NOTE: why is this HERE? It depends on the numeric
-;; types defined in this file... so it needs to be
-;; here or further downstream. At a glance I couldn't
-;; see an ideal place to stick it, so here it landed -AMK
-(define (extract-props obj type)
-  (cond
-    [(Empty? obj) (values type '())]
-    [else
-     (define props '())
-     (define new-type
-       (let extract ([rep type]
-                     [obj obj])
-         (match rep
-           [(app int-type->known-bounds
-                 (cons maybe-lower-bound maybe-upper-bound))
-            #:when (with-refinements?)
-            (when maybe-lower-bound
-              (set! props (cons (-leq (-lexp maybe-lower-bound) (-lexp obj))
-                                props)))
-            (when maybe-upper-bound
-              (set! props (cons (-leq (-lexp obj) (-lexp maybe-upper-bound))
-                                props)))
-            rep]
-           [(Pair: t1 t2) (make-Pair (extract t1 (-car-of obj))
-                                     (extract t2 (-cdr-of obj)))]
-           [(Refine-obj: obj t prop)
-            (set! props (cons prop props))
-            (extract t obj)]
-           [(HeterogeneousVector: ts)
-            #:when (with-refinements?)
-            (set! props (cons (-eq (-vec-len-of obj) (-lexp (length ts)))
-                              props))
-            rep]
-           [_ #:when (and (with-refinements?)
-                          (eqv? mask:vector (mask rep)))
-              (set! props (cons (-leq (-lexp 0) (-vec-len-of obj))
-                                props))
-              rep]
-           [(Intersection: ts _)
-            (apply -unsafe-intersect
-                   (for/list ([t (in-list ts)])
-                     (extract t obj)))]
-           [_ rep])))
-     (values new-type props)]))

--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -477,8 +477,6 @@
        [(_ _) ;; otherwise we case on t1
         (subtype-cases A t1 t2 obj)])]))
 
-
-
 ;; if obj ∈ t1, can we prove 'lower-bound <= obj' and 'obj <= upper-bound'? 
 (define (provable-int-subtype? A t1 t2 lower-bound upper-bound obj)
   (define lower-ineq


### PR DESCRIPTION
Move `extract-props` from 'types/numeric-tower' to 'types/abbrev'. The function was
already provided by 'types/abbrev' and the new location makes more sense
to me.

(History: yesterday I was trying to debug a test failure due to an issue in
'extract-props'. Of course I didn't know 'extract-props' was the problem
at first. It took me 2 hours to figure that out, partly because
'types/numeric-tower' was the last place I expected to look to debug a
problem with vector refinements.)