### PR TITLE
[WIP] attempt to fix types for `raise-argument-error`

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-indexing-abs.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-indexing-abs.rkt
@@ -328,10 +328,6 @@
    [real->decimal-string (-Real [index-type] . ->opt .  -String)]
 
 
-   [raise-argument-error
-    (cl->*
-     [-> Sym -String Univ (Un)]
-     [->* (list Sym -String index-type) Univ (Un)])]
    [raise-type-error
     (cl->*
      [-> Sym -String Univ (Un)]

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1285,6 +1285,9 @@
  (cl->* (-> Sym (Un))
         (->* (list -String) Univ (Un))
         (->* (list Sym -String) Univ (Un)))]
+[raise-argument-error
+ (cl->* (->key Sym -String Univ #:more-info (Un -String (-val #f)) #t (Un))
+        (->key Sym -String -Nat #:more-info (Un -String (-val #f)) #t Univ (Un)))]
 [raise-user-error
  (cl->* (-> Sym (Un))
         (->* (list -String) Univ (Un))

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -231,6 +231,15 @@
 
 (define-syntax (->key stx)
   (syntax-parse stx
+    [(_ ty:expr ... (~seq k:keyword kty:expr opt:boolean) ... rst rng)
+     (syntax/loc stx
+       (make-Fun
+        (list
+         (-Arrow (list ty ...)
+                 rng
+		 #:rest rst
+                 #:kws (sort (list (make-Keyword 'k kty opt) ...)
+                             Keyword<?)))))]
     [(_ ty:expr ... (~seq k:keyword kty:expr opt:boolean) ... rng)
      (syntax/loc stx
        (make-Fun


### PR DESCRIPTION
This is connected to https://github.com/racket/racket/pull/2544

Currently this fix does not work but here you go.

Based on various examples, I extended `->key` in `base-abbrev.rkt` to
support rst pattern variable since the new `raise-argument-error`
defintion has a rest argument.

I then move the old `raise-argument-error` type to `base-env.rkt` and
replace the type abstraction with the extended `->key` abstraction.

My interpretation of the `->key` pattern is that since `#:more-info` is
an optional keyword it needs to have the following signature
`#:more-info (Un -String (-val #f)) #t` since it has default argument of
`#f` if no strings are provided. I think `#t` is used to indicate that
`#:more-info` is optional but I could be entirely wrong.