### PR TITLE
type-environment: optionally provide struct constructor

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/extra-env-lang.rkt
+++ b/typed-racket-lib/typed-racket/base-env/extra-env-lang.rkt
@@ -60,7 +60,8 @@
                        (~optional (~seq #:extra-constructor-name extra:id)
                                   #:defaults ([extra #f]))
                        (~optional (~and (~seq #:no-provide) (~bind [provide? #f]))
-                                  #:defaults ([provide? #t]))]
+                                  #:defaults ([provide? #t]))
+                       d-s-options ...]
              #:when (or (not (attribute provide?)) (validate-fields #'name (syntax-e #'(field ...)) this-syntax))
              #:with form #'(d-s name ([field : type] ...))
              #:with outer-form (if (attribute provide?)
@@ -72,7 +73,8 @@
                        (~optional (~seq #:extra-constructor-name extra:id)
                                   #:defaults ([extra #f]))
                        (~optional (~and (~seq #:no-provide) (~bind [provide? #f]))
-                                  #:defaults ([provide? #t]))]
+                                  #:defaults ([provide? #t]))
+                       d-s-options ...]
              #:when (or (not (attribute provide?)) (validate-fields #'name (syntax-e #'(field ...)) this-syntax))
              #:with form #'(d-s (name par) ([field : type] ...) (par-type ...))
              #:with outer-form (if (attribute provide?)

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -172,8 +172,6 @@
 
 
 ;; construct all the various types for structs, and then register the appropriate names
-;; identifier listof[identifier] type listof[fld] listof[Type] boolean ->
-;;  (values Type listof[Type] listof[Type])
 (define/cond-contract (register-sty! sty names desc)
   (c:-> (c:or/c Struct? Prefab?) struct-names? struct-desc? void?)
 
@@ -189,7 +187,7 @@
   (register-type-name type-name
                       (make-Poly (struct-desc-tvars desc) sty)))
 
-;; Register the approriate types to the struct bindings.
+;; Register the appropriate types, return a list of struct bindings
 (define/cond-contract (register-struct-bindings! sty names desc si)
   (c:-> (c:or/c Struct? Prefab?) struct-names? struct-desc? (c:or/c #f struct-info?) (c:listof binding?))
   (match sty
@@ -499,9 +497,6 @@
 
 ;; register a struct type
 ;; convenience function for built-in structs
-;; tc/builtin-struct : identifier Maybe[identifier] Listof[identifier]
-;;                     Listof[Type] Maybe[identifier] Listof[Type]
-;;                     -> void
 ;; FIXME - figure out how to make this lots lazier
 (define/cond-contract (tc/builtin-struct nm parent fld-names tys kernel-maker)
   (c:-> identifier? (c:or/c #f identifier?) (c:listof identifier?)
@@ -517,7 +512,7 @@
   (define sty (mk/inner-struct-type names desc parent-type))
 
   (register-sty! sty names desc)
-  (register-struct-bindings! sty names desc #f)
+  (void (register-struct-bindings! sty names desc #f))
   (when kernel-maker
     (register-type kernel-maker (λ () (->* (struct-desc-all-fields desc) sty)))))
 

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -512,7 +512,8 @@
   (define sty (mk/inner-struct-type names desc parent-type))
 
   (register-sty! sty names desc)
-  (void (register-struct-bindings! sty names desc #f))
+  (void ;; need the `register-type` side effect, but not the output bindings
+    (register-struct-bindings! sty names desc #f))
   (when kernel-maker
     (register-type kernel-maker (λ () (->* (struct-desc-all-fields desc) sty)))))
 

--- a/typed-racket-test/succeed/type-environment.rkt
+++ b/typed-racket-test/succeed/type-environment.rkt
@@ -1,0 +1,18 @@
+#lang s-exp typed-racket/base-env/extra-env-lang
+
+(module untyped racket/base
+  (struct posn [x y])
+  (struct color-posn posn [c])
+  (provide (struct-out posn) (struct-out color-posn)))
+(require 'untyped)
+
+(type-environment
+ [#:struct posn ([x : -Real] [y : -Real]) #:kernel-maker posn]
+ [#:struct (color-posn posn) ([c : -Symbol]) (-Real -Real) #:kernel-maker color-posn])
+
+(module* test typed/racket
+  (require (submod ".."))
+
+  ;; make sure these have types
+  (void posn posn? posn-x posn-y
+        color-posn color-posn? color-posn-c))


### PR DESCRIPTION
Let `type-environment` accept the struct #:kernel-maker option,
 and pass it on to `d-s`.

Without this option, type-environment does not register a type for
 a struct constructor.

Also, delete some comments that have been replaced by contracts.