### PR TITLE
Introduce SequenceTop

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -519,6 +519,13 @@ or sets that are implemented using @racket[gen:set].
 is a sequence of strings, @racket[(Sequenceof Number String)] is a sequence which
 produces two values---a number and a string---on each iteration, etc.}
 
+@defidform[SequenceTop]{is the type of a @rtech{sequence} with unknown element
+  type and is the supertype of all sequences. This type typically
+  appears in programs via the combination of ocurrence typing ang
+  @racket[sequence?].
+@ex[(lambda: ([x : Any]) (if (sequence? x) x (error "not a sequence!")))]
+}
+
 @defform[(Custodian-Boxof t)]{A @rtech{custodian box} of @racket[t].}
 @defform[(Thread-Cellof t)]{A @rtech{thread cell} of @racket[t].}
 @defidform[Thread-CellTop]{is the type of a @rtech{thread cell} with unknown

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -35,6 +35,7 @@
           -MPairTop
           -BoxTop
           -ChannelTop
+          -SequenceTop
           -ThreadCellTop
           make-Ephemeron
           make-CustodianBox
@@ -1057,7 +1058,7 @@
 [make-weak-custom-hash (->opt (-> Univ Univ Univ) (-> Univ -Nat) [(-> Univ -Nat)] Univ)]
 
 ;; Section 4.14 (Sequences and Streams)
-[sequence? (make-pred-ty (-seq Univ))]
+[sequence? (make-pred-ty -SequenceTop)]
 [in-sequences
  (-poly (a) (->* (list) (-seq a) (-seq a)))]
 [in-cycle
@@ -1092,7 +1093,7 @@
 ;; Doesn't render nicely (but seems to work fine):
 [empty-sequence (-poly (a) (-seq a))]
 [sequence->list (-poly (a) ((-seq a) . -> . (-lst a)))]
-[sequence-length (-poly (a) ((-seq a) . -> . -Nat))]
+[sequence-length (-SequenceTop . -> . -Nat)]
 [sequence-ref (-poly (a) ((-seq a) -Integer . -> . a))]
 [sequence-tail (-poly (a) ((-seq a) -Integer . -> . (-seq a)))]
 [sequence-append (-poly (a) (->* (list) (-seq a) (-seq a)))]

--- a/typed-racket-lib/typed-racket/base-env/base-types.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-types.rkt
@@ -128,6 +128,7 @@
 [Mutable-VectorTop -Mutable-VectorTop]
 [HashTableTop -HashTableTop]
 [MPairTop -MPairTop]
+[SequenceTop -SequenceTop]
 [Thread-CellTop -ThreadCellTop]
 [Prompt-TagTop -Prompt-TagTop]
 [Continuation-Mark-KeyTop -Continuation-Mark-KeyTop]

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -516,6 +516,8 @@
         (or/sc (flat/sc #'exact-nonnegative-integer?)
                (sequence/sc (t->sc t)))]
        [(Sequence: ts) (apply sequence/sc (map t->sc ts))]
+       [(SequenceTop:)
+        (only-untyped (flat/sc #'sequence?))]
        [(Immutable-HeterogeneousVector: ts)
         (apply immutable-vector/sc (map t->sc ts))]
        [(Immutable-Vector: t)

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -1260,7 +1260,14 @@
    (f result)]
   [#:mask mask:unit])
 
-;; sequences
+
+;;************************************************************
+;; Sequences
+;;************************************************************
+
+(def-type SequenceTop ()
+  [#:singleton -SequenceTop])
+
 ;; includes lists, vectors, etc
 ;; tys : sequence produces this set of values at each step
 (def-type Sequence ([tys (listof Type?)])

--- a/typed-racket-lib/typed-racket/types/overlap.rkt
+++ b/typed-racket-lib/typed-racket/types/overlap.rkt
@@ -103,7 +103,11 @@
    [((Pair: a b) (Pair: a* b*)) (and (overlap? a a*)
                                      (overlap? b b*))]
    ;; lots of things are sequences, but not values where sequence? produces #f
-   [((Sequence: _) (Val-able: v)) #:no-order (sequence? v)]
+   [((or (Sequence: _)
+         (SequenceTop:))
+     (Val-able: v))
+    #:no-order
+    (sequence? v)]
    ;; hash tables are two-valued sequences
    [((Sequence: (or (list _) (list _ _ _ ...)))
      (or (HashTableTop:)
@@ -117,7 +121,11 @@
     #:no-order
     #f]
    ;; be conservative about other kinds of sequences
-   [((Sequence: _) _) #:no-order #t]
+   [((or (Sequence: _)
+         (SequenceTop:))
+     _)
+    #:no-order
+    #t]
    ;; Values where evt? produces #f cannot be Evt
    [((Evt: _) (Val-able: v)) #:no-order (evt? v)]
    [((Pair: _ _) _) #:no-order #f]

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -776,6 +776,7 @@
      `(Refinement ,(t->s parent) ,(syntax-e p?))]
     [(Sequence: ts)
      `(Sequenceof ,@(map t->s ts))]
+    [(SequenceTop:) 'SequenceTop]
     [(Error:) 'Error]
     ;[(fld: t a m) `(fld ,(type->sexp t))]
     [(Distinction: name sym ty) ; from define-new-subtype

--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -610,6 +610,16 @@
                (nbits-overlap? nbits bits)
                (bbits-overlap? bbits bits))
            A)]
+     [(SequenceTop:)
+      (cond
+        [(Base:Null? t1) A]
+        [(hash-ref seq->elem-table t1 #f) A]
+        [num?
+         (define type
+           (for/or ([num-t (in-list num-seq-types)])
+             (or (and (subtype* A t1 num-t) num-t))))
+         (and type A)]
+        [else #f])]
      [(Sequence: (list seq-t))
       (cond
         [(Base:Null? t1) A]
@@ -831,6 +841,7 @@
      (subtype-seq A
                   (subtype* key1 key2)
                   (subtype* val1 val2))]
+    [(SequenceTop:) A]
     [(Sequence: (list key2 val2))
      (subtype-seq A
                   (subtype* key1 key2)
@@ -856,6 +867,7 @@
      [(or (? Mutable-VectorTop?)
           (? Mutable-Vector?))
       #false]
+    [(SequenceTop:) A]
      [(Sequence: (list seq-t))
       (for/fold ([A A])
                 ([elem1 (in-list elems1)]
@@ -869,6 +881,7 @@
      [(or (? Mutable-VectorTop?)
           (? Mutable-Vector?))
       #false]
+    [(SequenceTop:) A]
      [(Sequence: (list seq-t))
       (subtype* A elem1 seq-t)]
      [_ (continue<: A t1 t2 obj)])]
@@ -948,6 +961,10 @@
                    (type≡? t12 t22))]
      ;; To check that mutable pair is a sequence we check that the cdr
      ;; is both an mutable list and a sequence 
+     [(SequenceTop:)
+      (subtype-seq A
+                   (subtype* t12 null-or-mpair-top)
+                   (subtype* t12 -SequenceTop))]
      [(Sequence: (list seq-t))
       (subtype-seq A
                    (subtype* t11 seq-t)
@@ -967,6 +984,7 @@
      (subtype-seq A
                   (type≡? key1 key2)
                   (type≡? val1 val2))]
+    [(SequenceTop:) A]
     [(Sequence: (list key2 val2))
      (subtype-seq A
                   (subtype* key1 key2)
@@ -992,6 +1010,7 @@
       (for/fold ([A A])
                 ([elem1 (in-list elems1)] #:break (not A))
         (type≡? A elem1 elem2))]
+     [(SequenceTop:) A]
      [(Sequence: (list seq-t))
       (for/fold ([A A])
                 ([elem1 (in-list elems1)]
@@ -1004,6 +1023,7 @@
       A]
      [(Mutable-Vector: elem2)
       (type≡? A elem1 elem2)]
+     [(SequenceTop:) A]
      [(Sequence: (list seq-t))
       (subtype* A elem1 seq-t)]
      [(Immutable-Vector: elem2)
@@ -1028,6 +1048,8 @@
       (subtype-seq A
                    (subtype* t11 t21 (-car-of obj))
                    (subtype* t12 t22 (-cdr-of obj)))]
+     [(SequenceTop:)
+      (subtype* A t12 (-lst Univ))]
      [(Sequence: (list seq-t))
       (subtype-seq A
                    (subtype* t11 seq-t)
@@ -1131,11 +1153,13 @@
   ;; sequences are covariant
   [(case: Sequence (Sequence: ts1))
    (match t2
+     [(SequenceTop:) A]
      [(Sequence: ts2) (subtypes* A ts1 ts2)]
      [_ (continue<: A t1 t2 obj)])]
   [(case: Set (Set: elem1))
    (match t2
      [(Set: elem2) (subtype* A elem1 elem2)]
+     [(SequenceTop:) A]
      [(Sequence: (list seq-t)) (subtype* A elem1 seq-t)]
      [_ (continue<: A t1 t2 obj)])]
   [(case: Struct (Struct: nm1 parent1 flds1 proc1 _ _))
@@ -1226,6 +1250,8 @@
       (for*/or ([b (in-list bs)]
                 [pred (in-value (Base-predicate b))])
         (and (pred val1) A))]
+     [(SequenceTop:)
+      (and (exact-nonnegative-integer? val1) A)]
      [(Sequence: (list seq-t))
       (cond
         [(exact-nonnegative-integer? val1)
@@ -1260,6 +1286,7 @@
      (subtype-seq A
                   (type≡? key1 key2)
                   (type≡? val1 val2))]
+    [(SequenceTop:) A]
     [(Sequence: (list key2 val2))
      (subtype-seq A
                   (subtype* key1 key2)


### PR DESCRIPTION
While implementing PolyDot sequences, I noticed that we'd have trouble generating contracts for unconstrained sequences. So here is a `SequenceTop` type to handle that case, as a prelude.

The expression
```
(sequence-length (in-parallel '(1 2 3) '(4 5 6)))
```
now typechecks.

This is my first time fiddling with TR internals, so apologies if this is totally the wrong approach!