### PR TITLE
update typed/web-server/http for v1.6 (typed-racket-more v1.13)

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -255,6 +255,9 @@ and the @racket[URL] and @racket[Path/Param] types from
          #:changed "1.11"
          @elem{Updated to reflect @racketmodname[web-server/http]
           version 1.4.}
+         #:changed "1.13"
+         @elem{Updated to reflect @racketmodname[web-server/http]
+          version 1.6.}
          ]
 
 @defmodule/incl[typed/db]

--- a/typed-racket-more/info.rkt
+++ b/typed-racket-more/info.rkt
@@ -6,7 +6,7 @@
                "base"
 	       "net-lib"
                "net-cookies-lib"
-	       ["web-server-lib" #:version "1.5"]
+	       ["web-server-lib" #:version "1.6"]
                ["db-lib" #:version "1.5"]
                "draw-lib"
                "rackunit-lib"
@@ -27,4 +27,4 @@
 
 (define pkg-authors '(samth stamourv))
 
-(define version "1.12")
+(define version "1.13")

--- a/typed-racket-more/typed/web-server/http.rkt
+++ b/typed-racket-more/typed/web-server/http.rkt
@@ -31,6 +31,13 @@
                                   [headers : (Listof Header)]
                                   [content : Bytes])
                                  #:extra-constructor-name make-binding:file]
+                       ;; It would be better if we could tell Typed Racket
+                       ;; that `binding:file/port` is a subtype of `binding:file`.
+                       [#:opaque binding:file/port binding:file/port?]
+                       [binding:file/port-in (-> binding:file/port Input-Port)]
+                       [make-binding:file/port
+                        (-> Bytes Bytes (Listof Header) Input-Port
+                            binding:file/port)]
                        [#:struct request
                                  ([method : Bytes]
                                   [uri : URL]
@@ -107,6 +114,10 @@
          Cookie-Value
          Valid-Domain)
 
+;; N.B.: The untyped cookie functions will implicitly convert bytes to
+;; strings on input, partially for compatability, but that doesn't seem
+;; very desirable in a typed context.
+
 (require/typed/provide
  web-server/http/cookie
  [make-cookie
@@ -145,14 +156,14 @@
                         (-> String
                             Bytes
                             Request
-                            [#:timeout Number]
+                            [#:timeout Number] ;; should have been Real
                             [#:shelf-life Real]
                             (Option String))]
                        [valid-id-cookie?
                         (-> Any ;; yes, this is really Any
                             #:name String
                             #:key Bytes
-                            [#:timeout Number]
+                            [#:timeout Number] ;; should have been Real
                             [#:shelf-life Real]
                             (Option String))]
                        [logout-id-cookie


### PR DESCRIPTION
- Add types related to `binding:file/port-in`.

- Strengthen the type of the `#:timeout` arguments to
  `valid-id-cookie?` and `request-id-cookie` from `Number` to `Real`,
  analogously to <https://github.com/racket/typed-racket/commit/acf7707>.
  (A non-real `#:timeout` has always been a runtime error and in one
  case was already prohibited by a contract on the untyped side.)
  Usually you don't actually want to be using the `#:timeout` argument:
  see <https://github.com/racket/web-server/commit/626ad02>.

Related to <https://github.com/racket/web-server/pull/84>.