### PR TITLE
Fixnum

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -741,6 +741,7 @@
 [exact? (make-pred-ty -ExactNumber)]
 [inexact? (make-pred-ty (Un -InexactReal -InexactImaginary -InexactComplex))]
 [fixnum? (make-pred-ty -Fixnum)]
+[fixnum-for-every-system? (asym-pred Univ B (-PS (-is-type 0 -Fixnum) -tt))]
 [index? (make-pred-ty -Index)]
 [positive? (-> -Real B : (-PS (-is-type 0 -PosReal) (-is-type 0 -NonPosReal)))]
 [negative? (-> -Real B : (-PS (-is-type 0 -NegReal) (-is-type 0 -NonNegReal)))]

--- a/typed-racket-lib/typed-racket/rep/numeric-base-types.rkt
+++ b/typed-racket-lib/typed-racket/rep/numeric-base-types.rkt
@@ -8,6 +8,7 @@
          (rep rep-utils base-type-rep type-mask core-rep)
          (types numeric-predicates)
          racket/unsafe/ops
+         racket/fixnum
          ;; For base type contracts
          (for-template racket/base racket/contract/base (types numeric-predicates)))
 
@@ -21,15 +22,12 @@
          nbits-union
          nbits-subtract)
 
-;; Is the number a fixnum on *all* the platforms Racket supports?  This
-;; works because Racket compiles only on 32+ bit systems.  This check is
+;; Is the number a fixnum on *all* the platforms Racket supports?  This check is
 ;; done at compile time to typecheck literals -- so use it instead of
 ;; `fixnum?' to avoid creating platform-dependent .zo files.
 (define (portable-fixnum? n)
-  (and (exact-integer? n)
-       (< n (expt 2 30))
-       (>= n (- (expt 2 30)))))
-;; same, for indexes
+  (fixnum-for-every-system? n))
+;; same, for indexes; Racket compiles only on 32+ bit systems
 (define (portable-index? n)
   (and (exact-integer? n)
        (< n (expt 2 28))


### PR DESCRIPTION
The implementation of `portable-fixnum?` is not correct for Racket CS, which has one less bit for fixnums on 32-bit platforms. I noticed because the implementation of `case` needs a similar function to replace its use of `fixnum?`. The `racket/fixnum` library now provides `fixnum-for-every-platform?`, so this patch uses and supports that function.