### PR TITLE
Fix `send-mail-message` type definition

### DIFF
--- a/typed-racket-more/typed/net/sendmail.rkt
+++ b/typed-racket-more/typed/net/sendmail.rkt
@@ -6,6 +6,6 @@
   [send-mail-message/port
    (String String (Listof String) (Listof String) (Listof String) String * -> Output-Port)]
   [send-mail-message
-   (String String (Listof String) (Listof String) (Listof String) (Listof String) String * -> Output-Port)])
+   (String String (Listof String) (Listof String) (Listof String) (Listof String) String * -> Void)])
 
 (provide send-mail-message/port send-mail-message #;no-mail-recipients)


### PR DESCRIPTION
See [send-mail-message definition](https://docs.racket-lang.org/net/sendmail.html#%28def._%28%28lib._net%2Fsendmail..rkt%29._send-mail-message%29%29).