### PR TITLE
WIP: Add Type/Predicate and make-positive-predicate

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -287,7 +287,7 @@ following steps are required:
   @item{Determine the data manipulated by the library, and how it will
   be represented in Typed Racket.}
   @item{Specify that data in Typed Racket, using @racket[require/typed]
-  and @racket[#:opaque] and/or @racket[#:struct].}
+  and @racket[#:type/predicate] and/or @racket[#:struct].}
   @item{Use the data types to import the various functions and constants
   of the library.}
   @item{Provide all the relevant identifiers from the new adapter module.}

--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -611,6 +611,7 @@ optionally-renamed identifier.
             [#:struct maybe-tvars (name-id parent) ([f : t] ...)
                  struct-option ...]
             [#:opaque t pred]
+            [#:type/predicate t pred]
 	    [#:signature name ([id : t] ...)]]
  [maybe-renamed id
                 (orig-id new-id)]
@@ -663,6 +664,11 @@ Opaque types must be required lexically before they are used.
                    [sync (Evt -> Any)])
     evt?
     (sync (alarm-evt (+ 100 (current-inexact-milliseconds))))]
+
+@index["type/predicate"]{The fifth case} defines a new type @racket[t]
+to represent values which have passed @racket[pred] at any point.
+@racket[pred] is imported from module @racket[m] with type
+@racket[(Any -> Boolean : #:+ t)].
 
 @index["signature"]{The @racket[#:signature] keyword} registers the required
 signature in the signature environment. For more information on the use of

--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -487,11 +487,26 @@ the type:
 @defform[(make-predicate t)]{
 
 Evaluates to a predicate for the type @racket[t], with the type
-@racket[(Any -> Boolean : t)]. @racket[t] may not contain function types, or
-types that may refer to mutable data such as @racket[(Vectorof Integer)].}
+@racket[(Any -> Boolean : t)]. @racket[t] may not contain function types,
+@racket[Type/Predicate] types, or types that may refer to mutable data
+such as @racket[(Vectorof Integer)].
+
+If the type @racket[t] includes @racket[Type/Predicate] types,
+@racket[make-positive-predicate] should be used instead.}
 
 @defform[(define-predicate name t)]{
-Equivalent to @racket[(define name (make-predicate t))].
+Equivalent to @racket[(define name (make-predicate t))].}
+
+@defform[(make-positive-predicate t)]{
+
+Evaluates to a predicate for the type @racket[t], with the type
+@racket[(Any -> Boolean : #:+ t)]. @racket[t] may not contain function types, or
+types that may refer to mutable data such as @racket[(Vectorof Integer)].
+
+@racket[make-positive-predicate] does work with @racket[Type/Predicate] types.}
+
+@defform[(define-positive-predicate name t)]{
+Equivalent to @racket[(define name (make-positive-predicate t))].}
 
 @section{Type Annotation and Instantiation}
 

--- a/typed-racket-doc/typed-racket/scribblings/reference/typed-units.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/typed-units.scrbl
@@ -255,6 +255,7 @@ The primary use of is for the reflective operation @racket[unit?]}
             [#:struct (name parent) ([f : t] ...)
                  struct-option ...]
             [#:opaque t pred]
+            [#:type/predicate t pred]
 	    [#:signature name ([id : t] ...)]]
  [maybe-renamed id
                 (orig-id new-id)]

--- a/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -1020,4 +1020,9 @@ prefab types with the (implicitly quoted) prefab-key
 @defform[(Opaque t)]{A type constructed using the @racket[#:opaque]
 clause of @racket[require/typed].}
 
+@defform[(Type/Predicate pred-id)]{
+  A type constructed using the @racket[#:type/predicate] clause of
+  @racket[require/typed].
+}
+
 @(close-eval the-eval)

--- a/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
@@ -20,7 +20,7 @@
 ;; special type names that are not bound to particular types
 (define-other-types
   -> ->* case-> U Union ∩ Intersection Rec All Opaque Immutable-Vector Mutable-Vector Vector
-  Parameterof List List* Class Object Row Unit Values AnyValues Instance Refinement
+  Parameterof List List* Class Object Row Unit Values AnyValues Instance Refinement Type/Predicate
   pred Struct Struct-Type Prefab PrefabTop Distinction Sequenceof Refine Self Imp)
 
 (define-other-props

--- a/typed-racket-lib/typed-racket/base-env/extra-env-lang.rkt
+++ b/typed-racket-lib/typed-racket/base-env/extra-env-lang.rkt
@@ -31,6 +31,7 @@
     #:attributes (form outer-form)
     (pattern :simple-clause)
     (pattern :opaque-clause)
+    (pattern :type/predicate-clause)
     (pattern :struct-clause))
 
   (define-syntax-class simple-clause
@@ -48,6 +49,19 @@
                                 (make-pred-ty (make-Opaque #'pred)))
                  (register-type-name (quote-syntax type)
                                      (make-Opaque #'pred)))
+             #:with outer-form #'(begin
+                                   (define-syntax type type-name-error)
+                                   (provide type pred))))
+
+  (define-syntax-class type/predicate-clause
+    #:description "[#:type/predicate type pred]"
+    (pattern [#:type/predicate type:id pred:id]
+             #:with form
+             #'(begin
+                 (register-type (quote-syntax id)
+                                (asym-pred Univ B (-PS (-is-type 0 (make-Type/Predicate #'pred)) -tt)))
+                 (register-type-name (quote-syntax type)
+                                     (make-Type/Predicate #'pred)))
              #:with outer-form #'(begin
                                    (define-syntax type type-name-error)
                                    (provide type pred))))
@@ -100,7 +114,8 @@
                              typed-racket/env/global-env typed-racket/env/type-alias-env
                              typed-racket/types/struct-table typed-racket/types/abbrev
                              typed-racket/typecheck/tc-structs
-                             (only-in typed-racket/rep/type-rep make-Name make-Opaque)
+                             (only-in typed-racket/rep/type-rep make-Name make-Opaque
+                                      make-Type/Predicate)
                              (rename-in racket/private/sort [sort raw-sort]))
                     ;; FIXME: add a switch to turn contracts on for testing
                     binding.form ...)))

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -275,6 +275,8 @@
                 (list ,@(map type->sexp rands)))]
     [(Opaque: pred)
      `(make-Opaque (quote-syntax ,pred))]
+    [(Type/Predicate: pred)
+     `(make-Type/Predicate (quote-syntax ,pred))]
     [(Refinement: parent pred)
      `(make-Refinement ,(type->sexp parent) (quote-syntax ,pred))]
     [(Mu-maybe-name: n (? Type? b))

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -139,6 +139,7 @@
 (define-literal-syntax-class #:for-label Union)
 (define-literal-syntax-class #:for-label All)
 (define-literal-syntax-class #:for-label Opaque)
+(define-literal-syntax-class #:for-label Type/Predicate)
 (define-literal-syntax-class #:for-label Parameter)
 (define-literal-syntax-class #:for-label Immutable-Vector)
 (define-literal-syntax-class #:for-label Mutable-Vector)
@@ -789,6 +790,8 @@
        (parse-all-type stx)]
       [(:Opaque^ p?:id)
        (make-Opaque #'p?)]
+      [(:Type/Predicate^ p?:id)
+       (make-Type/Predicate #'p?)]
       [(:Distinction^ name:id unique-id:id rep-ty:expr)
        (-Distinction (syntax-e #'name) (syntax-e #'unique-id) (parse-type #'rep-ty))]
       [(:Parameter^ t)
@@ -1106,6 +1109,8 @@
           Err])]
       [(:Opaque^ . rest)
        (parse-error "bad syntax in Opaque")]
+      [(:Type/Predicate^ . rest)
+       (parse-error "bad syntax in Type/Predicate")]
       [(:U^ . rest)
        (parse-error "bad syntax in Union")]
       [(:Rec^ . rest)

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -50,7 +50,11 @@
           #t)]
     [_ #f]))
 
-(struct contract-def (type flat? maker? typed-side) #:prefab)
+;; The exact? field determines whether the contract must decide
+;; exactly whether the value has the type.
+;;  - flat? true and exact? true must generate (-> Any Boolean : type)
+;;  - flat? true and exact? false can generate (-> Any Boolean : #:+ type)
+(struct contract-def (type flat? exact? maker? typed-side) #:prefab)
 
 ;; get-contract-def-property : Syntax -> (U False Contract-Def)
 ;; Checks if the given syntax needs to be fixed up for contract generation
@@ -83,7 +87,8 @@
 ;; (such as mutually recursive class types).
 (define (generate-contract-def stx cache sc-cache)
   (define prop (get-contract-def-property stx))
-  (match-define (contract-def type-stx flat? maker? typed-side) prop)
+  ;; TODO: deal with exact? differently for Type/Predicate and Opaque
+  (match-define (contract-def type-stx flat? exact? maker? typed-side) prop)
   (define *typ (if type-stx (parse-type type-stx) t:-Dead-Code))
   (define kind (if (and type-stx flat?) 'flat 'impersonator))
   (syntax-parse stx #:literals (define-values)

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -536,6 +536,11 @@
         (promise/sc (t->sc t))]
        [(Opaque: p?)
         (flat/sc #`(flat-named-contract (quote #,(syntax-e p?)) #,p?))]
+       [(Type/Predicate: p?)
+        ; TODO:
+        ;   make it error on `make-predicate`,
+        ;   but work on `make-positive-predicate`, `cast`, and type-untyped boundaries
+        (flat/sc #`(flat-named-contract (quote #,(syntax-e p?)) #,p?))]
        [(Continuation-Mark-Keyof: t)
         (continuation-mark-key/sc (t->sc t))]
        ;; TODO: this is not quite right for case->

--- a/typed-racket-lib/typed-racket/private/with-types.rkt
+++ b/typed-racket-lib/typed-racket/private/with-types.rkt
@@ -154,7 +154,7 @@
 (define (type-stxs->ids+defs type-stxs typed-side)
   (for/lists (_1 _2) ([t (in-list type-stxs)])
     (define ctc-id (generate-temporary))
-    (define contract-def `#s(contract-def ,t #f #f ,typed-side))
+    (define contract-def `#s(contract-def ,t #f #f #f ,typed-side))
     (values ctc-id
             #`(define-values (#,ctc-id)
                 #,(contract-def-property

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -543,6 +543,10 @@
   #:base
   [#:custom-constructor (make-Opaque (normalize-id pred))])
 
+(def-type Type/Predicate ([pred identifier?])
+  #:base
+  [#:custom-constructor (make-Type/Predicate (normalize-id pred))])
+
 
 
 ;;************************************************************

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/simple.rkt
@@ -47,7 +47,7 @@
         #:methods gen:equal+hash
          [(define (equal-proc s1 s2 recur)
             (and ;; have to make sure identifiers are compared by free-id=?
-                 ;; because of struct predicates, opaque, etc.
+                 ;; because of struct predicates, opaque, type/predicate, etc.
                  (stx-equal? (simple-contract-syntax s1)
                              (simple-contract-syntax s2))
                  (recur (simple-contract-kind s1)

--- a/typed-racket-lib/typed-racket/types/overlap.rkt
+++ b/typed-racket-lib/typed-racket/types/overlap.rkt
@@ -50,6 +50,7 @@
    [((Univ:) _) #:no-order #t]
    [((or (B: _) (F: _)) _) #:no-order #t]
    [((Opaque: _) _) #:no-order #t]
+   [((Type/Predicate: _) _) #:no-order #t]
    [((Name/simple: n) (Name/simple: n*)) #:when (free-identifier=? n n*) #t]
    [((Distinction: _ _ t1) t2) #:no-order (overlap? t1 t2)]
    [(t1 (or (? Name? t2)

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -655,6 +655,7 @@
     [(? improper-tuple? t)
      `(List* ,@(map type->sexp (improper-tuple-elems t)))]
     [(Opaque: pred) `(Opaque ,(syntax->datum pred))]
+    [(Type/Predicate: pred) `(Type/Predicate ,(syntax->datum pred))]
     [(Struct: nm par (list (fld: t _ _) ...) proc _ _ property-tys)
      `#(,(string->symbol (format "struct:~a" (syntax-e nm)))
         ,(map t->s t)

--- a/typed-racket-lib/typed/racket/unsafe.rkt
+++ b/typed-racket-lib/typed/racket/unsafe.rkt
@@ -54,4 +54,9 @@
         other-clause ...)
      #'(begin (unsafe-require/typed lib clause)
               (provide t pred)
+              (unsafe-require/typed/provide lib other-clause ...))]
+    [(_ lib (~and clause [#:type/predicate t:id pred:id])
+        other-clause ...)
+     #'(begin (unsafe-require/typed lib clause)
+              (provide t pred)
               (unsafe-require/typed/provide lib other-clause ...))]))

--- a/typed-racket-test/unit-tests/parse-type-tests.rkt
+++ b/typed-racket-test/unit-tests/parse-type-tests.rkt
@@ -291,8 +291,10 @@
          #:msg "Index 2 used in"]
 
    [(Opaque foo?) (make-Opaque #'foo?)]
+   [(Type/Predicate foo?) (make-Type/Predicate #'foo?)]
    ;; PR 14122
    [FAIL (Opaque 3)]
+   [FAIL (Type/Predicate 3)]
 
    ;; struct types
    [(Struct-Type arity-at-least) (make-StructType (resolve -Arity-At-Least))]

--- a/typed-racket-test/unit-tests/subtype-tests.rkt
+++ b/typed-racket-test/unit-tests/subtype-tests.rkt
@@ -148,6 +148,9 @@
    ;; Opaque
    [(make-Opaque x1) (make-Opaque x2)]
    [FAIL (make-Opaque #'a) (make-Opaque #'b)]
+   ;; Type/Predicate
+   [(make-Type/Predicate x1) (make-Type/Predicate x2)]
+   [FAIL (make-Type/Predicate #'a) (make-Type/Predicate #'b)]
    ;; Refinement
    [(make-Refinement A x1) (make-Refinement A x2)]
    ;[(make-Refinement t1a x1) (make-Refinement t1b x1)]

--- a/typed-racket-test/unit-tests/type-printer-tests.rkt
+++ b/typed-racket-test/unit-tests/type-printer-tests.rkt
@@ -67,6 +67,7 @@
 
     (check-prints-as? -Custodian "Custodian")
     (check-prints-as? (make-Opaque #'integer?) "(Opaque integer?)")
+    (check-prints-as? (make-Type/Predicate #'integer?) "(Type/Predicate integer?)")
     (check-prints-as? (make-Immutable-Vector -Nat) "(Immutable-Vectorof Nonnegative-Integer)")
     (check-prints-as? (make-Mutable-Vector -Nat) "(Mutable-Vectorof Nonnegative-Integer)")
     (check-prints-as? (make-Vector -Nat) "(Vectorof Nonnegative-Integer)")


### PR DESCRIPTION
Addresses https://github.com/racket/typed-racket/issues/457 by adding `Type/Predicate` and `#:type/predicate` as sound versions of what's most useful about `Opaque` and `#:opaque`.

- [x] 1. A type constructor `Type/Predicate` that takes a predicate id and produces a type. If `foo?` is a predicate, then `(Type/Predicate foo?)` produces a type for values that have passed `foo?` even just once. So if `(foo? x)` returns `#true` and then returns `#false`, `x` still has type `Foo` after that.
 
- [x] 2. A required/typed keyword `[#:type/predicate Foo foo?]` that imports the predicate `foo?` and defines the type `Foo` as `(Type/Predicate foo?)`. The `foo?` predicate is imported with type `(-> Any Boolean : #:+ Foo)`. It can _not_ have type `(-> Any Boolean : Foo)`.

- [x] 3. A new expression form `make-positive-predicate` that takes a type and produces a predicate with only the positive `#:+` proposition. So `(make-positive-predicate X)` will produce a predicate with the type `(-> Any Boolean : #:+ X)`.
   * `(make-positive-predicate (Type/Predicate foo?))` produces a predicate equivalent to `foo?` with type `(-> Any Boolean : #:+ (Type/Predicate foo?))`
   * `(make-positive-predicate (Opaque foo?))` also produces a predicate equivalent to `foo?` with type `(-> Any Boolean : #:+ (Opaque foo?))`

- [ ] 4. Make sure `make-predicate` errors on `Type/Predicate` types, with an error message that suggests using `make-positive-predicate` instead. It should give a warning on `Opaque` types, similarly suggesting `make-positive-predicate` instead.
