### PR TITLE
Add types for new sha functions in v7.1

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -72,6 +72,7 @@ The following libraries are included with Typed Racket in the
 }
 
 @defmodule/incl[typed/file/md5]
+@defmodule/incl[typed/file/sha1]
 @defmodule/incl[typed/file/tar]
 @defmodule/incl[typed/framework]
 @defmodule/incl[typed/json]

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -2300,6 +2300,11 @@
 
 ;; Section 13.10
 
+;; Section 13.11
+[sha1-bytes (->opt (Un -Bytes -Input-Port) [-Nat (Un -Nat (-val #f))] -Bytes)]
+[sha224-bytes (->opt (Un -Bytes -Input-Port) [-Nat (Un -Nat (-val #f))] -Bytes)]
+[sha256-bytes (->opt (Un -Bytes -Input-Port) [-Nat (Un -Nat (-val #f))] -Bytes)]
+
 ;; Section 14.1 (Namespaces)
 [namespace? (make-pred-ty -Namespace)]
 [make-namespace (->opt [(one-of/c  'empty 'initial)] -Namespace)]

--- a/typed-racket-lib/typed/file/sha1.rkt
+++ b/typed-racket-lib/typed/file/sha1.rkt
@@ -1,0 +1,13 @@
+#lang typed/racket/base
+(require/typed file/sha1
+  [sha1 (->* [(U Bytes Input-Port)]
+             [Exact-Nonnegative-Integer
+              (U Exact-Nonnegative-Integer False)]
+             String)]
+  [sha1-bytes (->* [(U Bytes Input-Port)]
+                   [Exact-Nonnegative-Integer
+                    (U Exact-Nonnegative-Integer False)]
+                   Bytes)]
+  [bytes->hex-string (-> Bytes String)]
+  [hex-string->bytes (-> String Bytes)])
+(provide sha1 sha1-bytes bytes->hex-string hex-string->bytes)


### PR DESCRIPTION
Types for `sha1-bytes`, `sha224-bytes`, `sha256-bytes` along with types for `file/sha1` in `typed/file/sha1`.