### PR TITLE
Change source of web-server's response/empty function

### DIFF
--- a/typed-racket-more/typed/web-server/http.rkt
+++ b/typed-racket-more/typed/web-server/http.rkt
@@ -243,7 +243,7 @@
                             [#:cookies (Listof Cookie)]
                             Response)])
 
-(require/typed/provide web-server/http/empty
+(require/typed/provide web-server/http
                        [response/empty
                         (-> [#:code Natural]
                             [#:message (Option Bytes)]


### PR DESCRIPTION
This is the TR analogue of a proposed change to the
web-server (https://github.com/racket/web-server/pull/85),
in which `web-server/http/empty` goes away, having been
incorporated into `web-server/http/response-structs`.