### PR TITLE
type-contract: add common ctc-cache

### DIFF
--- a/typed-racket-lib/typed-racket/core.rkt
+++ b/typed-racket-lib/typed-racket/core.rkt
@@ -33,6 +33,7 @@
                                              (with-refinements?))])
          (tc-module/full stx pmb-form
           (λ (new-mod pre-before-code pre-after-code)
+            (define ctc-cache (make-hash))
             (with-syntax*
              (;; pmb = #%plain-module-begin
               [(pmb . body2) new-mod]
@@ -40,11 +41,11 @@
               [transformed-body (begin0 (remove-provides #'body2) (do-time "Removed provides"))]
               ;; add the real definitions of contracts on requires
               [transformed-body
-               (begin0 (change-contract-fixups (syntax->list #'transformed-body))
+               (begin0 (change-contract-fixups (syntax->list #'transformed-body) ctc-cache)
                        (do-time "Fixed contract ids"))]
               ;; add the real definitions of contracts on the before- and after-code
-              [(before-code ...) (change-provide-fixups (flatten-all-begins pre-before-code))]
-              [(after-code ...) (begin0 (change-provide-fixups (flatten-all-begins pre-after-code))
+              [(before-code ...) (change-provide-fixups (flatten-all-begins pre-before-code) ctc-cache)]
+              [(after-code ...) (begin0 (change-provide-fixups (flatten-all-begins pre-after-code) ctc-cache)
                                   (do-time "Generated contracts"))]
               ;; potentially optimize the code based on the type information
               [(optimized-body ...) (maybe-optimize #'transformed-body)] ;; has own call to do-time

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -193,8 +193,7 @@
 ;;   submodule, which always has the above `require`s.
 (define include-extra-requires? (box #f))
 
-(define (change-contract-fixups forms)
-  (define ctc-cache (make-hash))
+(define (change-contract-fixups forms [ctc-cache (make-hash)])
   (with-new-name-tables
    (for/list ((e (in-list forms)))
      (if (not (has-contract-def-property? e))

--- a/typed-racket-lib/typed-racket/typecheck/toplevel-trampoline.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/toplevel-trampoline.rkt
@@ -105,8 +105,9 @@
                ;; doesn't work for looking up types in the optimizer.
                (define new-stx
                  (apply append
-                        (for/list ([form (in-list forms)])
-                          (change-contract-fixups (maybe-optimize (list form))))))
+                        (let ([ctc-cache (make-hash)])
+                          (for/list ([form (in-list forms)])
+                            (change-contract-fixups (maybe-optimize (list form)) ctc-cache)))))
                (kont new-stx result)]))])]))
 
   ;; Trampoline that continues the typechecking process.


### PR DESCRIPTION
Make a cache at the top of `mb-core` and share it across all passes that might generate contracts.