### PR TITLE
Fixes to `for` with `#:break` and `#:when` together.

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/for-clauses.rkt
+++ b/typed-racket-lib/typed-racket/base-env/for-clauses.rkt
@@ -21,7 +21,6 @@
            #:with (expand* ...) (list (quasisyntax/loc #'c
                                         ((v.ann-name ...) seq-expr))
                                       #'#:when #''#t))
-  ;; Note: #:break and #:final clauses don't ever typecheck
   (pattern (~seq (~and kw (~or #:when #:unless #:break #:final)) guard:expr)
            #:with (expand ...) (list #'kw #'guard)
            #:with (expand* ...) #'(expand ...)))


### PR DESCRIPTION
The original implementation could never work. Also fix `for/vector`.