### PR TITLE
any-wrap: move channel? case before evt? case

### DIFF
--- a/typed-racket-lib/typed-racket/utils/any-wrap.rkt
+++ b/typed-racket-lib/typed-racket/utils/any-wrap.rkt
@@ -171,10 +171,6 @@
                                    (with-contract-continuation-mark
                                     blame+neg-party
                                     (any-wrap/traverse k neg-party seen/v))))] ;; key
-      [(? evt?) (chaperone-evt v (lambda (e) (values e (λ (v)
-                                                         (with-contract-continuation-mark
-                                                          blame+neg-party
-                                                          (any-wrap/traverse v neg-party seen/v))))))]
       [(? set?) (chaperone-hash-set
                  v
                  (λ (s e) e) ; inject
@@ -208,8 +204,14 @@
        (chaperone-channel v
                           (lambda (e) (with-contract-continuation-mark
                                        blame+neg-party
-                                       (values v (any-wrap/traverse v neg-party seen/v))))
-                          (lambda (e) (fail neg-party v)))]
+                                       (values e (lambda (inner-val) (any-wrap/traverse inner-val neg-party seen/v)))))
+                          (lambda (_e _new-val) (fail neg-party v)))]
+      [(? evt?)
+       ;; must come after cases for write-able values that can be used as events
+       (chaperone-evt v (lambda (e) (values e (λ (v)
+                                                (with-contract-continuation-mark
+                                                 blame+neg-party
+                                                 (any-wrap/traverse v neg-party seen/v))))))]
       [_
        (on-opaque v b neg-party)]))
   any-wrap/traverse)

--- a/typed-racket-test/unit-tests/contract-tests.rkt
+++ b/typed-racket-test/unit-tests/contract-tests.rkt
@@ -891,4 +891,18 @@
    (t (-prefab-top 'point 2))
    (t (-prefab-top '(box-box #(0)) 1))
 
+   (t-int -ChannelTop
+          channel-get
+          (let ((ch (make-channel))) (thread (λ () (channel-put ch "ok"))) ch)
+          #:typed)
+   (t-int -ChannelTop
+          channel-get
+          (let ((ch (make-channel))) (thread (λ () (channel-put ch "ok"))) ch)
+          #:untyped)
+   (t-int/fail -ChannelTop
+               (lambda (ch)
+                 (channel-put ch 'error))
+               (make-channel)
+               #:typed
+               #:msg "higher-order value passed as `Any`")
    ))


### PR DESCRIPTION
(channel? x) implies (evt? x), so the any-wrap code that protects
channels was never used --- leaving a soundness bug

- move the evt? case below the channel? case
- fix bugs in the channel? chaperone

- - -

Unsoundness example (segfault on 7.6 BC/CS):
```
#lang typed/racket
(require typed/rackunit)

(: ch (Channelof (Pairof Symbol Symbol)))
(define ch (make-channel))

(module u racket/base
  (provide f)
  (define (f x)
    (thread (lambda () (channel-put x 'NotPair)))
    (void)))
(require/typed 'u
  (f (-> ChannelTop Void)))

(check-exn exn:fail:contract?
  (lambda ()
    (f ch)
    (cdr (channel-get ch))))
```