### PR TITLE
simple fix for issue #764 bad typing of NaN equals

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -754,8 +754,7 @@
 
 [=
  (from-cases
-   (-> -Real -RealZero B : (-PS (-is-type 0 -RealZeroNoNan) (-not-type 0 -RealZeroNoNan)))
-   (-> -RealZero -Real B : (-PS (-is-type 1 -RealZeroNoNan) (-not-type 1 -RealZeroNoNan)))
+  (commutative-equality/strict-prop -Real -RealZeroNoNan)
   (map (lambda (t) (commutative-equality/prop -ExactNumber t))
        (list -One -PosByte -Byte -PosIndex -Index
              -PosFixnum -NonNegFixnum -NegFixnum -NonPosFixnum -Fixnum

--- a/typed-racket-test/succeed/gh-issue-764.rkt
+++ b/typed-racket-test/succeed/gh-issue-764.rkt
@@ -1,0 +1,19 @@
+#lang typed/racket
+
+(ann (= 0 +nan.0) False)
+(ann (= +nan.0 0) False)
+
+(ann (= 0 +0.0) True)
+(ann (= +0.0 0) True)
+
+(ann (= 0 -0.0) True)
+(ann (= -0.0 0) True)
+
+(ann (= -0.0 +0.0) True)
+
+; This was always ok:
+(ann (= 1 +nan.0) False)
+
+(ann (= 0 1) False)
+(ann (= 1 0) False)
+


### PR DESCRIPTION
The culprit in issue #764 is [two lines](https://github.com/racket/typed-racket/blob/e03fd8884ed3c512dbac168c240d96816a42b4c3/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt#L757-L758) specifying type signatures for `=`.

```
(-> -Real -RealZero B : (-PS (-is-type 0 -RealZeroNoNan) (-not-type 0 -RealZeroNoNan)))
(-> -RealZero -Real B : (-PS (-is-type 1 -RealZeroNoNan) (-not-type 1 -RealZeroNoNan)))
```

## Explanation of fix

Replace those two lines with:

    (commutative-equality/strict-prop -Real -RealZeroNoNan)

Since the second type does not contain `NaN`, if a real does not equal 
any one of the zeros in the second type (they are all actually equal), then it is not in that type.

## Why not just delete it?

Some type information like this is necessary for the type inference
engine to understand that downward induction terminates at zero and
does not go negative. See the test [`dviu-infer-fact.rkt`](https://github.com/racket/typed-racket/blob/1825355c4879b6263b0c8fe88b30e11d79fc0d31/typed-racket-test/succeed/dviu-infer-fact.rkt).

## Explanation of the problem

The problem with these lines is:

1. When `=` is false in the presence of a possible `NaN`, no type
   information is gained, so the false branches should be `-tt`. (This
   is correct other places in the `base-env-numeric` code.)
2. `RealZero` itself includes `NaN` (footgun!!), so as written, the first
   line applies to `(= 0 +nan.0)`. 

   Interpreting the PropSet as written (which is an error), we see
   that if the preposition (`=`) is true, the conclusion is that the
   first input is a RealZeroNoNan. If the proposition is false, the
   first input is not of type RealZeroNoNan. Since those two types are
   mutually exclusive and the type system knows that 0 is a
   RealZeroNoNan, it deduces that the output of the comparison is
   `True`.
   
   Since `NaN` is never equal to anything, one correct deduction in
   the first case would be:

        (-PS (-and (-is-type 0 -RealZeroNoNan) (-is-type 1 -RealZeroNoNan)) -tt)

    Another possibility would be to consider `-RealZeroNoNan` instead
    of `-RealZero` as the type of an input. This is the proposed fix.
