### PR TITLE
test: change expected contract message

### DIFF
--- a/typed-racket-test/fail/class-contract-1.rkt
+++ b/typed-racket-test/fail/class-contract-1.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred #rx"promised: String.*produced: 'not-a-string")
+(exn-pred #rx"expected: String.*given: 'not-a-string")
 #lang racket
 
 ;; Ensure contracts for inner work correctly


### PR DESCRIPTION
The old message produced by class contracts was less accurate.

Discussion:

  <https://github.com/racket/racket/pull/2582>