### PR TITLE
type-contract: add (only-untyped ....) to HashTableTop contract

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -454,12 +454,12 @@
        [(? Union? t)
         (match (normalize-type t)
           [(HashTableTop:)
-           ;; NOTE: this is a special case to make `HashTableTop` produce a flat contract.
+           ;; NOTE: this is a special case to make `HashTableTop` produce a flat contract in casts.
            ;; Without this case:
            ;; - `HashTableTop` would make a chaperone contract
            ;; - because `HashTableTop` is a union containing `(Immutable-HashTable Any Any)`
            ;; - and `Any` makes a chaperone contract
-           hash?/sc]
+           (only-untyped hash?/sc)]
           [(Union-all-flat: elems)
            (apply or/sc (merge-overlapping-scs (map t->sc elems)))]
           [t (t->sc t)])]

--- a/typed-racket-test/succeed/hashtabletop-flat-contract.rkt
+++ b/typed-racket-test/succeed/hashtabletop-flat-contract.rkt
@@ -1,6 +1,17 @@
 #lang typed/racket/base
+(require typed/rackunit)
 
-;; Test that `HashTableTop` generates a flat contract
+;; Test that `HashTableTop` generates a flat contract in cast,
+;;  and a chaperone when exported to untyped code
 
-(define h : HashTableTop (hash))
+(define h : (Mutable-HashTable Symbol String) (make-hash '((A . "A"))))
 (void (cast h HashTableTop))
+
+(module u racket/base
+  (provide f)
+  (define (f x)
+    (hash-set! x 'A 'bad)))
+(require/typed 'u
+  (f (-> HashTableTop Void)))
+
+(check-exn exn:fail:contract? (lambda () (f h)))

--- a/typed-racket-test/succeed/vectortop-flat-contract.rkt
+++ b/typed-racket-test/succeed/vectortop-flat-contract.rkt
@@ -1,6 +1,17 @@
 #lang typed/racket/base
+(require typed/rackunit)
 
-;; Test that VectorTop generates a flat contract
+;; Test that VectorTop generates a flat contract in cast,
+;;  and a chaperone when exported to untyped code
 
-(define v : VectorTop (vector))
+(define v : (Mutable-Vectorof String) (vector "A"))
 (void (cast v VectorTop))
+
+(module u racket/base
+  (provide f)
+  (define (f x)
+    (vector-set! x 0 'bad)))
+(require/typed 'u
+  (f (-> VectorTop Void)))
+
+(check-exn exn:fail:contract? (lambda () (f v)))


### PR DESCRIPTION
- casts to HashTableTop still work b/c they happen in typed code,
- but untyped code gets an Any-wrapped value

closes a soundness bug