### PR TITLE
type-contract: fix byte-regexp contract

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -406,7 +406,7 @@
                  ;; requires an equal? check
                  (not (number? v))
                  ;; regexps don't match themselves when used as contracts
-                 (not (regexp? v)))
+                 (not (or (regexp? v) (byte-regexp? v))))
             (flat/sc #`(quote #,v))
             (flat/sc #`(flat-named-contract '#,v (lambda (x) (equal? x '#,v))) v))]
        [(Base-name/contract: sym ctc) (flat/sc ctc)]

--- a/typed-racket-test/unit-tests/contract-tests.rkt
+++ b/typed-racket-test/unit-tests/contract-tests.rkt
@@ -890,5 +890,7 @@
    (t (-prefab '(box-box #(0)) (-box -Number)))
    (t (-prefab-top 'point 2))
    (t (-prefab-top '(box-box #(0)) 1))
+   (t-int (-val #rx"aa") void #rx"aa" #:untyped)
+   (t-int (-val #rx#"bb") void #rx#"bb" #:untyped)
 
    ))


### PR DESCRIPTION
Check for byte-regexp? and avoid using the value as a literal contract