### PR TITLE
typed/web-server/http: update types (typed-racket-more v1.10)

### DIFF
--- a/typed-racket-doc/info.rkt
+++ b/typed-racket-doc/info.rkt
@@ -3,6 +3,7 @@
 (define collection 'multi)
 
 (define build-deps '("net-doc"
+                     "net-cookies-doc"
                      "scheme-lib"
                      "srfi-lite-lib"
                      "r6rs-doc"
@@ -14,7 +15,7 @@
                      "pict-lib"
                      ("typed-racket-lib" #:version "1.10")
                      "typed-racket-compatibility"
-                     "typed-racket-more"
+                     ("typed-racket-more" #:version "1.10")
                      "racket-doc"
                      "draw-lib"))
 (define deps '("base"))

--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -94,10 +94,29 @@ exported by @racketmodname[typed/json].
 @defmodule/incl[typed/mred/mred]
 @defmodule/incl[typed/net/base64]
 @defmodule/incl[typed/net/cgi]
-@defmodule/incl[typed/net/cookie]
+@defmodule/incl[typed/net/cookies]
+@defmodule/incl[typed/net/cookies/common]
+@history[#:added "1.10"]
+
+@defmodule/incl[typed/net/cookies/server]
 
 @deftype[Cookie]{
-  Describes an HTTP cookie as implemented by @racketmodname[net/cookie].
+ Describes a server-side @hyperlink["https://tools.ietf.org/html/rfc6265.html"]{RFC 6265}
+ HTTP cookie, as implemented by @racketmodname[net/cookies/server].
+}
+
+@history[#:added "1.10"]
+
+@defmodule/incl[typed/net/cookie]
+
+@deprecated[@racketmodname[typed/net/cookies]]{
+ This library is deprecated for the same reasons
+ that @racketmodname[net/cookie] is deprecated.
+}
+
+@deftype[Cookie]{
+ Describes an HTTP cookie as implemented by @racketmodname[net/cookie],
+ which is deprecated in favor of @racketmodname[net/cookies].
 }
 
 @defmodule/incl[typed/net/dns]
@@ -229,6 +248,11 @@ and the @racket[URL] and @racket[Path/Param] types from
 @defmodule/incl[typed/syntax/stx]
 @defmodule/incl[typed/web-server/configuration/responders]
 @defmodule/incl[typed/web-server/http]
+
+@history[#:changed "1.10"
+         @elem{Updated to reflect @racketmodname[web-server/http]
+          version 1.3.}]
+
 @defmodule/incl[typed/db]
 @defmodule/incl[typed/db/base]
 @defmodule/incl[typed/db/sqlite3]

--- a/typed-racket-more/info.rkt
+++ b/typed-racket-more/info.rkt
@@ -5,7 +5,8 @@
 (define deps '("srfi-lite-lib"
                "base"
 	       "net-lib"
-	       "web-server-lib"
+               "net-cookies-lib"
+	       ["web-server-lib" #:version "1.3"]
                ["db-lib" #:version "1.5"]
                "draw-lib"
                "rackunit-lib"
@@ -25,4 +26,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.9")
+(define version "1.10")

--- a/typed-racket-more/typed/net/cookies.rkt
+++ b/typed-racket-more/typed/net/cookies.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket/base
+
+(require "cookies/server.rkt"
+         "cookies/common.rkt")
+
+(provide (all-from-out "cookies/server.rkt")
+         (all-from-out "cookies/common.rkt"))

--- a/typed-racket-more/typed/net/cookies/common.rkt
+++ b/typed-racket-more/typed/net/cookies/common.rkt
@@ -1,0 +1,23 @@
+#lang typed/racket/base
+
+(require (for-syntax racket/base))
+
+(define-syntax require/typed/provide-string-predicates
+  (syntax-rules ()
+    [(_ id)
+     (begin (: id (-> Any Boolean : #:+ String))
+            (provide id)
+            (require/typed
+             net/cookies/common
+             [(id untyped-id) (-> Any Boolean)])
+            (define (id v)
+              (and (string? v)
+                   (untyped-id v))))]
+    [(_ id ...)
+     (begin (require/typed/provide-string-predicates id) ...)]))
+
+(require/typed/provide-string-predicates
+ cookie-name?
+ cookie-value?
+ path/extension-value?
+ domain-value?)

--- a/typed-racket-more/typed/net/cookies/server.rkt
+++ b/typed-racket-more/typed/net/cookies/server.rkt
@@ -1,0 +1,30 @@
+#lang typed/racket/base
+
+(require typed/racket/date)
+
+(require/typed/provide
+ net/cookies/server
+ #| ; a cookie is this, but the cookie constructor isn't provided
+ [#:struct cookie
+  ([name : String]
+   [value : String]
+   [expires : (U #f Date)]
+   [max-age : (U #f Exact-Positive-Integer)]
+   [domain : (U #f String)]
+   [path : (U #f String)]
+   [secure? : Boolean] ;; yes, really not Any
+   [http-only? : Boolean] ;; yes, really not Any
+   [extension : (U #f String)])]
+  |#
+ [#:opaque Cookie cookie?]
+ [make-cookie
+  (->* [String String]
+       [#:expires (U #f date)	 	 	 	 
+        #:max-age (U #f Exact-Positive-Integer)	 	 	 	 
+        #:domain (U #f String)	 	 	 	 
+        #:path (U #f String)	 	 	 	 
+        #:secure? Boolean ;; yes, really not Any	 	 	 	 
+        #:http-only? Boolean ;; yes, really not Any	 	 	 	 
+        #:extension (U #f String)]
+       Cookie)]
+ )


### PR DESCRIPTION
- Weaken the types of `response-output` and
  the `#:output` argument to `response/output`
  from `Void` to `Any`, corresponding to
  <https://github.com/racket/web-server/commit/a93685>
  and v1.2 of the `web-server-lib`.

  The return type should really be `AnyValues`
  to match the contract `any`,
  but Typed Racket can't generate a contract for `AnyValues`.

- Update the types for cookie-related functions
  to reflect the re-implementation based on `net/cookies/server`
  from <https://github.com/racket/web-server/commit/7974d4d>.
  This commit adds only as much of `typed/net/cookies/server`
  and `typed/net/cookies/common` as needed for `typed/web-server/http`.

- Document that `net/cookie` is deprecated.

- Update the types for `valid-id-cookie?` and `request-id-cookie`
  to support the `#:shelf-life` argument added in
  <https://github.com/racket/web-server/commit/626ad02>.

- Add the value `temporarily/same-method` with
  the type `Redirection-Status`, corresponding
  to <https://github.com/racket/web-server/commit/4601f4>.

- Correct the types of `response-seconds` and the
  corresponding arguments to `response/full`,
  `response/output`, and `response/xexpr`
  to use `Real`.
  While this corresponds to
  <https://github.com/racket/web-server/pull/61>,
  using response values containing complex numbers
  would cause runtime errors even before this:
  the `response-seconds` is passed to `seconds->date`.