### PR TITLE
cover polymorphic types when printing

### DIFF
--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -293,21 +293,21 @@
     (filter-map
      (match-lambda
        [(and name/type (cons name t*))
-        (match t*
-          [(or (? Union?) (? BaseUnion?))
-           #:when (not (member name ignored-names))
-           (and (subtype t* t) name/type)]
-          [(Poly: names (and raw-body (or (? Union?) (? BaseUnion?))))
-           #:when (not (member name ignored-names))
-           (match (infer names null (list raw-body) (list t) Univ)
-             [(and (? hash? type-sub)
-                   (app (λ (sub) (subst-all sub raw-body))
-                        (and body (or (? Union?) (? BaseUnion?)))))
-              (define args (for/list ([arg-name (in-list names)])
-                             (type->sexp (t-subst-type (hash-ref type-sub arg-name)))))
-              (cons (cons name args) body)]
-             [_ #f])]
-          [_ #f])])
+        (and
+         (not (member name ignored-names))
+         (match t*
+           [(or (? Union?) (? BaseUnion?))
+            (and (subtype t* t) name/type)]
+           [(Poly: names (and raw-body (or (? Union?) (? BaseUnion?))))
+            (match (infer names null (list raw-body) (list t) Univ)
+              [(and (? hash? type-sub)
+                    (app (λ (sub) (subst-all sub raw-body))
+                         (and body (or (? Union?) (? BaseUnion?)))))
+               (define args (for/list ([arg-name (in-list names)])
+                              (type->sexp (t-subst-type (hash-ref type-sub arg-name)))))
+               (cons (cons name args) body)]
+              [_ #f])]
+           [_ #f]))])
      (force (current-type-names))))
   ;; names and the sets themselves (not the union types)
   ;; note that racket/set supports lists with equal?

--- a/typed-racket-test/unit-tests/type-printer-tests.rkt
+++ b/typed-racket-test/unit-tests/type-printer-tests.rkt
@@ -69,7 +69,7 @@
     (check-prints-as? (make-Opaque #'integer?) "(Opaque integer?)")
     (check-prints-as? (make-Immutable-Vector -Nat) "(Immutable-Vectorof Nonnegative-Integer)")
     (check-prints-as? (make-Mutable-Vector -Nat) "(Mutable-Vectorof Nonnegative-Integer)")
-    (check-prints-as? (make-Vector -Nat) "(U (Immutable-Vectorof Nonnegative-Integer) (Mutable-Vectorof Nonnegative-Integer))")
+    (check-prints-as? (make-Vector -Nat) "(Vectorof Nonnegative-Integer)")
     (check-prints-as? (make-Immutable-HeterogeneousVector (list -Symbol -String))
                       "(Immutable-Vector Symbol String)")
     (check-prints-as? (make-Mutable-HeterogeneousVector (list -Symbol -String))
@@ -218,7 +218,7 @@
     (check-prints-as? (-refine/fresh x (-vec Univ) (-leq (-lexp (-vec-len-of (-id-path x)))
                                                          (-lexp 42)))
                       (λ (str) (match (read (open-input-string str))
-                                 [`(Refine [,x : (U (Immutable-Vectorof Any) (Mutable-Vectorof Any))] (<= (vector-length ,x) 42)) #t]
+                                 [`(Refine [,x : (Vectorof Any)] (<= (vector-length ,x) 42)) #t]
                                  [_ #f])))
     (check-prints-as? (-refine/fresh x -Int (-and (-leq (-lexp x) (-lexp 42))
                                                   (-leq (-lexp 42) (-lexp x))

--- a/typed-racket-test/unit-tests/type-printer-tests.rkt
+++ b/typed-racket-test/unit-tests/type-printer-tests.rkt
@@ -204,6 +204,7 @@
       (check-prints-as? (make-Unit (list a^ b^) (list c^ d^) (list b^ a^) (-values (list -String)))
                         "(Unit (import a^ b^) (export c^ d^) (init-depend b^ a^) String)"))
     (check-prints-as? -UnitTop "UnitTop")
+    (check-prints-as? (-HT -String -Symbol) "(HashTable String Symbol)")
     (check-prints-as? (-refine/fresh x -Int (-leq (-lexp x) (-lexp 42)))
                       (λ (str) (match (read (open-input-string str))
                                  [`(Refine [,(? symbol? x) : Integer]


### PR DESCRIPTION
Previously the algorithm which tried to tidy-up large union types by covering them with type names in the current environment only considered monomorphic types. This adds support for polymorphic types as well.

e.g., previously hash-set had a very verbose type when printed because the `HashTable` abstraction wasn't considered:

```
> hash-set
- : (All (a b)
      (-> (U (Immutable-HashTable a b)
             (Mutable-HashTable a b)
             (Weak-HashTable a b))
          a
          b
          (Immutable-HashTable a b)))
#<procedure:hash-set>
```

and now it is:

```
> hash-set
- : (All (a b) (-> HashTable a b) a b (Immutable-HashTable a b)))
#<procedure:hash-set>
```

This of course also works for any user-defined types that are polymorphic (yay!).