### PR TITLE
make usage of rest arguments consistent with grammar. minor edits.

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -175,8 +175,8 @@ is the provided type annotation.
 
 @ex[
   (lambda (x . rst) rst)
-  (lambda (x rst : Integer *) rst)
-  (lambda #:forall (A ...) (x rst : A ... A) rst)
+  (lambda (x . [rst : Integer *]) rst)
+  (lambda #:forall (A ...) (x . [rst : A ... A]) rst)
 ]
 }
 
@@ -357,14 +357,14 @@ Like @racket[lambda], optional and keyword arguments are supported.
 
 @ex[
     (define (add [first : Integer]
-                 [rest  : Integer]) : Integer
-      (+ first rest))
+                 [second  : Integer]) : Integer
+      (+ first second))
 
     (define #:forall (A)
             (poly-app [func : (A A -> A)]
                       [first : A]
-                      [rest  : A]) : A
-      (func first rest))]
+                      [second  : A]) : A
+      (func first second))]
 
 The function definition form also allows curried function arguments with
 corresponding type annotations.


### PR DESCRIPTION
Reading issue #862, I wondered how someone got the idea that you could use a rest argument without a `.` in front of it. According to [the grammar in the reference](https://docs.racket-lang.org/ts-reference/special-forms.html?q=-%3E#%28form._%28%28lib._typed-racket%2Fbase-env%2Fprims..rkt%29._lambda%29%29), rest has to be preceded by a`.` and if it is annotated by a type, the type must be bracketed in the usual way.

I noticed that some existing examples don't do that, so I fixed them.

I also changed a non-list use of a variable named `rest` to the name `second`.  

The fact that they are accepted by the compiler is somebody else's issue. :)