### PR TITLE
fix issue #944 by adding an appropriate space in error message

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
@@ -119,7 +119,7 @@
       [(RestDots: dty dbound)
        (format "~a ~a ... ~a~a" doms-string dty dbound rng-string)]
       [rst
-       (format "~a~a~a"
+       (format "~a ~a~a"
                doms-string
                (match rst
                  [(Rest: (list rst-t)) (format "~a *" rst-t)]

--- a/typed-racket-test/fail/gh-issue-944.rkt
+++ b/typed-racket-test/fail/gh-issue-944.rkt
@@ -1,0 +1,12 @@
+#;
+(exn-pred "Domain: String String *")
+#lang typed/racket
+
+(: f (-> String String * String))
+(define (f . xs)
+    (apply string-append xs))
+;(f "c" "d" "e" "f") ; succeeds
+(apply f "c" 1) ; typecheck fail
+
+
+


### PR DESCRIPTION
Certain type errors with rest arguments lacked a space in their output, making them confusing for beginners. (What is the type `StringString`?)
