### PR TITLE
Fix xvfb in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,11 @@ matrix:
   - TESTS=extra VARIANT=cs PATH=~/racket/bin:$PATH
   
 
+services:
+- xvfb
+
 before_install:
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
+- "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 - if [ $VARIANT = "cs" ]; then curl -L -o installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-cs-xenial.sh; else curl -L -o installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-precise.sh; fi
 - sh installer.sh --in-place --dest ~/racket/
 


### PR DESCRIPTION
There was some change in Travis-ci, and the test are failing. I tried with the new recommended method to start `xvfb`, but I got an error in the `integration` test. 

    exception-message:  "Gtk initialization failed for display \":99.0\"" 

(See [travis-ci/gus-massa/typed-racket/#L766](https://travis-ci.org/gus-massa/typed-racket/jobs/568025328#L766) )

After some googling ans some random tries, I got this solution, mostly from https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-directly , but I'm not sure about the details.

