### PR TITLE
Provide a proper syntax location for `require-typed-signature`.

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -177,7 +177,7 @@
                              #,@(if unsafe? #'(unsafe-kw) #'())
                              #,lib))
    (pattern sig:signature-clause #:attr spec
-     #`(require-typed-signature sig.sig-name (sig.var ...) (sig.type ...) #,lib))
+     (quasisyntax/loc #'sig (require-typed-signature sig.sig-name (sig.var ...) (sig.type ...) #,lib)))
    (pattern sc:simple-clause #:attr spec
      #`(require/typed #:internal sc.nm sc.ty #,lib
                       #,@(if unsafe? #'(unsafe-kw) #'()))))


### PR DESCRIPTION
This fixes the last incorrect path in `Typed_Units.html`.
Related to racket/racket#1150.