### PR TITLE
doc: remove link from deprecated deftype Cookie

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -114,7 +114,7 @@ exported by @racketmodname[typed/json].
  that @racketmodname[net/cookie] is deprecated.
 }
 
-@deftype[Cookie]{
+@deftype[#:link-target? #false Cookie]{
  Describes an HTTP cookie as implemented by @racketmodname[net/cookie],
  which is deprecated in favor of @racketmodname[net/cookies].
 }


### PR DESCRIPTION
Add `#:link-target? #false` to the second definition of the `Cookie` type.

The goal here is to remove warnings like this from the TR docs:
```
WARNING: collected information for key multiple times: '(index-entry (form ((lib "typed-racket/typed-racket.rkt") Cookie))); values: (list '("Cookie") (list (cached-element (style "RktSym" (list 'tt-chars (css-addition '(collects #"scribble" #"racket.css")) (tex-addition '(collects #"scribble" #"racket.tex")))) "Cookie" ...)) (delayed-index-desc #<procedure:.../manual-bind.rkt:93:3>)) (list '("Cookie") (list (cached-element (style "RktSym" (list 'tt-chars (css-addition '(collects #"scribble" #"racket.css")) (tex-addition '(collects #"scribble" #"racket.tex")))) "Cookie" ...)) (delayed-index-desc #<procedure:.../manual-bind.rkt:93:3>))
```

In a small package with two `defidform`s, I know this change works.

For TR, I don't see the warning when I run `raco scribble ....` on the file (`libraries.scrbl`) but I do see it when I run `raco setup typed-racket`. Maybe there's a cache I need to delete?

Edit: this PR follows up on <https://github.com/racket/typed-racket/commit/acf77075d9e0802c69378be60031a8c83be55c44#commitcomment-33147423>. Between then & now, I tested `#:link-target? #false` on a small package.