### PR TITLE
Repair output type for `regexp-match-positions*`.

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -3493,7 +3493,7 @@
         (?N (-opt -Integer))
         (ind-pair (-pair -Index -Index))
         (sel (-> (-lst (-opt ind-pair)) (-opt ind-pair)))
-        (output (-opt (-pair ind-pair (-lst (-opt ind-pair)))))
+        (output (Un (-lst ind-pair) (-lst (-lst (-opt ind-pair)))))
         (-Input (Un -String -Input-Port -Bytes -Path)))
    (->optkey -Pattern -Input (N ?N -Bytes) #:match-select sel #f output)))
 

--- a/typed-racket-test/fail/regexp-match-pos-star.rkt
+++ b/typed-racket-test/fail/regexp-match-pos-star.rkt
@@ -1,0 +1,5 @@
+#lang typed/racket/base #:no-optimize
+
+(lambda ()
+  (let ([problem (regexp-match-positions* #rx"." "")])
+    (and problem (ann problem (Pairof Any Any)))))


### PR DESCRIPTION
Closes #901.