### PR TITLE
require/typed struct: provide the static struct info

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -546,10 +546,15 @@
                                                        (id-drop orig-sels orig-muts num-fields)))
                                            (struct-info-list new-sels new-muts)))))))
 
-                         (define-syntax nm
-                              (if id-is-ctor?
-                                  (make-struct-info-self-ctor #'internal-maker si)
-                                  si))
+                         #,(ignore
+                             ;; provide the static struct info directly, unlike other define-syntax forms
+                             ;; this is similar to the struct quad code in `typecheck/provide-handling.rkt`
+                             #'(begin
+                                 (define-syntax nm
+                                   (if id-is-ctor?
+                                     (make-struct-info-self-ctor #'internal-maker si)
+                                     si))
+                                 (provide nm)))
 
                          (dtsi* (tvar ...) spec type (body ...) #:maker maker-name #:type-only)
                          #,(ignore #'(require/contract pred hidden (or/c struct-predicate-procedure?/c (c-> any-wrap/c boolean?)) lib))

--- a/typed-racket-test/succeed/require-typed-struct-info.rkt
+++ b/typed-racket-test/succeed/require-typed-struct-info.rkt
@@ -1,0 +1,17 @@
+#lang racket/base
+
+;; Make sure static struct info is available after a require/typed
+
+(module u typed/racket/base
+  (struct foo ((a : Symbol)))
+  (provide (struct-out foo)))
+
+(module t typed/racket
+  (require/typed/provide (submod ".." u)
+    (#:struct foo ((a : Symbol)))))
+
+(require 't racket/match)
+
+(match (foo 'xxx)
+  [(foo a0) ;; syntax error if `foo` is NOT bound to struct-info at phase 1
+   (void)])


### PR DESCRIPTION
require/typed creates a `define-syntax` for struct info;
 make sure this is provided directly, and not redirected to
 a type-name-error syntax transformer

- - -

For example, this program currently works:

```
  #lang racket/base

  (module t typed/racket
    (struct foo ((a : Symbol)))
    (provide (struct-out foo)))

  (require 't racket/match)
  (match-define (foo a0) (foo 'xxx))
```

And so this next program ought to work, but raises a syntax error in the
match pattern because `foo` is bound to a syntax transformer and not
a `struct-info?`

```
  #lang racket/base

  (module u typed/racket/base
    (struct foo ((a : Symbol)))
    (provide (struct-out foo)))

  (module t typed/racket
    (require/typed/provide (submod ".." u)
      (#:struct foo ((a : Symbol)))))

  (require 't racket/match)
  (match-define (foo a0) (foo 'xxx))
```

- - -

At first I tried to solve this problem with some a `def-struct-stx-binding`, but I don't think this require/typed code can fit into that path ... we'd need a new kind of `def-binding`