### PR TITLE
type-contract: look for lists, make list/sc

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -529,8 +529,21 @@
        [(Mutable-VectorTop:)
         (only-untyped mutable-vector?/sc)]
        [(Box: t) (box/sc (t->sc/both t))]
-       [(Pair: t1 t2)
-        (cons/sc (t->sc t1) (t->sc t2))]
+       [(Pair: t-car t-cdr)
+        ;; look ahead as long as t-cdr is a Pair
+        (define-values [t-last rev-sc*]
+          (let loop ((t t-cdr)
+                     (sc* (list (t->sc t-car))))
+            (match t
+             [(Pair: t-car t-cdr)
+              (loop t-cdr (cons (t->sc t-car) sc*))]
+             [_
+              (values t sc*)])))
+        (if (eq? -Null t-last)
+          (apply list/sc (reverse rev-sc*))
+          (for/fold ((sc-cdr (t->sc t-last)))
+                    ((sc (in-list rev-sc*)))
+            (cons/sc sc sc-cdr)))]
        [(Async-Channel: t) (async-channel/sc (t->sc t))]
        [(Promise: t)
         (promise/sc (t->sc t))]

--- a/typed-racket-test/unit-tests/contract-tests.rkt
+++ b/typed-racket-test/unit-tests/contract-tests.rkt
@@ -238,6 +238,16 @@
    (t-sc (Un (-lst Univ) (-val #t)) (or/sc (flat/sc #''#t) (listof/sc any-wrap/sc)))
    (t-sc (Un (-val #f) (-val #t) (-lst (-val #f)))
          (or/sc (flat/sc #''#t) (flat/sc #''#f) (listof/sc (flat/sc #''#f))))
+   (t-sc (-pair Univ Univ)
+         (cons/sc any-wrap/sc any-wrap/sc))
+   (t-sc -Null
+         (flat/sc #''()))
+   (t-sc (-pair Univ (-pair Univ -Null))
+         (list/sc any-wrap/sc any-wrap/sc))
+   (t-sc (-lst* -Symbol -String)
+         (list/sc (flat/sc #'symbol?) (flat/sc #'string?)))
+   (t-sc (-lst* -Number -Integer #:tail -Integer)
+         (cons/sc number/sc (cons/sc integer/sc integer/sc)))
 
    (t-int Any-Syntax syntax? #'#'A #:typed) ;; GitHub issue #616
 


### PR DESCRIPTION
Check for proper list types and output a matching static contract,
 instead of using cons/sc for all kinds of pairs

- - -

Looks like we never make `list/sc` contracts currently --- even though there are sc-optimizer cases for them.