### PR TITLE
Support #:result clause in for/fold and for/list

### DIFF
--- a/typed-racket-doc/info.rkt
+++ b/typed-racket-doc/info.rkt
@@ -13,7 +13,7 @@
                      "at-exp-lib"
                      ("scribble-lib" #:version "1.16")
                      "pict-lib"
-                     ("typed-racket-lib" #:version "1.10")
+                     ("typed-racket-lib" #:version "1.11")
                      "typed-racket-compatibility"
                      ("typed-racket-more" #:version "1.10")
                      "racket-doc"
@@ -26,4 +26,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.10")
+(define version "1.11")

--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -262,26 +262,34 @@ Like the above, except they are not yet supported by the typechecker.
 }
 
 @deftogether[[
-@defform[(for/lists type-ann-maybe ([id : t] ...)
+@defform[(for/lists type-ann-maybe ([id : t] ... maybe-result)
            (for-clause ...)
            expr ...+)]
-@defform[(for/fold  type-ann-maybe ([id : t init-expr] ...)
+@defform[(for/fold  type-ann-maybe ([id : t init-expr] ... maybe-result)
            (for-clause ...)
-           expr ...+)]]]{
+           expr ...+)
+         #:grammar
+         ([maybe-result (code:line)
+                        (code:line #:result result-expr)])]]]{
 These behave like their non-annotated counterparts. Unlike the above,
 @racket[#:when] clauses can be used freely with these.
+@history[#:changed "1.11" @elem{Added the @racket[#:result] form.}]
 }
 
 @deftogether[[
 @defform[(for* void-ann-maybe (for-clause ...)
            expr ...+)]
-@defform[(for*/lists type-ann-maybe ([id : t] ...)
+@defform[(for*/lists type-ann-maybe ([id : t] ... maybe-result)
            (for-clause ...)
            expr ...+)]
-@defform[(for*/fold  type-ann-maybe ([id : t init-expr] ...)
+@defform[(for*/fold  type-ann-maybe ([id : t init-expr] ... maybe-result)
            (for-clause ...)
-           expr ...+)]]]{
+           expr ...+)
+         #:grammar
+         ([maybe-result (code:line)
+                        (code:line #:result result-expr)])]]]{
 These behave like their non-annotated counterparts.
+@history[#:changed "1.11" @elem{Added the @racket[#:result] form.}]
 }
 
 @defform/subs[(do : u ([id : t init-expr step-expr-maybe] ...)

--- a/typed-racket-lib/info.rkt
+++ b/typed-racket-lib/info.rkt
@@ -12,4 +12,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.10")
+(define version "1.11")

--- a/typed-racket-lib/typed-racket/base-env/for-clauses.rkt
+++ b/typed-racket-lib/typed-racket/base-env/for-clauses.rkt
@@ -36,7 +36,11 @@
   #:attributes (ann-name init ty)
   (pattern (:optionally-annotated-name init:expr)))
 
+(define-splicing-syntax-class result-clause
+  #:description "result clause"
+  (pattern (~seq #:result result-expr:expr)))
+
 (define-syntax-class accumulator-bindings
   #:description "accumumulator bindings"
-  #:attributes ((ann-name 1) (init 1) (ty 1))
-  (pattern (:accumulator-binding ...)))
+  #:attributes ((ann-name 1) (init 1) (ty 1) result)
+  (pattern (:accumulator-binding ... (~optional result:result-clause))))

--- a/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -398,19 +398,19 @@ the typed racket language.
 (define-syntax (for/lists: stx)
   (syntax-parse stx
     [(_ a1:optional-standalone-annotation*
-        (var:optionally-annotated-formal ...)
+        (var:optionally-annotated-formal ... (~optional result:result-clause))
         clause:for-clauses
         a2:optional-standalone-annotation*
         c ...)
      (define all-typed? (andmap values (attribute var.ty)))
      (define for-stx
        (quasisyntax/loc stx
-          (for/lists (var.ann-name ...)
+          (for/lists (var.ann-name ... (~@ . (~? result ())))
             (clause.expand ... ...)
             c ...)))
      ((attribute a1.annotate)
       ((attribute a2.annotate)
-       (if all-typed?
+       (if (and all-typed? (not (attribute result)))
            (add-ann
             for-stx
             #'(values var.ty ...))
@@ -425,12 +425,12 @@ the typed racket language.
      (define all-typed? (andmap values (attribute accum.ty)))
      (define for-stx
        (quasisyntax/loc stx
-         (for/fold ((accum.ann-name accum.init) ...)
+         (for/fold ((accum.ann-name accum.init) ... (~@ . (~? accum.result ())))
                    (clause.expand ... ...)
            c ...)))
      ((attribute a1.annotate)
       ((attribute a2.annotate)
-       (if all-typed?
+       (if (and all-typed? (not (attribute accum.result)))
            (add-ann
             for-stx
             #'(values accum.ty ...))
@@ -476,37 +476,37 @@ the typed racket language.
 (define-syntax (for*/lists: stx)
   (syntax-parse stx
     [(_ a1:optional-standalone-annotation*
-        ((var:optionally-annotated-name) ...)
+        ((var:optionally-annotated-name) ... (~optional result:result-clause))
         clause:for-clauses
         a2:optional-standalone-annotation*
         c ...)
      (define all-typed? (andmap values (attribute var.ty)))
      (define for-stx
        (quasisyntax/loc stx
-         (for/lists (var.ann-name ...)
+         (for/lists (var.ann-name ... (~@ . (~? result ())))
              (clause.expand* ... ...)
            c ...)))
      ((attribute a1.annotate)
       ((attribute a2.annotate)
-       (if all-typed?
+       (if (and all-typed? (not (attribute result)))
            (add-ann for-stx #'(values var.ty ...))
            for-stx)))]))
 (define-syntax (for*/fold: stx)
   (syntax-parse stx #:literals (:)
     [(_ a1:optional-standalone-annotation*
-        ((var:optionally-annotated-name init:expr) ...)
+        ((var:optionally-annotated-name init:expr) ... (~optional result:result-clause))
         clause:for-clauses
         a2:optional-standalone-annotation*
         c ...)
      (define all-typed? (andmap values (attribute var.ty)))
      (define for-stx
        (quasisyntax/loc stx
-         (for/fold ((var.ann-name init) ...)
+         (for/fold ((var.ann-name init) ... (~@ . (~? result ())))
              (clause.expand* ... ...)
            c ...)))
      ((attribute a1.annotate)
       ((attribute a2.annotate)
-       (if all-typed?
+       (if (and all-typed? (not (attribute result)))
            (add-ann for-stx #'(values var.ty ...))
            for-stx)))]))
 

--- a/typed-racket-test/fail/for-result-bad-ann-1.rkt
+++ b/typed-racket-test/fail/for-result-bad-ann-1.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket
+(for/lists : (Values (Listof Integer) (Listof Integer))
+           ([l1 : (Listof Integer)]
+            [l2 : (Listof Integer)]
+            #:result (+ (length l1) (length l2)))
+           ([x (in-range 3)])
+  (values x x))

--- a/typed-racket-test/fail/for-result-bad-ann-2.rkt
+++ b/typed-racket-test/fail/for-result-bad-ann-2.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket
+(for*/lists : (Values (Listof Integer) (Listof Integer))
+            ([l1 : (Listof Integer)]
+             [l2 : (Listof Integer)]
+             #:result (append l1 l2))
+            ([x (in-range 3)])
+  (values x x))

--- a/typed-racket-test/fail/for-result-bad-ann-3.rkt
+++ b/typed-racket-test/fail/for-result-bad-ann-3.rkt
@@ -1,0 +1,6 @@
+#lang typed/racket
+(for/fold : Integer
+           ([x : Integer 0]
+            #:result (number->string x))
+           ([y (in-range 3)])
+  (+ x y))

--- a/typed-racket-test/fail/for-result-bad-ann-4.rkt
+++ b/typed-racket-test/fail/for-result-bad-ann-4.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket
+(for*/fold : (Values Integer Integer)
+           ([x : Integer 0]
+            [y : Integer 0]
+            #:result (+ x y))
+           ([i (in-range 3)]
+            [j (in-range 3)])
+  (values (+ x i) (+ y i j)))

--- a/typed-racket-test/succeed/for-result.rkt
+++ b/typed-racket-test/succeed/for-result.rkt
@@ -1,0 +1,55 @@
+#lang typed/racket
+
+(require typed/rackunit)
+
+(check-equal?
+ (for/lists ([l1 : (Listof Integer)]
+             [l2 : (Listof Integer)]
+             #:result (append l1 l2))
+            ([x (in-range 3)])
+   (values x (add1 x)))
+ '(0 1 2 1 2 3))
+
+(check-equal?
+ (for/lists : Integer
+            ([l1 : (Listof Integer)]
+             [l2 : (Listof Integer)]
+             #:result (+ (length l1) (length l2)))
+            ([x (in-range 3)])
+   (values x (add1 x)))
+ 6)
+
+(check-equal?
+ (let-values ([(v1 v2)
+               (for/lists ([l1 : (Listof Integer)]
+                           [l2 : (Listof Integer)]
+                           #:result (values l2 l1))
+                          ([x (in-range 3)])
+                 (values x (add1 x)))])
+   (append v1 v2))
+ '(1 2 3 0 1 2))
+
+(check-equal?
+ (for/fold ([x : Integer 0]
+            #:result (number->string x))
+           ([y (in-range 3)])
+   (+ x y))
+ "3")
+
+(check-equal?
+ (for/fold : String
+           ([x : Integer 1]
+            #:result (number->string x))
+           ([y (in-range 3)])
+   (+ x y))
+ "4")
+
+(check-equal?
+ (for*/fold : Integer
+            ([x : Integer 0]
+             [y : Integer 0]
+             #:result (+ x y))
+            ([i (in-range 3)]
+             [j (in-range 3)])
+  (values (+ x i) (+ y i j)))
+ 27)

--- a/typed-racket/info.rkt
+++ b/typed-racket/info.rkt
@@ -11,4 +11,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.10")
+(define version "1.11")


### PR DESCRIPTION
Syntax is the same as untyped racket; the existing optional return type annotation can be used as necessary.

I've updated the documentation and bumped the version number since the API has changed.

Closes issue #872.