### PR TITLE
add index-of to base-env.rkt

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -675,6 +675,10 @@
                         . -> . (-opt (-pair a b)))))]
 [assf  (-poly (a b) ((a . -> . Univ) (-lst (-pair a b))
                      . -> . (-opt (-pair a b))))]
+[index-of (-poly (a b)
+                 (cl->* ((-lst a) Univ . -> . (-opt -Index))
+                        ((-lst a) b (-> a b Univ)
+                           . -> . (-opt -Index))))]
 
 [list? (make-pred-ty (-lst Univ))]
 [list (-poly (a) (->* '() a (-lst a)))]

--- a/typed-racket-test/succeed/index-of.rkt
+++ b/typed-racket-test/succeed/index-of.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket
+
+(require typed/rackunit)
+
+(check-equal? (index-of '(a 12 c d) 'd) 3)
+(check-equal? (index-of '(a 12 c d) 'e) #f)
+(check-equal? (index-of
+               '("ab" "cde" "fhgi")
+               3
+               (λ ([str : String] [len : Integer])
+                 (= (string-length str) len)))
+              1)


### PR DESCRIPTION
This PR adds the "index-of" primitive to typed racket. I couldn't find a place to put any test cases; here's the code I would use, though:

``` racket
#lang typed/racket

(require typed/rackunit)

(check-equal? (index-of '(a 12 c d) 'd) 3)
(check-equal? (index-of '(a 12 c d) 'e) #f)
(check-equal? (index-of
               '("ab" "cde" "fhgi")
               3
               (λ ([str : String] [len : Integer])
                 (= (string-length str) len)))
              1)
```



