### PR TITLE
make-sequence, do not check global env to infer type

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
@@ -40,13 +40,16 @@
   ;; to provide a better instantiation
   (pattern ((~var op (id-from 'make-sequence 'racket/private/for))
             (~and quo (quote (i:id ...))) arg:expr)
-    #:when (andmap type-annotation (syntax->list #'(i ...)))
+    #:do [(define i-anns
+            (for/list ([id (in-list (syntax-e #'(i ...)))])
+              (type-annotation id #:lookup? #false)))]
+    #:when (andmap values i-anns)
     (match (single-value #'op)
         [(tc-result1: (and t Poly?))
          (tc-expr/check #'quo (ret Univ))
          (tc/funapp #'op #'(quo arg)
                     (instantiate-poly t (list-extend (list Univ Univ)
-                                                     (stx-map type-annotation #'(i ...))
+                                                     i-anns
                                                      Univ))
                     (list (ret Univ) (single-value #'arg))
                     expected)]))

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -5188,6 +5188,14 @@
                                        (-is-type (cons 0 0) (-val #f)))
                                 : (make-Path null (cons 0 0))))
                         -true-propset))
+       (tc-e
+         ;; https://github.com/racket/typed-racket/issues/849
+         (let ()
+           (: x Zero)
+           (define x 0)
+           (for ((x (ann '(A B C) (Sequenceof Symbol))))
+             (void)))
+         -Void)
        )
       #reader tests/racket/maybe-single
       (if (single-flonum-available?)


### PR DESCRIPTION
When inferring a second arg. to `make-sequence`, don't check the global
env because the arg might be bound by a for-clause

fixes #849