### PR TITLE
Prevent failure generating constraints for values without psets

### DIFF
--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -480,12 +480,14 @@
               (ValuesDots: (list (Result: _ psets _) ...) _ _))
           (AnyValues: q))
          (cset-join
-          (for*/list ([pset (in-list psets)]
-                      [cs (in-value (% cset-meet
-                                       (cgen/prop context (PropSet-thn pset) q)
-                                       (cgen/prop context (PropSet-els pset) q)))]
-                      #:when cs)
-            cs))]
+          (cons
+           empty
+           (for*/list ([pset (in-list psets)]
+                       [cs (in-value (% cset-meet
+                                        (cgen/prop context (PropSet-thn pset) q)
+                                        (cgen/prop context (PropSet-els pset) q)))]
+                       #:when cs)
+             cs)))]
 
         ;; check all non Type? first so that calling subtype is safe
 

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -479,15 +479,15 @@
         [((or (Values: (list (Result: _ psets _) ...))
               (ValuesDots: (list (Result: _ psets _) ...) _ _))
           (AnyValues: q))
-         (cset-join
-          (cons
-           empty
-           (for*/list ([pset (in-list psets)]
-                       [cs (in-value (% cset-meet
-                                        (cgen/prop context (PropSet-thn pset) q)
-                                        (cgen/prop context (PropSet-els pset) q)))]
-                       #:when cs)
-             cs)))]
+         (if (null? psets)
+             empty
+             (cset-join
+              (for*/list ([pset (in-list psets)]
+                          [cs (in-value (% cset-meet
+                                           (cgen/prop context (PropSet-thn pset) q)
+                                           (cgen/prop context (PropSet-els pset) q)))]
+                          #:when cs)
+                cs)))]
 
         ;; check all non Type? first so that calling subtype is safe
 

--- a/typed-racket-test/succeed/values-dots-result.rkt
+++ b/typed-racket-test/succeed/values-dots-result.rkt
@@ -1,0 +1,6 @@
+#lang typed/racket/base
+
+(define #:forall (A ...) (f [v : (List A ... A)])
+  (apply values v))
+
+(f '(1 2 3))

--- a/typed-racket-test/unit-tests/infer-tests.rkt
+++ b/typed-racket-test/unit-tests/infer-tests.rkt
@@ -192,6 +192,7 @@
    (infer-t (-v a) (-v b) #:fail)
    (infer-t (-v a) (-v b) #:vars '(a))
    (infer-t (-v a) (-v b) #:vars '(b))
+   (infer-t (-values-dots '() (-v a) 'a) ManyUniv #:vars '(a))
 
    (infer-t (make-ListDots -Symbol 'b) (-lst -Symbol) #:indices '(b)
             #:result [(make-ListDots (-v b) 'b) -Null])

--- a/typed-racket-test/unit-tests/infer-tests.rkt
+++ b/typed-racket-test/unit-tests/infer-tests.rkt
@@ -192,7 +192,6 @@
    (infer-t (-v a) (-v b) #:fail)
    (infer-t (-v a) (-v b) #:vars '(a))
    (infer-t (-v a) (-v b) #:vars '(b))
-   (infer-t (-values-dots '() (-v a) 'a) ManyUniv #:vars '(a))
 
    (infer-t (make-ListDots -Symbol 'b) (-lst -Symbol) #:indices '(b)
             #:result [(make-ListDots (-v b) 'b) -Null])


### PR DESCRIPTION
I found this while working on dotted sequence types, but there is a simple case to reproduce:
```
(define #:forall (A ...) (f [v : (List A ... A)])
  (apply values v))
(f '(1 2 3))
```

When typechecked as a module form, the last line has expected type `AnyValues`, which ends up in a call `cgen` with types `(Values A ... A)` and `AnyValues`. The former (as an instance of ValuesDots with no non-var prefix) has an empty list of psets, which is joined to form a "null" cset (equal to `no-cset`), which results in a typecheck failure.

This change includes the empty cset in the join so that this case passes even when there are no psets, which seems to me to be the correct behavior.

Incidentally, if the example above is entered into the toplevel REPL instead of as a module, `tc-toplevel-form` passes `#f` as the expected type to `infer`, and typecheck succeeds with a default empty expected-cset.