### PR TITLE
typed/web-server/http: response message inference (typed-racket-more v1.11)

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -251,7 +251,11 @@ and the @racket[URL] and @racket[Path/Param] types from
 
 @history[#:changed "1.10"
          @elem{Updated to reflect @racketmodname[web-server/http]
-          version 1.3.}]
+          version 1.3.}
+         #:changed "1.11"
+         @elem{Updated to reflect @racketmodname[web-server/http]
+          version 1.4.}
+         ]
 
 @defmodule/incl[typed/db]
 @defmodule/incl[typed/db/base]

--- a/typed-racket-more/info.rkt
+++ b/typed-racket-more/info.rkt
@@ -6,7 +6,7 @@
                "base"
 	       "net-lib"
                "net-cookies-lib"
-	       ["web-server-lib" #:version "1.3"]
+	       ["web-server-lib" #:version "1.4"]
                ["db-lib" #:version "1.5"]
                "draw-lib"
                "rackunit-lib"
@@ -26,4 +26,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.10")
+(define version "1.11")

--- a/typed-racket-more/typed/web-server/http.rkt
+++ b/typed-racket-more/typed/web-server/http.rkt
@@ -57,14 +57,14 @@
 (require/typed/provide web-server/http/response-structs
                        [#:struct response
                                  ([code : Natural]
-                                  [message : Bytes]
+                                  [message : Bytes] ;; NOT (Option Bytes)
                                   [seconds : Real]
                                   [mime : (Option Bytes)]
                                   [headers : (Listof Header)]
                                   [output : (-> Output-Port Any)])]
                        [response/full
                         (-> Natural
-                            Bytes
+                            (Option Bytes)
                             Real
                             (Option Bytes)
                             (Listof Header)
@@ -73,7 +73,7 @@
                        [response/output
                         (-> (-> Output-Port Any)
                             [#:code Natural]
-                            [#:message Bytes]
+                            [#:message (Option Bytes)]
                             [#:seconds Real]
                             [#:mime-type (Option Bytes)]
                             [#:headers (Listof Header)]
@@ -210,7 +210,7 @@
                        [response/xexpr
                         (-> Any  ;;; it should be `xexpr?`ed value, but `Any` also works well.
                             [#:code Natural]
-                            [#:message Bytes]
+                            [#:message (Option Bytes)]
                             [#:seconds Real]
                             [#:mime-type (Option Bytes)]
                             [#:headers (Listof Header)]


### PR DESCRIPTION
This commit weakens the type of the message argument
of `response/full`, `response/output`, and `response/xexpr`
from `Bytes` to `(Option Bytes)`.
A `#false` argument causes the message to be inferred from the
numeric response code: note that the type of `response-message`
*does not* change.

Corresponds to v1.4 of the `web-server-lib` package,
https://github.com/racket/web-server/commit/9262724, and
https://github.com/racket/web-server/pull/62.