### PR TITLE
adapt to `*in-directory` rename as `in-directory` from `racket/private/for`

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -262,7 +262,7 @@
   [(make-template-identifier 'in-bytes-lines 'racket/private/for)
    (->opt [-Input-Port -Symbol] (-seq -Bytes))]
   ;; in-directory
-  [(make-template-identifier '*in-directory 'racket/private/for)
+  [(make-template-identifier 'in-directory 'racket/private/for)
    (->opt [(Un (-val #f) -Pathlike) (-> -Path Univ)] (-seq -Path))]
   ;; in-producer
   [(make-template-identifier 'in-producer 'racket/private/for)


### PR DESCRIPTION
Sync with racket/racket@3907f35d1d.