### PR TITLE
more docs for #:opaque

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/guide/typed-untyped-interaction.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/typed-untyped-interaction.scrbl
@@ -73,6 +73,49 @@ typed/racket
 is a valid use of the @racket[require/typed] form and imports @racket[add1]
 from the @racketmodname[racket/base] library.
 
+
+@subsection{Opaque Types}
+
+The @racket[#:opaque] clause of @racket[require/typed] defines a new type
+ using a predicate from untyped code.
+Suppose we have an untyped distance function that uses
+ pairs of numbers as points:
+
+@racketmod[#:file "distance2.rkt"
+racket
+
+(provide point?
+         distance)
+
+(code:contract A Point is a (cons real real))
+(define (point? x)
+  (and (pair? x)
+       (real? (car x))
+       (real? (cdr x))))
+
+(code:contract distance : Point Point -> real)
+(define (distance p1 p2)
+  (sqrt (+ (sqr (- (car p2) (car p1)))
+           (sqr (- (cdr p2) (cdr p1))))))
+]
+
+A typed module can use @racket[#:opaque] to define a @racket[Point] type as
+ all values that the @racket[point?] predicate returns @racket[#t] for:
+
+@racketmod[#:file "client2.rkt"
+typed/racket
+
+(require/typed "distance2.rkt"
+               [#:opaque Point point?]
+               [distance (-> Point Point Real)])
+
+(define p0 : Point (assert (cons 3 5) point?))
+(define p1 : Point (assert (cons 7 0) point?))
+(distance p0 p1)
+]
+
+
+
 @section{Using Typed Code in Untyped Code}
 
 In the previous subsection, we saw that the use of untyped code from

--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -659,10 +659,11 @@ be used as a predicate in @racket[if] expressions in Typed Racket.
                         [left  : IntTree]
                         [right : IntTree])]))]
 
-@index["opaque"]{The fourth case} defines a new type @racket[t].  @racket[pred], imported from
-module @racket[m], is a predicate for this type.  The type is defined
-as precisely those values to which @racket[pred] produces
-@racket[#t].  @racket[pred] must have type @racket[(Any -> Boolean)].
+@index["opaque"]{The fourth case} defines a new type @racket[t] using the
+function @racket[pred] as a @seclink["Generating_Predicates_Automatically"]{predicate}.
+(Module @racket[m] must provide @racket[pred] and @racket[pred] must have type @racket[(Any -> Boolean)].)
+The type @racket[t] is defined as precisely those values for which @racket[pred] produces
+@racket[#t].
 Opaque types must be required lexically before they are used.
 
 @ex[(require/typed racket/base

--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -659,11 +659,12 @@ be used as a predicate in @racket[if] expressions in Typed Racket.
                         [left  : IntTree]
                         [right : IntTree])]))]
 
-@index["opaque"]{The fourth case} defines a new type @racket[t] using the
+@index["opaque"]{The fourth case} defines a new @deftech{opaque type} @racket[t] using the
 function @racket[pred] as a @seclink["Generating_Predicates_Automatically"]{predicate}.
-(Module @racket[m] must provide @racket[pred] and @racket[pred] must have type @racket[(Any -> Boolean)].)
-The type @racket[t] is defined as precisely those values for which @racket[pred] produces
-@racket[#t].
+(Module @racket[m] must provide @racket[pred] and @racket[pred] must have type
+@racket[(Any -> Boolean)].)
+The type @racket[t] is defined as precisely those values that @racket[pred]
+returns @racket[#t] for.
 Opaque types must be required lexically before they are used.
 
 @ex[(require/typed racket/base


### PR DESCRIPTION
- add a small example to the guide
- edit the reference paragraph on `#:opaque` to:
  1. say "opaque" in the first sentence (also using a `deftech`)
  2. avoid starting/ending sentences with code
  3. add a link to the `define-predicate` section to explain what a predicate is
