### PR TITLE
Only allow 29 bits of mask size, to support 32-bit Racket CS.

### DIFF
--- a/typed-racket-lib/typed-racket/rep/type-mask.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-mask.rkt
@@ -11,7 +11,7 @@
 ;;
 ;; - - Details - -
 ;;
-;; Type masks are represented with a simple 30-bit fixnum.
+;; Type masks are represented with a simple 29-bit fixnum.
 ;;
 ;; If a bit flag in a Type's bitmask is set to 1, it means the Type
 ;; _may_ overlap with the values described by that bit flag.
@@ -52,13 +52,13 @@
 ;; type mask predicate
 (define-syntax type-mask? (make-rename-transformer #'fixnum?))
 
-;; define the max size of type  masks -- if we limit the size to
-;; 30 we are guaranteed to be a fixnum on 32 and 64 bit machines.
-;; (30 is the max number of bits available in a 2's complement
-;; tagged integer on a 32-bit machine)
+;; define the max size of type masks -- if we limit the size to 29 we
+;; are guaranteed to be a fixnum on 32 and 64 bit machines.  (29 is
+;; the max number of bits available in a 2's complement tagged integer
+;; on a 32-bit machine (on Racket CS, traditional Racket has 30 bits))
 (module const racket/base
   (provide max-mask-size)
-  (define max-mask-size 30))
+  (define max-mask-size 29))
 (require 'const (for-syntax 'const))
 
 
@@ -140,7 +140,6 @@
  mask:thread-cell
  mask:promise ;; huh? (structs can be promises)
  mask:ephemeron
- mask:future
  mask:other-box
  mask:set
  mask:procedure

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -398,8 +398,7 @@
 ;; Future
 ;;---------
 
-(def-structural Future ([t #:covariant])
-  [#:mask mask:future])
+(def-structural Future ([t #:covariant]))
 
 
 ;;---------------


### PR DESCRIPTION
Drop `mask:future` since subtyping with future values seems
uncommon.

Related to racket/racket#2925.