### PR TITLE
allow (apply values x) when (: x (Listof _))

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1286,7 +1286,8 @@
 [values (-polydots (a b) (cl->*
                            (-> (-values null))
                            (->acc (list a) a null)
-                           ((list a) (b b) . ->... . (make-ValuesDots (list (-result a)) b 'b))))]
+                           ((list a) (b b) . ->... . (make-ValuesDots (list (-result a)) b 'b))
+                           (->* (list) Univ ManyUniv)))]
 [call-with-values
   (-polydots (b a)
     (cl->*

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -1005,7 +1005,7 @@
                                 #:multiple? [multiple-substitutions? #f]
                                 #:objs [objs '()])
      (((listof symbol?) (listof symbol?) (listof Type?) (listof Type?)
-       (or/c #f Values/c ValuesDots?))
+       (or/c #f Values/c AnyValues? ValuesDots?))
       ((or/c #f Values/c AnyValues? ValuesDots?)
        #:multiple? boolean?
        #:objs (listof OptObject?))

--- a/typed-racket-lib/typed-racket/infer/signatures.rkt
+++ b/typed-racket-lib/typed-racket/infer/signatures.rkt
@@ -34,7 +34,7 @@
                             ;; domain
                             (listof Type?)
                             ;; range
-                            (or/c #f Values/c ValuesDots?))
+                            (or/c #f Values/c AnyValues? ValuesDots?))
                            ;; optional expected type
                            ((or/c #f Values/c AnyValues? ValuesDots?)
                             ;; optional multiple substitutions?

--- a/typed-racket-lib/typed-racket/infer/signatures.rkt
+++ b/typed-racket-lib/typed-racket/infer/signatures.rkt
@@ -52,7 +52,7 @@
                                    ;; rest
                                    (or/c #f Type? Rest?)
                                    ;; range
-                                   (or/c #f Values/c ValuesDots?))
+                                   (or/c #f Values/c AnyValues? ValuesDots?))
                                   ;; [optional] expected type
                                   ((or/c #f Values/c AnyValues? ValuesDots?)
                                    #:objs (listof OptObject?))

--- a/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
@@ -19,6 +19,7 @@
           (for/list ([t (in-list ts)]) -tt-propset)
           (for/list ([t (in-list ts)]) -empty-obj)
           dty dbound)]
+    [(AnyValues: p) (-tc-any-results p)]
     [_ (int-err "do-ret fails: ~a" t)]))
 
 (define (tc/apply f args)

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -1354,6 +1354,8 @@
         [tc-e/t (ann (lambda (x) x) (All (a) (a -> a)))
                 (-poly (a) (a . t:-> . a))]
         [tc-e (apply values (list 1 2 3)) #:ret (tc-ret (list -One -PosByte -PosByte))]
+        [tc-e (apply values (string->list "")) #:ret (-tc-any-results -tt)]
+        [tc-e (apply values (string->list "abc")) #:ret (-tc-any-results -tt)]
 
         [tc-e/t (ann (if #t 3 "foo") Integer) -Integer]
 


### PR DESCRIPTION
add a base type to values for when the number of inputs is unknown

(this type matches the relevant parts of `call-with-values`)

- - -

I found this by looking for ways to reach the 3rd case in `tc/app-apply` here:
https://github.com/racket/typed-racket/blob/master/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-apply.rkt#L32

Are there any other examples worth testing?