### PR TITLE
add some disarms

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/class-prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/class-prims.rkt
@@ -262,12 +262,12 @@
                             #'letrec-values))
     (define expanded (local-expand stx (syntax-local-context) stop-list))
     (define stx*
-      (syntax-parse expanded
+      (syntax-parse (disarm* expanded)
         #:literal-sets (kernel-literals)
         ;; an extra #%expression is inserted by the local expansion but
         ;; won't appear in the actual expansion, so ignore it
         [(#%expression e) #'e]
-        [_ expanded]))
+        [e #'e]))
     (syntax-parse stx*
       #:literal-sets (kernel-literals)
       #:literals (lambda λ)

--- a/typed-racket-lib/typed-racket/utils/redirect-contract.rkt
+++ b/typed-racket-lib/typed-racket/utils/redirect-contract.rkt
@@ -2,7 +2,8 @@
 
 (require syntax/private/modcollapse-noctc
          syntax/private/id-table
-         (for-template racket/base))
+         (for-template racket/base)
+         "disarm.rkt")
 (provide make-make-redirect-to-contract)
 
 ;; This is used to define identifiers that expand to a local-require
@@ -28,7 +29,8 @@
 
 (define id-table (make-free-id-table))
 
-(define ((make-make-redirect-to-contract contract-defs-submod-modidx) id)
+(define ((make-make-redirect-to-contract contract-defs-submod-modidx) orig-id)
+  (define id (disarm* orig-id))
   (define (redirect stx)
     (cond
      [(identifier? stx)

--- a/typed-racket-lib/typed-racket/utils/utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/utils.rkt
@@ -10,7 +10,8 @@ at least theoretically.
          racket/match
          racket/list
          syntax/parse/define
-         racket/struct-info "timing.rkt")
+         racket/struct-info "timing.rkt"
+         "disarm.rkt")
 
 (provide
  ;; optimization
@@ -217,7 +218,7 @@ at least theoretically.
 ;FIXME when multiple bindings are supported
 (define (self-ctor-transformer orig stx)
   (define (transfer-srcloc orig stx)
-    (datum->syntax orig (syntax-e orig) stx orig))
+    (datum->syntax (disarm* orig) (syntax-e orig) stx orig))
   (syntax-case stx ()
     [(self arg ...) (datum->syntax stx
                                    (cons (syntax-property (transfer-srcloc orig #'self)


### PR DESCRIPTION
Two extra calls to `disarm*` allow TR to keep working if some libraries are changed to include `syntax-protect`s (that seem needed).