### PR TITLE
Trim excess right paren from ts-reference.scrbl

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/ts-reference.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/ts-reference.scrbl
@@ -44,7 +44,7 @@ For technical details, refer to the @secref{tr-bibliography}.
 @include-section["reference/experimental.scrbl"]
 
 @(define (bib-note . str*)
-   (list (linebreak) (linebreak) str* (linebreak) (linebreak))))
+   (list (linebreak) (linebreak) str* (linebreak) (linebreak)))
 
 @(define DLS "Dynamic Languages Symposium")
 @(define SFP "Workshop on Scheme and Functional Programming")


### PR DESCRIPTION
Looking at https://docs.racket-lang.org/ts-reference/index.html as of December 22, I see, at the very bottom, below the Index heading, a stray right paren.