### PR TITLE
do not contract prefab field operators

### DIFF
--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -467,19 +467,10 @@
   (make-init-code
    struct-fn-table-map
    (λ (id v)
-     (match-define (struct-field-entry type idx mutator? mutable?) v)
-     (cond
-       [mutator?
-        #`(add-struct-mutator-fn!
-           (quote-syntax #,id)
-           #,(type->sexp type)
-           #,idx)]
-       [else
-        #`(add-struct-accessor-fn!
-           (quote-syntax #,id)
-           #,(type->sexp type)
-           #,idx
-           #,mutable?)]))))
+     (match-define (struct-field-metadata type info) v)
+     #`(add-struct-field-metadata!
+        (quote-syntax #,id)
+        (struct-field-metadata #,(type->sexp type) (quote #,info))))))
 
 ;; -> (Listof Syntax)
 ;; Construct syntax that does type environment serialization

--- a/typed-racket-lib/typed-racket/typecheck/provide-handling.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/provide-handling.rkt
@@ -7,6 +7,7 @@
          (only-in (private type-contract) include-extra-requires?)
          (private syntax-properties)
          (typecheck renamer def-binding)
+         (types struct-table)
          (utils tc-utils)
          (env env-utils)
          (for-syntax racket/base)
@@ -77,6 +78,8 @@
                           ;; if it wasn't there, put it in, and skip this case
                           (λ () (free-id-table-set! mapping internal-id new-id) #f))
        => mk-ignored-quad]
+      [(prefab-struct-field-operator? internal-id)
+       (mk-ignored-quad internal-id)]
       [(free-id-table-ref defs internal-id #f)
        =>
        (match-lambda

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -200,14 +200,14 @@
                                  fld-t
                                  (list path))
                           (-> prefab-top-type Univ)))])])
-          (add-struct-accessor-fn! acc-id prefab-top-type idx self-mutable)
+          (add-struct-accessor-fn! acc-id prefab-top-type idx self-mutable #t)
           (make-def-binding acc-id func-t)))
       (if self-mutable
           (for/list ([s (in-list (struct-names-setters names))]
                      [t (in-list self-fields)]
                      [idx (in-naturals parent-count)])
             (let ([fld-t (list-ref field-tvar-Fs idx)])
-              (add-struct-mutator-fn! s prefab-top-type idx)
+              (add-struct-mutator-fn! s prefab-top-type idx #t)
               (make-def-binding s (make-Poly
                                    field-tvar-syms
                                    (->* (list raw-poly-prefab fld-t) -Void)))))
@@ -302,13 +302,13 @@
                       (if mutable
                           (->* (list poly-base) t)
                           (->acc (list poly-base) t (list path))))])
-          (add-struct-accessor-fn! g poly-base i mutable)
+          (add-struct-accessor-fn! g poly-base i mutable #f)
           (make-def-binding g func)))
       (if mutable
           (for/list ([s (in-list (struct-names-setters names))]
                      [t (in-list self-fields)]
                      [i (in-naturals parent-count)])
-            (add-struct-mutator-fn! s poly-base i)
+            (add-struct-mutator-fn! s poly-base i #f)
             (make-def-binding s (poly-wrapper (->* (list poly-base t) -Void))))
           null))))
 

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -253,7 +253,7 @@
                  [(ForcePE:) (list 'force sexp)]
                  [(StructPE: t idx)
                   (define maybe-accessor-id
-                    (id-for-struct-pe
+                    (find-struct-accessor-id
                      (λ (t* idx*) (and (subtype t t*)
                                        (= idx idx*)))))
                   (cond
@@ -262,7 +262,7 @@
                     [else (list 'struct-ref sexp idx)])]
                  [(PrefabPE: key idx)
                   (define maybe-accessor-id
-                    (id-for-struct-pe
+                    (find-struct-accessor-id
                      (λ (t* idx*) (and (Prefab? t*)
                                        (prefab-key-subtype? (Prefab-key t*) key)
                                        (= idx idx*)))))

--- a/typed-racket-lib/typed-racket/types/struct-table.rkt
+++ b/typed-racket-lib/typed-racket/types/struct-table.rkt
@@ -11,57 +11,88 @@
 
 
 ;; struct-type : what type is this an accessor for?
-;; field-index : what is the (absolute) field-index for this field?
-;;             (i.e. the `i` where `(unsafe-struct-ref s i)` would return
-;;                   this field)
-;; mutator? : #t if this is a mutator, #f if it is an accessor
-;; mutable? : #t if this field is mutable, #f if it is immutable
-(struct struct-field-entry (struct-type field-index mutator? mutable?) #:prefab)
+;; info : bitfield with field info
+;; bit 0 : is this a mutator?
+;; bit 1 : field mutability
+;; bit 2 : is this for a prefab struct?
+;; bits 3-rest : field index
+(struct struct-field-metadata (struct-type info) #:prefab)
+
+(define (mk-field-metadata struct-type field-index mutator? mutable? prefab?)
+  (struct-field-metadata
+   struct-type
+   (bitwise-ior (if mutator? #b001 #b000)
+                (if mutable? #b010 #b000)
+                (if prefab?  #b100 #b000)
+                (arithmetic-shift field-index 3))))
+
+(define (struct-field-accessor? metadata) (not (struct-field-mutator? metadata)))
+(define (struct-field-mutator? metadata) (bitwise-bit-set? (struct-field-metadata-info metadata)  0))
+(define (struct-field-mutable? metadata) (bitwise-bit-set? (struct-field-metadata-info metadata)  1))
+(define (struct-field-prefab? metadata)  (bitwise-bit-set? (struct-field-metadata-info metadata)  2))
+(define (struct-field-index metadata)    (arithmetic-shift (struct-field-metadata-info metadata) -3))
 
 (define struct-fn-table (make-free-id-table))
 
 
-(define (add-struct-accessor-fn! fn-id type idx mutable-field?)
-  (free-id-table-set! struct-fn-table fn-id (struct-field-entry type idx #f mutable-field?)))
+(define (add-struct-field-metadata! fn-id metadata)
+  (free-id-table-set! struct-fn-table fn-id metadata))
 
-(define (add-struct-mutator-fn! fn-id type idx)
-  (free-id-table-set! struct-fn-table fn-id (struct-field-entry type idx #t #t)))
+(define (add-struct-accessor-fn! fn-id type idx mutable-field? prefab?)
+  (free-id-table-set! struct-fn-table fn-id (mk-field-metadata type idx #f mutable-field? prefab?)))
+
+(define (add-struct-mutator-fn! fn-id type idx prefab?)
+  (free-id-table-set! struct-fn-table fn-id (mk-field-metadata type idx #t #t prefab?)))
 
 (define (struct-accessor? id)
   (match (free-id-table-ref struct-fn-table id #f)
-    [(struct-field-entry _ idx #f _) idx]
+    [(? struct-field-metadata? entry)
+     (and (not (struct-field-mutator? entry))
+          (struct-field-index entry))]
     [_ #f]))
 
 (define (struct-mutator? id)
   (match (free-id-table-ref struct-fn-table id #f)
-    [(struct-field-entry _ idx #t _) idx]
+    [(? struct-field-metadata? entry)
+     (and (struct-field-mutator? entry)
+          (struct-field-index entry))]
     [_ #f]))
 
 (define (immutable-struct-field-accessor? id)
   (match (free-id-table-ref struct-fn-table id #f)
-    [(struct-field-entry _ idx #t #t) idx]
+    [(? struct-field-metadata? entry)
+     (and (not (struct-field-mutable? entry))
+          (struct-field-index entry))]
+    [_ #f]))
+
+(define (prefab-struct-field-operator? id)
+  (match (free-id-table-ref struct-fn-table id #f)
+    [(? struct-field-metadata? entry) (struct-field-prefab? entry)]
     [_ #f]))
 
 (define (struct-fn-table-map f)
   (for/list ([(k v) (in-sorted-free-id-table struct-fn-table)])
     (f k v)))
 
+
 (define (id-for-struct-pe type/idx=?)
   (for*/or ([(id entry) (in-free-id-table struct-fn-table)]
-            [type (in-value (struct-field-entry-struct-type entry))]
-            [idx (in-value (struct-field-entry-field-index entry))]
+            [type (in-value (struct-field-metadata-struct-type entry))]
+            [idx (in-value (struct-field-index entry))]
             #:when (type/idx=? type idx))
     id))
 
 
-(provide struct-field-entry)
+(provide struct-field-metadata)
 
 (provide/cond-contract
- [add-struct-accessor-fn! (identifier? Type? exact-nonnegative-integer? boolean? . c:-> . c:any/c)]
- [add-struct-mutator-fn! (identifier? Type? exact-nonnegative-integer? . c:-> . c:any/c)]
+ [add-struct-accessor-fn! (identifier? Type? exact-nonnegative-integer? boolean? boolean? . c:-> . c:any/c)]
+ [add-struct-mutator-fn! (identifier? Type? exact-nonnegative-integer? boolean? . c:-> . c:any/c)]
+ [add-struct-field-metadata! (identifier? struct-field-metadata? . c:-> . c:any/c)]
  [struct-accessor? (identifier? . c:-> . (c:or/c #f exact-nonnegative-integer?))]
  [struct-mutator? (identifier? . c:-> . (c:or/c #f exact-nonnegative-integer?))]
+ [prefab-struct-field-operator? (identifier? . c:-> . c:any/c)]
  [immutable-struct-field-accessor? (identifier? . c:-> . exact-nonnegative-integer?)]
  [id-for-struct-pe (c:-> (c:-> Type? exact-nonnegative-integer? boolean?) (c:or/c identifier? #f))]
- [struct-fn-table-map (c:-> (c:-> identifier? struct-field-entry? c:any/c)
+ [struct-fn-table-map (c:-> (c:-> identifier? struct-field-metadata? c:any/c)
                             (c:listof c:any/c))])

--- a/typed-racket-test/succeed/prefab-field-provide.rkt
+++ b/typed-racket-test/succeed/prefab-field-provide.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+
+(module m typed/racket/base
+
+  (struct foo ([x : Integer]) #:prefab)
+  (define f (foo 42))
+  (struct bar ([y : Integer]) #:prefab #:mutable)
+  (define b (bar 43))
+  (provide f foo-x b bar-y set-bar-y!))
+
+(module n racket/base
+  (require (submod ".." m))
+  (display (foo-x f))
+  (display (bar-y b))
+  (set-bar-y! b 44)
+  (unless (with-handlers ([(λ (_) #t) (λ (_) #t)])
+            (set-bar-y! b "44")
+            #f)
+    (error "what happened!")))
+
+(require (submod 'n))


### PR DESCRIPTION
First attempt at fixing https://github.com/racket/typed-racket/issues/777.

Records which struct field operators are for prefab structs and avoids performing any contract generation for those values (since there is no reasonable protection to be offered beyond what the operator already inherently provides).