### PR TITLE
typed/json: handle json-null

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -76,8 +76,18 @@ The following libraries are included with Typed Racket in the
 @defmodule/incl[typed/framework]
 @defmodule/incl[typed/json]
 
+Unlike the untyped @racketmodname[json] library,
+@racketmodname[typed/json] always uses @racket['null]
+to represent the JSON ``null'' value.
+The functions exported by @racketmodname[typed/json]
+do not accept a @racket[#:null] argument, and they
+are not sensitive to the current value of the @racket[json-null] parameter.
+The @racket[json-null] binding itself is not
+exported by @racketmodname[typed/json].
+
 @deftype[JSExpr]{
-  Describes a @tech["jsexpr" #:doc '(lib "json/json.scrbl")].
+ Describes a @tech["jsexpr" #:doc '(lib "json/json.scrbl")],
+ where @racket['null] is always used to represent the JSON ``null'' value.
 }
 
 @defmodule/incl[typed/mred/mred]

--- a/typed-racket-more/typed/json.rkt
+++ b/typed-racket-more/typed/json.rkt
@@ -2,18 +2,63 @@
 
 ;; a typed wrapper for the json library
 
-(provide JSExpr)
+;; To be robust against the json-null parameter,
+;; the typed interface will always explicitly specify 'null.
+
+(provide JSExpr
+         (rename-out
+          [jsexpr?* jsexpr?]
+          [write-json* write-json]
+          [read-json* read-json]
+          [jsexpr->string* jsexpr->string]
+          [jsexpr->bytes* jsexpr->bytes]
+          [string->jsexpr* string->jsexpr]
+          [bytes->jsexpr* bytes->jsexpr]))
 
 (define-type JSExpr
   (U 'null Boolean String Integer Inexact-Real (Listof JSExpr) (HashTable Symbol JSExpr)))
 
-(require/typed/provide json
-                       [jsexpr? (Any -> Boolean)]
-                       [write-json (->* (JSExpr)
-                                        (Output-Port #:encode (U 'control 'all))
-                                        Any)]
-                       [read-json (->* () (Input-Port) (U JSExpr EOF))]
-                       [jsexpr->string (JSExpr [#:encode (U 'control 'all)] -> String)]
-                       [jsexpr->bytes (JSExpr [#:encode (U 'control 'all)] -> Bytes)]
-                       [string->jsexpr (String -> JSExpr)]
-                       [bytes->jsexpr (Bytes -> JSExpr)])
+(require/typed
+ json
+ [jsexpr? (-> Any #:null 'null Boolean)]
+ [write-json (->* (JSExpr #:null 'null)
+                  (Output-Port #:encode (U 'control 'all))
+                  Any)]
+ [read-json (->* (#:null 'null) (Input-Port) (U JSExpr EOF))]
+ [jsexpr->string (-> JSExpr #:null 'null [#:encode (U 'control 'all)] String)]
+ [jsexpr->bytes (-> JSExpr #:null 'null [#:encode (U 'control 'all)] Bytes)]
+ [string->jsexpr (-> String #:null 'null JSExpr)]
+ [bytes->jsexpr (-> Bytes #:null 'null JSExpr)])
+
+(: jsexpr?* (-> Any Boolean))
+(define (jsexpr?* v)
+  (jsexpr? v #:null 'null))
+
+(: write-json* (->* (JSExpr)
+                    (Output-Port #:encode (U 'control 'all))
+                    Any))
+(define (write-json* js [out (current-output-port)]
+                     #:encode [enc 'control])
+  (write-json js out #:encode enc #:null 'null))
+
+(: read-json* (->* () (Input-Port) (U JSExpr EOF)))
+(define (read-json* [in (current-input-port)])
+  (read-json in #:null 'null))
+
+(: jsexpr->string* (-> JSExpr [#:encode (U 'control 'all)] String))
+(define (jsexpr->string* js #:encode [enc 'control])
+  (jsexpr->string js #:encode enc #:null 'null))
+
+(: jsexpr->bytes* (-> JSExpr [#:encode (U 'control 'all)] Bytes))
+(define (jsexpr->bytes* js #:encode [enc 'control])
+  (jsexpr->bytes js #:encode enc #:null 'null))
+
+(: string->jsexpr* (-> String JSExpr))
+(define (string->jsexpr* v)
+  (string->jsexpr v #:null 'null))
+
+(: bytes->jsexpr* (-> Bytes JSExpr))
+(define (bytes->jsexpr* v)
+  (bytes->jsexpr v #:null 'null))
+
+

--- a/typed-racket-test/unit-tests/all-tests.rkt
+++ b/typed-racket-test/unit-tests/all-tests.rkt
@@ -44,4 +44,5 @@
   "prims-tests.rkt"
   "tooltip-tests.rkt"
   "prefab-tests.rkt"
+  "json-tests.rkt"
   "typed-units-tests.rkt")

--- a/typed-racket-test/unit-tests/json-tests.rkt
+++ b/typed-racket-test/unit-tests/json-tests.rkt
@@ -1,0 +1,36 @@
+#lang racket/base
+
+;; Unit tests for typed/json
+
+(require typed/json
+         (only-in json json-null)
+         rackunit)
+
+(provide tests)
+
+(define tests
+  (test-suite
+   "Tests for typed/json"
+   (test-case
+    "test that json-null parameter can't break typed/json"
+    (parameterize ([json-null '|bogus json-null|])
+      ;; predicate
+      (check-false (jsexpr? '|bogus json-null|))
+      (check-true (jsexpr? 'null))
+      ;; writing
+      (check-equal? (let ([out (open-output-string)])
+                      (write-json 'null out)
+                      (get-output-string out))
+                    "null")
+      (check-equal? (jsexpr->string 'null)
+                    "null")
+      (check-equal? (jsexpr->bytes 'null)
+                    #"null")
+      ;; reading
+      (check-eq? (read-json (open-input-string "null"))
+                 'null)
+      (check-eq? (string->jsexpr "null")
+                 'null)
+      (check-eq? (bytes->jsexpr #"null")
+                 'null)))))
+


### PR DESCRIPTION
Previously, untyped code could use the `json-null` parameter to cause
the functions from `typed/json` not to obey their declared types.
This commit prevents that problem by having the typed wrapper functions
explicitly pass `'null` as the `#:null` argument.

If this approach sees promising, I can add documentation (and probably tests, somewhere?).

Closes https://github.com/racket/typed-racket/issues/768