### PR TITLE
Separate types of find-or-create-brush depending on first argument's type

### DIFF
--- a/typed-racket-more/typed/racket/private/gui-types.rkt
+++ b/typed-racket-more/typed/racket/private/gui-types.rkt
@@ -162,7 +162,8 @@
 (define-type Brush-List%
   (Class [find-or-create-brush
           (case->
-           ((U (Instance Color%) String) Brush-Style -> (Option (Instance Brush%))))]))
+           ((Instance Color%) Brush-Style -> (Instance Brush%))
+           (String Brush-Style -> (Option (Instance Brush%))))]))
 
 (define-type Pen%
   (Class (init [color (U String (Instance Color%)) #:optional]


### PR DESCRIPTION
According to the racket/draw documentation, [`find-or-create-brush`][docs] returns a `brush%` or `#f` if the first argument is a string, but always returns a `brush%` if the first argument is a `color%` instead.

The linked docs aren't very clear; according to the above link, `find-or-create-brush` may also always return a `brush%` even if its first argument is a string.

As a side note, the implementation of `find-or-create-brush` [seems to return a black brush][black] if the first argument is a string that isn't recognized as a `color%`. Should the documentation be updated to reflect this or is this intentionally left ambiguous?

[docs]: https://docs.racket-lang.org/draw/brush-list_.html#%28meth._%28%28%28lib._racket%2Fdraw..rkt%29._brush-list~25%29._find-or-create-brush%29%29
[black]: https://github.com/racket/draw/blob/6ada7d8abdc664b4b4b42c6e2a7a3703d3794f9e/draw-lib/racket/draw/private/brush.rkt#L222