### PR TITLE
fix 506: parent structs error when #:type-name is provided

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -72,7 +72,6 @@
     [v:parent
       (if (attribute v.par)
           (let* ([parent0 (parse-type #'v.par)]
-                 ;; TODO ensure this is a struct
                  [parent (let loop ((parent parent0))
                                (cond
                                  ((Name? parent) (loop (resolve-name parent)))
@@ -134,9 +133,12 @@
   ;; a type alias needs to be registered here too, to ensure
   ;; that parse-type will map the identifier to this Name type
   (define type-name (struct-names-type-name names))
-  (register-resolved-type-alias
-   type-name
-   (make-Name type-name (length (struct-desc-tvars desc)) (Struct? sty)))
+  (define (register-alias alias)
+    (register-resolved-type-alias
+     alias
+     (make-Name type-name (length (struct-desc-tvars desc)) (Struct? sty))))
+  (register-alias type-name)
+  (register-alias (struct-names-struct-name names))
   (register-type-name type-name
                       (make-Poly (struct-desc-tvars desc) sty)))
 

--- a/typed-racket-test/succeed/gh-issue-506.rkt
+++ b/typed-racket-test/succeed/gh-issue-506.rkt
@@ -1,0 +1,22 @@
+#lang typed/racket
+
+; Test for Github issue 506
+; https://github.com/racket/typed-racket/issues/506
+
+; Struct with #:type-name can be inherited:
+(struct a ([f : Integer]) #:type-name A)
+(struct b a ())
+(void (list
+       (ann (a 1) A)
+       (ann (b 1) A)
+       (ann (a 1) a)
+       (ann (b 1) a)))
+
+; Test with a polymorphic parent also:
+(struct (T) p ([a : T]) #:type-name P)
+(struct (T) q p ())
+(void (list
+       (ann (p 1) (P Integer))
+       (ann (q 1) (P Integer))
+       (ann (p 1) (p Integer))
+       (ann (q 1) (q Integer))))


### PR DESCRIPTION
Fix #506 

Note - this change means that the struct name can now be used as a type name. For example, consider `(struct a () #:type-name A)`

**Today:** Only `A` can be used as a type name. A new type named `a` cannot be created (the identifier is already in use.)

**With this change:** Both `A` and `a` can be used as type names to refer to this struct.

If this is a problem, my only idea is to introduce a new lookup table to map `a` to `A`. (There might be a better solution, but I don't know the codebase well enough.)