### PR TITLE
type-contract: remove sc-cache (was: fix empty cache typo)

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -326,10 +326,9 @@
          (cond [(hash-ref sc-cache key #f)]
                [else
                 (define sc (match type match-clause ...))
-                (define fvs (fv type))
-                ;; Only cache closed terms, otherwise open terms may show up
-                ;; out of context.
-                (unless (or (not (null? fv))
+                (unless (or ;; Only cache closed terms, otherwise open terms may show up
+                            ;; out of context.
+                            (not (null? (fv type)))
                             ;; Don't cache types with applications of Name types because
                             ;; it does the wrong thing for recursive references
                             (has-name-app? type))

--- a/typed-racket-test/unit-tests/contract-tests.rkt
+++ b/typed-racket-test/unit-tests/contract-tests.rkt
@@ -891,22 +891,4 @@
    (t (-prefab-top 'point 2))
    (t (-prefab-top '(box-box #(0)) 1))
 
-   (test-case "sc-cache hit"
-     (define sc-cache (make-hash))
-     (void
-       (type->contract -Number tc-fail #:typed-side #t #:sc-cache sc-cache))
-     (check-false (hash-empty? sc-cache))
-     (check-not-false (hash-ref sc-cache (cons -Number 'typed) #f)))
-
-   (test-case "sc-cache miss"
-     (define sc-cache (make-hash))
-     (define t
-       ;; cache the full recursive type,
-       ;;  but not any type that depends on the bound variable
-       (-mu X (Un -Null -String (-pair -Symbol X))))
-     (void
-       (type->contract t tc-fail #:typed-side #t #:sc-cache sc-cache))
-     (check-false (hash-empty? sc-cache))
-     (check-not-false (hash-ref sc-cache (cons t 'typed) #f))
-     (check-false (hash-ref sc-cache (cons (-pair -Symbol (-v X)) 'typed) #f)))
    ))


### PR DESCRIPTION
the old test (not (null? fv)) was always #t because fv is a function,
so `cached-match` never added anything to the cache

- - - 

two questions:

1. any idea how to test this? EDIT: 05dda60 has a test
2. is there a simpler function than `fv` that works here? I noticed `fv` builds a set then converts that to a list ... maybe `(equal? empty-free-vars (free-vars* type))` is better? EDIT: see below, `fv` isn't enough