### PR TITLE
Preserve plambda property when typechecking expanded opt-lambdas

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
@@ -305,14 +305,16 @@
                    (~and _ (~bind [(mand-kw 1) '()])))
               (quote (all-kw:keyword ...))
               . rst))))
-       (ret (kw-unconvert (tc-expr/t #'fun)
+       (define p (plambda-property form))
+       (ret (kw-unconvert (tc-expr/t (plambda-property #'fun p))
                           (syntax->list #'(formals ...))
                           (syntax->datum #'(mand-kw ...))
                           (syntax->datum #'(all-kw ...))))]
       [(~and opt:opt-lambda^
              (let-values ([(f) fun])
                (case-lambda (formals . cl-body) ...)))
-       (ret (opt-unconvert (tc-expr/t #'fun)
+       (define p (plambda-property form))
+       (ret (opt-unconvert (tc-expr/t (plambda-property #'fun p))
                            (syntax->list #'(formals ...))))]
       ;; let
       [(let-values bindings . body)

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -2839,10 +2839,12 @@
              #:ret (ret -String #f #f)]
        [tc-e ((inst (tr:lambda #:forall (A ...) (x . [rst : A ... A]) rst) String) 'a "foo")
              (-lst* -String)]
-       #| FIXME: does not work yet, TR thinks the type variable is unbound
        [tc-e (inst (tr:lambda #:forall (A) (x [y : A] [z : String "z"]) y) String)
              #:ret (tc-ret (->opt Univ -String [-String] -String) -true-propset)]
-       |#
+       [tc-e (inst (tr:lambda #:forall (A) (x #:y [y : A] [z : String "z"]) y) String)
+             #:ret (tc-ret (->optkey Univ [-String] #:y -String #t -String))]
+       [tc-e (inst (tr:lambda #:forall (A) (x #:y [y : A] #:z [z : String "z"]) y) String)
+             #:ret (tc-ret (->key Univ #:y -String #t #:z -String #f -String))]
 
        ;; test `define` with mixed type annotations
        [tc-e (let () (tr:define y "bar")


### PR DESCRIPTION
lambdas with optional arguments expand to a

  `(let-values (((core) (lambda))) (case-lambda))`

form, which is special-cased in tc-expr-unit. Properties added
to the expansion of typed-lambda (including type var information)
are attached to the whole let-values expression, rather than the
core lambda. To correctly parse type variables in the core lambda,
this patch re-adds the plambda property (if any) when passing it to typecheck.

This fixes #875, https://github.com/racket/racket/issues/1130 and possibly others.