### PR TITLE
Fix <method not found> and in-fxvector in for form

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -3174,6 +3174,8 @@
 [unsafe-struct*-ref top-func]
 [unsafe-struct-set! top-func]
 [unsafe-struct*-set! top-func]
+[unsafe-fxvector-length (-FxVector . -> . -Fixnum)]
+[unsafe-fxvector-ref (-FxVector -Fixnum . -> . -Fixnum)]
 
 ;; Section 17.4 (Unsafe Undefined)
 [check-not-unsafe-undefined (-poly (a) (-> a -Symbol a))]

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -3174,7 +3174,7 @@
 [unsafe-struct*-ref top-func]
 [unsafe-struct-set! top-func]
 [unsafe-struct*-set! top-func]
-[unsafe-fxvector-length (-FxVector . -> . -Fixnum)]
+[unsafe-fxvector-length (-FxVector . -> . -Index)]
 [unsafe-fxvector-ref (-FxVector -Fixnum . -> . -Fixnum)]
 
 ;; Section 17.4 (Unsafe Undefined)

--- a/typed-racket-more/typed/private/framework-types.rkt
+++ b/typed-racket-more/typed/private/framework-types.rkt
@@ -872,14 +872,12 @@
     (Class #:row-var r #:implements Frame:Searchable<%>
            [edit-menu:find-callback (-> Boolean)]
            [edit-menu:create-find? (-> #t)]
-           ; FIXME: doc says "Overrides <method not found>" from here on
-           [edit-menu:find-again-callback
+           [edit-menu:find-next-callback
             (Menu-Item%-Instance Control-Event%-Instance -> Void)]
-           [edit-menu:create-find-again? (-> #t)]
-           [edit-menu:find-again-backwards-callback
+           [edit-menu:create-find-next? (-> #t)]
+           [edit-menu:find-previous-callback
             (Menu-Item%-Instance Control-Event%-Instance -> Void)]
-           [edit-menu:create-find-again-backwards? (-> #t)]
-           ; end bug doc saying "Overrides <method not found>"
+           [edit-menu:create-find-previous? (-> #t)]
            [edit-menu:create-replace-all? (-> #t)]
            [edit-menu:create-find-case-sensitive? (-> #t)])))
 

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -2652,6 +2652,12 @@
                (list f1 f2))
              (-lst* -Flonum -Fixnum)]
 
+       ;; test expansion of in-fxvector and in-flvector in for
+       [tc-e (for/list : (Listof Fixnum) ([a (in-fxvector (fxvector 1 2))]) a)
+             (Listof Fixnum)]
+       [tc-e (for/list : (Listof Flonum) ([a (in-flvector (flvector 1.0 2.0))]) a)
+             (Listof Flonum)]
+
        ;; The typechecker should be able to handle the expansion of
        ;; for/flvector, for*/flvector, for/extflvector, and for*/extflvector
        [tc-e

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -2654,9 +2654,9 @@
 
        ;; test expansion of in-fxvector and in-flvector in for
        [tc-e (for/list : (Listof Fixnum) ([a (in-fxvector (fxvector 1 2))]) a)
-             (Listof Fixnum)]
+             (-lst -Fixnum)]
        [tc-e (for/list : (Listof Flonum) ([a (in-flvector (flvector 1.0 2.0))]) a)
-             (Listof Flonum)]
+             (-lst -Flonum)]
 
        ;; The typechecker should be able to handle the expansion of
        ;; for/flvector, for*/flvector, for/extflvector, and for*/extflvector


### PR DESCRIPTION
- Correct the method names that were "not found".
  See also racket/gui#185
- Add unsafe-fxvector-length and unsafe-fxvector-ref
  so that in-fxvector in the for form works correctly.
  Add corresponding tests.
  Thanks to James Cooper who reported the issue in Slack.