### PR TITLE
typed/pict: add missing struct field

### DIFF
--- a/typed-racket-more/typed/pict.rkt
+++ b/typed-racket-more/typed/pict.rkt
@@ -67,6 +67,7 @@
                  [width : -Real]
                  [height : -Real]
                  [ascent : -Real]
+                 [descent : -Real]
                  [children : (-lst -child)]
                  [panbox : Univ]
                  [last : -pict-path])

--- a/typed-racket-test/succeed/pict.rkt
+++ b/typed-racket-test/succeed/pict.rkt
@@ -4,7 +4,15 @@
 
 (require typed/pict typed/racket/draw)
 
-(pict-children (blank 50 50))
+(let ((p (blank 50 50)))
+  (pict-draw p)
+  (assert (pict-width p) real?)
+  (assert (pict-height p) real?)
+  (assert (pict-ascent p) real?)
+  (assert (pict-descent p) real?)
+  (assert (pict-children p) list?)
+  (pict-panbox p)
+  (assert (pict-last p) pict-path?))
 
 (blank)
 (blank 1)


### PR DESCRIPTION
Currently, `(pict-children (blank 50 50))` = `0`