### PR TITLE
Improve typechecking for for/last and for*/last

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -232,6 +232,7 @@ variants.
 @defform[(for/or   type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/sum type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/product type-ann-maybe (for-clause ...) expr ...+)]
+@defform[(for/last type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/set type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for*/list type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for*/hash type-ann-maybe (for-clause ...) expr ...+)]
@@ -241,6 +242,7 @@ variants.
 @defform[(for*/or   type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for*/sum type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for*/product type-ann-maybe (for-clause ...) expr ...+)]
+@defform[(for*/last type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for*/set type-ann-maybe (for-clause ...) expr ...+)]
 ]]{
 These behave like their non-annotated counterparts, with the exception
@@ -253,10 +255,8 @@ annotated with a @racket[Listof] type. All annotations are optional.
 @deftogether[[
 @defform[(for/and type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for/first type-ann-maybe (for-clause ...) expr ...+)]
-@defform[(for/last type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for*/and type-ann-maybe (for-clause ...) expr ...+)]
 @defform[(for*/first type-ann-maybe (for-clause ...) expr ...+)]
-@defform[(for*/last type-ann-maybe (for-clause ...) expr ...+)]
 ]]{
 Like the above, except they are not yet supported by the typechecker.
 }

--- a/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -390,8 +390,7 @@ the typed racket language.
   (for/list: for/list)
   (for/and: for/and)
   (for/or: for/or)
-  (for/first: for/first)
-  (for/last: for/last))
+  (for/first: for/first))
 
 ;; Unlike with the above, the inferencer can handle any number of #:when
 ;; clauses with these 2.
@@ -469,8 +468,7 @@ the typed racket language.
 (define-for*-variants
   (for*/and: for*/and)
   (for*/or: for*/or)
-  (for*/first: for*/first)
-  (for*/last: for*/last))
+  (for*/first: for*/first))
 
 ;; Like for/lists: and for/fold:, the inferencer can handle these correctly.
 (define-syntax (for*/lists: stx)
@@ -548,6 +546,8 @@ the typed racket language.
                   for*? #'for/folder: #'for/folder #'op #'initial #'final))
               ...))]))
 (define-for/acc:-variants
+  (for/last: for/fold: for/last #f begin #f #%expression)
+  (for*/last: for*/fold: for*/last #t begin #f #%expression)
   (for/sum: for/fold: for/sum #f + 0 #%expression)
   (for*/sum: for*/fold: for*/sum #t + 0 #%expression)
   (for*/list: for*/fold: for*/list #t (lambda (x y) (cons y x)) null reverse)

--- a/typed-racket-test/succeed/for-last.rkt
+++ b/typed-racket-test/succeed/for-last.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket
+
+(require typed/rackunit)
+
+(check-equal? (for/last : (U String #f) ([i '(1 2 3 4 5)]
+                                         #:when (even? i))
+                 (number->string i))
+              "4")
+
+(check-equal? (for/last ([i '()])
+                (error "doesn't get here"))
+              #f)
+
+(check-equal? (for*/last : (U (List Integer Char) #f) ([i '(1 2)]
+                                                       [j "ab"])
+                (list i j))
+              (list 2 #\b))
+
+(check-equal? (for*/last : (U (List Integer Integer) #f) ([i (in-range 5)]
+                                                          #:when (odd? i)
+                                                          [j (in-range 4)]
+                                                          #:unless (= i j))
+                (list i j))
+              (list 3 2))
+

--- a/typed-racket-test/succeed/for-last.rkt
+++ b/typed-racket-test/succeed/for-last.rkt
@@ -1,6 +1,6 @@
 #lang typed/racket
 
-(require typed/rackunit)
+(require math/array typed/rackunit)
 
 (check-equal? (for/last : (U String #f) ([i '(1 2 3 4 5)]
                                          #:when (even? i))
@@ -23,3 +23,25 @@
                 (list i j))
               (list 3 2))
 
+
+;; based on a question by 曹朝 on the Racket Users mailing list:
+;; https://groups.google.com/d/msg/racket-users/0tOGWZ9O57c/jRXJYkUdAQAJ
+(: shortest-edit-distance (-> String String (U #f Integer)))
+(define (shortest-edit-distance str0 str1)
+(let* ([l0 : Integer (string-length str0)]
+       [l1 : Integer (string-length str1)]
+       [table : (Mutable-Array Integer) (array->mutable-array (make-array (vector l0 l1) 0))])
+  (for*/last : (U #f Integer) ([i0 : Integer (in-range l0)]
+                               [i1 : Integer (in-range l1)])
+    (let* ([c0 : Char (string-ref str0 i0)]
+           [c1 : Char (string-ref str1 i1)]
+           [base : Integer (cond
+                             [(and (= i0 0) (= i1 0)) 0]
+                             [(= i0 0) (array-ref table (vector i0 (sub1 i1)))]
+                             [(= i1 0) (array-ref table (vector (sub1 i0) i1))]
+                             [else (min (array-ref table (vector i0 (sub1 i1)))
+                                        (array-ref table (vector (sub1 i0) i1))
+                                        (array-ref table (vector (sub1 i0) (sub1 i1))))])]
+           [answer : Integer (if (char=? c0 c1) base (add1 base))])
+      (array-set! table (vector i0 i1) answer)
+      answer))))


### PR DESCRIPTION
This fixes a problem raised about `for/last` and `for*/last` in this thread on the Racket Users List:
https://groups.google.com/d/topic/racket-users/0tOGWZ9O57c/discussion

It uses the existing internal `define-for/acc:-variants` macro to transform
```
(for/last : type (clause ...)
  body)
```
into
```
(for/fold ([acc : type #f])
          (clause ...)
  body)
```
which type-checks in more situations because it assigns a type for `acc` other than `False`.