### PR TITLE
require/untyped-contract: adjust for relative submod path

### DIFF
--- a/typed-racket-more/typed/untyped-utils.rkt
+++ b/typed-racket-more/typed/untyped-utils.rkt
@@ -39,13 +39,18 @@
                     [*typed/racket/base (datum->syntax #'from-module-spec
                                                        'typed/racket/base)]
                     [*require (datum->syntax #'from-module-spec
-                                             'require)])
+                                             'require)]
+                    [from-module-spec-for-submod
+                      (syntax-parse #'from-module-spec #:literals (submod)
+                        [(submod (~and base (~or "." "..")) elem ...)
+                         (syntax/loc #'from-module-spec (submod base ".." elem ...))]
+                        [x #'x])])
        (syntax/loc stx
          (begin
            (module typed-module *typed/racket/base ; to bind in `T`s
              (*require typed/racket/base) ; to bind introduced `begin`, etc.
              (begin form ...)
-             (require (only-in from-module-spec
+             (require (only-in from-module-spec-for-submod
                                [name untyped2-name] ...))
              (provide untyped-name ...)
              (: untyped-name T) ...
@@ -54,7 +59,7 @@
            (module untyped-module *racket/base
              (*require racket/base)
              (require typed/untyped-utils
-                      (only-in from-module-spec
+                      (only-in from-module-spec-for-submod
                                [name typed-name] ...)
                       (only-in (submod ".." typed-module)
                                [untyped-name untyped3-name] ...))

--- a/typed-racket-test/succeed/pr907-non-relative.rkt
+++ b/typed-racket-test/succeed/pr907-non-relative.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket
+
+;; This is a simple typed module with a typed submodule that exports something,
+;; so the main test (pr907.rkt) can import from the submodule
+
+(module* m #f
+  (provide g)
+  (define g 'g))

--- a/typed-racket-test/succeed/pr907.rkt
+++ b/typed-racket-test/succeed/pr907.rkt
@@ -1,0 +1,25 @@
+#lang racket/base
+
+;; Test require/untyped-contract with submod paths
+
+(module a typed/racket
+  (define (f (x : (U Symbol String))) : Void (void))
+  (provide f))
+
+(module b racket/base
+  (require typed/untyped-utils typed/racket/base)
+  (require/untyped-contract (submod ".." a) (f (-> Symbol Void)))
+  (void))
+(require 'b)
+
+(module c racket/base
+  (require typed/untyped-utils typed/racket/base)
+  (require/untyped-contract (submod "." ".." a) (f (-> Symbol Void)))
+  (void))
+(require 'c)
+
+(require typed/untyped-utils typed/racket/base)
+(require/untyped-contract (submod "." a) (f (-> Symbol Void)))
+
+;; a non-relative submod should not be adjusted
+(require/untyped-contract (submod "pr907-non-relative.rkt" m) (g Symbol))


### PR DESCRIPTION
Add a ".." to any relative submodule paths.

- - -

Example program (test.rkt):

```
  #lang racket/base
  ;; test.rkt

  (module a typed/racket
    (define (f (x : (U Symbol String))) : Void (void))
    (provide f))

  (module b racket/base
    (require typed/untyped-utils typed/racket/base)
    (require/untyped-contract (submod ".." a) (f (-> Symbol Void)))
    (void))
  (require 'b)
```

Without adjustment, `require/untyped-contract` expands to an invalid
require. This new require appears in a new submodule but points to
the same path `(submod ".." a)`, which is not the same goal.

The old error message is:

```
  syntax-local-module-exports: unknown module
    module name: #<resolved-module-path:(submod 'test[7305] b a)>
```