### PR TITLE
transient semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,9 @@ jobs:
         if: ${{ !matrix.enable-contracts }}
       - run: raco test -em typed-racket-test/test-docs-complete.rkt
         if: ${{ !matrix.enable-contracts }}
-      - run: raco setup math
+      - run: raco setup plot math
       - run: racket -l typed-racket-test -- --external
+      - run: raco make typed-racket-test/external/historical-counterexamples.rkt
       - run: racket -l typed-racket-test/external/historical-counterexamples
         if: ${{ !matrix.enable-contracts }}
       - run: racket -l typed-racket-test/external/tr-random-testing

--- a/rfcs/text/0003-shallow-optional-semantics.md
+++ b/rfcs/text/0003-shallow-optional-semantics.md
@@ -1,0 +1,399 @@
+- Feature Name: shallow-optional-semantics
+- Start Date: 2020-07-21
+- RFC PR: (leave this empty)
+- Feature Commit(s): (leave this empty)
+
+# Summary
+
+This RFC adds two new languages to the Typed Racket (TR) world: Shallow Typed
+Racket and Optional Typed Racket. By contrast to normal Typed Racket --- which
+we'll call Deep Typed Racket --- the new languages have "weaker" types. They
+do less work at run-time to protect typed code from untyped Racket code.
+
+All three languages (Shallow, Optional, and Deep) use the same syntax for types
+and the same type checker. The only difference is what types mean (and cost) at
+run-time.
+
+For example, let's begin with the static type `(Listof String)` and ask what
+untyped values are allowed to have this type in the different languages. In
+other words, the question is what values of `str*` can satisfy the run-time
+requirements of the declaration `(: str* (Listof String))`:
+
+1. In Deep TR (`#lang typed/racket` or `#lang typed/racket/deep`), the value
+   `str*` must be a list of strings.
+
+2. In Shallow TR (`#lang typed/racket/shallow`), the value `str*` must be a
+   list. There are no constraints on the elements of the list; they don't need
+   to be strings.
+     That being said, if typed code reads the first element of the list and
+   expects a `String`, then Shallow TR will make sure that one element is a
+   string.
+
+3. In Optional TR (`#lang typed/racket/optional`), `str*` can be any value.
+
+
+In general, Deep types give strong guarantees. Shallow types give weaker
+"surface-level" guarantees. Optional types give no guarantees.
+
+Shallow and Optional types are useful, though, because they are weaker.
+They add a lower run-time cost for interactions with untyped Racket code
+(zero cost for Optional!) and have simpler behavior (examples in the rest
+of this document illustrate).
+
+
+## Document Outline
+
+In the rest of this RFC, the focus is on Shallow types and how we plan to
+implement them using the _Transient_ strategy. The idea with Transient is
+to rewrite all typed code with simple assertions about the shape of values.
+
+By contrast to Transient, normal TR gets Deep types through the Guarded
+(aka Natural) semantics. The idea with Guarded is to keep a strict boundary
+between typed and untyped code with flat contracts, chaperones, and
+impersonators.
+
+The Optional idea is simple: use the TR type checker at compile-time and normal
+`#lang racket` behavior at run-time. It is simlar to the no-check language,
+but actually runs the type checker.
+
+
+# Motivation
+
+Deep types are expensive and difficult to enforce. Shallow types via the
+Transient semantics are often cheaper and always easier to check. Changing a
+program to use Shallow types may give two immediate benefits:
+
+  S1. A program should run faster if it heavily mixes typed and untyped code.
+
+  S2. Some type-correct programs that cannot run in Deep can run in Shallow.
+
+Deep types still have benefits over Shallow types:
+
+  D1. When a typed/untyped interaction goes wrong, Deep types blame a
+      precise boundary between a typed module and an untyped one.
+      Shallow types cannot be so precise.
+
+  D2. Fully-typed (and mostly-typed) Deep programs often run faster than
+      untyped, but Shallow programs always run slower with more types.
+
+Points S1 and S2 motivate Shallow. Points D1 and D2 motivate a mix of Deep
+and Shallow. The goal is to offer both as `#lang`s that can interact.
+
+
+### (S1) Shallow types can be faster
+
+These comments are about Shallow types as implemented by Transient.
+
+#### Example 1 : read-only data
+
+When an untyped list flows into Deep code, every element in the list gets a
+runtime check.  When the same list flows to Shallow code, there is a simple
+`list?` check only; other checks come as needed. So, simple list functions
+should run much faster.
+
+  ```
+  (: get-first (-> (Listof String) String))
+  (define (get-first str*)
+    (car str*))
+  ```
+
+If `get-first` lives in a `#lang typed/racket/deep` module, every call walks
+the whole list. But if `get-first` is in a `#lang typed/racket/shallow` module,
+only 1 element gets checked because only 1 element gets accessed.
+
+
+### Example 2 : mutable data
+
+When an untyped vector flows into Deep code, it gets wrapped in a chaperone
+to make sure that its future behavior matches the type. When a vector flows
+into Shallow code, there is one `vector?` check. Shallow does not add a
+wrapper and element checks happen only when needed.
+
+Example:
+
+  ```
+  (: vector-id (-> (Vectorof Real) (Vectorof Real)))
+  (define (vector-id v)
+    v)
+  ```
+
+With Deep types, the incoming vector gets wrapped in a chaperone. After this
+vector flows out, all future uses of it need to go through the chaperone, so
+those future uses suffer indirection and checking costs.
+
+With Shallow types, this code has one `vector?` check. The vector `v` does
+not get a wrapper.
+
+
+### Example 3 : functions
+
+Deep types wrap and chaperone functions just like mutable data. Shallow types
+spot-check the result of function calls, but do not create wrappers.
+
+This example makes a typed wrapper around the `racket/base` map
+function:
+
+  ```
+  (: rmap (-> (-> Real Boolean) (Listof Real) (Listof Boolean)))
+  (define (rmap f r*)
+    (map f r*))
+  ```
+
+With Deep types, the function `f` gets a wrapper. When `map` uses this function,
+the wrapper checks that `f` gets a `Real` and returns a `Boolean` for every
+element in the list. Deep also pre-emptively checks the list `r*` before
+shipping it to `map`.
+
+With Shallow types, there are two checks: does `f` look good? and does `r*` look
+good? These checks are basically `procedure?` and `list?`. That's all.
+
+
+### (S2) Shallow types can allow new interactions
+
+Deep types need to use wrappers to check/protect mutable values. Every kind of
+mutable value in Racket needs a custom kind of wrapper. But some wrappers do
+not exist yet, and so TR conservatively rejects some programs.
+
+For example, mpairs are mutable and do not have a wrapper. Thus, the following
+"good" program gives a runtime error with Deep types:
+
+  ```
+  #lang racket
+
+  (module t typed/racket
+    (: add-mpair (-> (MPairof Real Real) Real))
+    (define (add-mpair mp)
+      (+ (mcar mp) (mcdr mp)))
+    (provide add-mpair))
+
+  (require 't)
+
+  (add-mpair (mcons 2 4))
+  ;; Type Checker: could not convert type to a contract;
+  ;; contract generation not supported for this type
+  ```
+
+Shallow types (via Transient) can run the program. For Shallow type safety, the
+typed function checks `mpair?` of its input and `real?` after the getter
+functions.
+
+Syntax objects also lack wrappers. (Wrappers are needed for Deep types because
+a syntax object may contain a mutable value.) Implementing these wrappers would
+require changes to basic parts of Racket including the macro expander.
+
+
+### (D1) Deep types give better errors
+
+Thanks to the heavy checking and careful use of wrappers, Deep types give a
+strong guarantee: every communication between typed and untyped code will
+either match the types or stop the program. In other words, there is no way
+that untyped code can sneak a bad value into typed code.
+
+Because of this Deep-types guarantee (called "complete monitoring" in the
+papers), TR can blame one _correct_ source-code boundary when a check fails.
+The boundary is to blame in the sense that something is wrong on at least
+one of its sides: either the untyped code produced a bad value, or typed code
+has a bad expectation.
+
+Shallow types cannot always blame a single boundary because they rarely check
+a boundary completely. Let's go back to lists; here is a typed function that
+looks at part of a list and passes it on:
+
+  ```
+  (: spot-check (-> (Listof Symbol) (Listof Symbol)))
+  (define (spot-check sym*)
+    (cons (cadr sym*) (cons (car sym*) (cddr sym*))))
+  ```
+
+With Shallow types, there is no guarantee that the result is a list of symbols.
+Suppose that we start with a list `'(A B "C")` and it goes through this
+function and later crosses several typed/untyped boundaries and finally
+some typed code realizes the 3rd element is a string. Unless we keep a record
+of every place the list has been, there is no way to point back to the first
+`spot-check` call. There is also no reason the first boundary should always
+be blamed.
+
+Shallow-type blame gets even worse when types make claims about untyped
+libraries. There might be no blame at all. In the example below, the types in
+the middle incorrectly say that the library on top sends numbers to its
+callback. The client on the bottom assumes the types are right. If the
+types are Shallow, they do not protect the client from unexpected input:
+
+  ```
+  #lang racket
+
+  (module library racket
+    (define (sender f)
+      (f "hello"))
+    (provide sender))
+
+  (module types typed/racket/shallow
+    (require/typed/provide (submod ".." library)
+      (sender (-> (-> Real Real) Real))))
+
+  (module client racket
+    (require (submod ".." types))
+    (sender (lambda (n) (add1 n))))
+
+  (require 'client)
+  ;; Shallow => add1 contract violation
+  ```
+
+In Shallow TR, a type mismatch leads to a simple assertion failure. Shallow TR
+does not try to trace the error back to a boundary (or set of boundaries).
+
+There is a method for improving blame in Transient that Shallow TR could use,
+but we have found it is too slow. More information can be found here:
+
+  <http://cs.brown.edu/people/bgreenma/publications/publications.html#gldf-pj-2022>
+
+
+### (D2) Adding types affects Deep and Shallow differently
+
+Deep types check the boundaries between typed and untyped code. If there are
+no boundaries, there are no checks.
+
+Shallow types via Transient pre-emptively protect typed code. Every expression
+in typed code may get compiled to have a check. It all depends on whether the
+code can receive untyped input.
+
+Early experience with Deep and Shallow TR suggests a few general claims
+about how adding types changes performance:
+
+- Deep types can add a huge slowdown when typed and untyped code share
+  mutable data.
+
+- Deep types also enable optimizations. If there are no crippling typed/untyped
+  boundaries in a program, then a typed version is often faster than untyped.
+
+- Shallow types add a low, steady overhead as more code gets typed.
+
+- Shallow types enable some optimizations, but these rarely outweigh the cost
+  of the checks.
+
+Chapter 6 of Greenman's dissertation has more information:
+
+  <http://cs.brown.edu/people/bgreenma/publications/publications.html#g-dissertation-2020>
+
+
+# Guide-level explanation
+
+See `Summary` section.
+
+
+# Reference-level explanation
+
+## 8 Typed Racket Syntax With Shallow Types
+
+(The reference will use parts of the motivation above, a short description
+ like the one for optional typing below, and maybe some tips about when
+ to use Shallow types)
+
+
+## 9 Typed Racket Syntax With Optional Types
+
+The `typed/racket/optional` and `typed/racket/base/optional` languages provide
+the same bindings as `typed/racket` and `typed/racket/base` and use the same
+type-checking, but have the same run-time behavior as `racket` and
+`racket/base`. Typed Racket types are normally true claims about the ways
+that a program can behave, but in these optional languages the types say
+nothing about behavior.
+
+Optional typing is useful if you want the type-checker to spot-check your
+program and are willing to deal with arbitrary Racket behaviors. For example,
+an optionally-typed function with type `(-> Integer Integer)` could receive
+a string as input and return a symbol.
+
+
+# Drawbacks and Alternatives
+[drawbacks]: #drawbacks
+
+Drawback: more languages = more choices = more ways to get confused.
+And people may be surprised that typed-to-typed communication is still
+ expensive (because Deep needs to protect itself against Shallow types).
+
+One alternative is to keep trying to make TR faster.
+
+Another is to implement Shallow types using wrappers instead of the Transient
+strategy. With wrappers, interaction with TR should be faster. But doing may
+require new contracts (or chaperones), and will prevent some typed/untyped
+mixes that Transient allows (unless we can make new chaperones to allow them).
+
+
+# Prior art
+[prior-art]: #prior-art
+
+Shallow types are in Reticulated Python and Grace.
+
+Reticulated is the original home of the Transient semantics. Michael Vitousek
+invented Transient; his dissertation talks about experiences with it
+(especially in Chapter 4).
+
+Grace has shallow checks that were inspired by Transient.
+
+
+Resources for transient semantics (Shallow):
+- <https://scholarworks.iu.edu/dspace/handle/2022/23172>
+- <https://2019.ecoop.org/details/ecoop-2019-papers/15/Transient-Typechecks-are-Almost-Free>
+
+Resources that compare Deep and Shallow types:
+- <http://prl.ccs.neu.edu/blog/2018/12/11/the-behavior-of-gradual-types-a-user-study/>
+- <http://prl.ccs.neu.edu/blog/2019/10/31/complete-monitors-for-gradual-types/>
+
+Resources that talk about many ways of mixing typed and untyped code:
+- <http://prl.ccs.neu.edu/blog/2018/10/06/a-spectrum-of-type-soundness-and-performance/>
+- <http://ccs.neu.edu/home/types/publications/publications.html#gfd-oopsla-2019>
+
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+PR #948 has a list of lower-level todo items.
+
+
+> - What parts of the design do you expect to resolve through the RFC process
+>   before this gets merged?
+
+Documentation. What should it include, and how should it be organized to
+introduce new TR languages.
+
+
+> - What parts of the design do you expect to resolve through the implementation
+>   of this feature before stabilization?
+
+1. [RESOLVED] How to insert checks everywhere. Today, RackUnit `test-case`s and
+   `with-handlers` blocks are unsafe because they're marked as "ignored" by TR.
+   There may be others. (2020-07-26)
+
+2. What's the ideal check for every type?
+   Should `(Listof T)` use `list?` or `(or/c null? pair?)`?
+   Should `(-> Void Void)` use `procedure?` or
+    `(and/c procedure? (procedure-arity-includes/c 1))`?
+   So far I've gone for "complete" checks to help the programmer and TR
+    optimizer, but if the cost is too high let's go simpler.
+
+3. [RESOLVED] How to minimize the cost of each check, probably by avoiding
+   `racket/contract` combinators.
+
+
+> - What related issues do you consider out of scope for this RFC that could be
+>   addressed in the future independently of the solution that comes out of this
+>   RFC?
+
+Below are 4 issues related to the transient semantics.
+
+
+- How to add blame? For now, an error gives a failed check (value, type,
+  srcloc) and a stack trace. It may be helpful to give some blame info.
+  Then again, programmers can always switch to Deep TR for precise blame.
+
+- How to avoid redundant checks (via static/dynamic analysis)? For example, a
+  function that takes the `car` of a pair twice currently pays 2 checks.
+
+  ```
+    (define (f (xy : (Pairor Real Real))) : Real
+      (+ (car xy) (car xy))
+
+      #;(+ (check real? (car xy)) (check real? (car xy))))
+  ```
+

--- a/typed-racket-compatibility/typed/scheme/base.rkt
+++ b/typed-racket-compatibility/typed/scheme/base.rkt
@@ -12,7 +12,8 @@
                          for*/and
                          for*/or for*/sum for*/product for*/first for*/last
                          for*/fold for*/foldr))
-	   (basics #%module-begin #%top-interaction))
+	   (basics #%module-begin #%top-interaction)
+	   (ts-except with-type-shallow with-type-optional))
 
 (require typed-racket/base-env/extra-procs
          (rename-in

--- a/typed-racket-doc/typed-racket/scribblings/guide/typed-untyped-interaction.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/typed-untyped-interaction.scrbl
@@ -6,6 +6,9 @@
 
 @(define the-eval (make-base-eval))
 @(the-eval '(require typed/racket))
+@(define shallow-eval (make-base-eval #:lang 'typed/racket/shallow))
+@(define optional-eval (make-base-eval #:lang 'typed/racket/optional))
+
 
 @title[#:tag "typed-untyped-interaction"]{Typed-Untyped Interaction}
 
@@ -14,7 +17,21 @@ that are entirely typed. One of the key features of Typed Racket is that
 it allows the combination of both typed and untyped code in a single
 program.
 
-@section{Using Untyped Code from Typed Code}
+From a static typing perspective, combining typed and untyped code is
+straightforward.
+Typed code must declare types for its untyped imports to let the type checker
+validate their use (@secref{untyped-in-typed}).
+Untyped code can freely import bindings from typed code (@secref{typed-in-untyped}).
+
+At run-time, combining typed and untyped code is complicated because there is a
+tradeoff between strong type guarantees and the performance cost of checking
+that untyped code matches the types.
+Typed Racket provides strong @emph{Deep} type guarantees by default, but offers two
+weaker options as well: Shallow and Optional types
+(@secref{protecting-interaction}).
+
+
+@section[#:tag "untyped-in-typed"]{Using Untyped Code in Typed Code}
 
 Suppose that we write the untyped module from @secref["quick"] again:
 
@@ -38,7 +55,7 @@ it. Since the untyped module did not specify any types, we need to annotate
 the imports with types (just like how the example in @secref["quick"] had
 additional type annotations with @racket[:]):
 
-@margin-note{Note that a typed module @emph{does not} need to use @racket[require/typed]
+@margin-note{Note that a typed module @emph{should not} use @racket[require/typed]
 to import from another typed module. The @racket[require] form will work in such
 cases.}
 
@@ -116,7 +133,7 @@ typed/racket
 
 
 
-@section{Using Typed Code in Untyped Code}
+@section[#:tag "typed-in-untyped"]{Using Typed Code in Untyped Code}
 
 In the previous subsection, we saw that the use of untyped code from
 typed code requires the use of @racket[require/typed]. However, the
@@ -128,28 +145,26 @@ to use the bindings defined in the typed module as expected. The major
 exception to this rule is that macros defined in typed modules may not
 be used in untyped modules.
 
-@section{Protecting Typed-Untyped Interaction}
+
+@section[#:tag "protecting-interaction"]{Protecting Typed-Untyped Interaction}
 
 One might wonder if the interactions described in the first two
-subsections are actually safe; after all, untyped code might be able to
+subsections are actually safe. After all, untyped code might be able to
 ignore the errors that Typed Racket's type system will catch at
 compile-time.
 
-To ensure that typed-untyped interactions are safe, Typed Racket establishes
-contracts wherever typed and untyped code interact. For example, suppose
+For example, suppose
 that we write an untyped module that implements an @racket[_increment]
 function:
 
-@margin-note{For general information on Racket's contract system
-, see @secref[#:doc '(lib "scribblings/guide/guide.scrbl")]{contracts}.}
-
-@examples[#:label #f #:eval the-eval
+@examples[#:eval shallow-eval #:hidden (module increment racket (provide increment) (code:contract increment : exact-integer? -> exact-integer?) (define (increment x) "this is broken"))]
+@examples[#:eval optional-eval #:hidden (module increment racket (provide increment) (code:contract increment : exact-integer? -> exact-integer?) (define (increment x) "this is broken"))]
+@examples[#:eval the-eval
 (module increment racket
   (provide increment)
 
   (code:contract increment : exact-integer? -> exact-integer?)
-  (define (increment x) "this is broken"))
-]
+  (define (increment x) "this is broken"))]
 
 and a typed module that uses it:
 
@@ -161,23 +176,55 @@ and a typed module that uses it:
   (increment 5))
 ]
 
-This combined program is not correct. All uses of @racket[_increment]
+This combined program has a problem. All uses of @racket[_increment]
 in Typed Racket are correct under the assumption that the
 @racket[_increment] function upholds the @racket[(-> Integer Integer)]
 type. Unfortunately, our @racket[_increment] implementation does not
 actually uphold this assumption, because the function actually produces
 strings.
 
-On the other hand, when the program is run:
+By default, Typed Racket establishes contracts wherever typed and untyped code
+interact to ensure strong types.
+These contracts can, however, have a non-trivial performance impact.
+For programs in which these costs are problematic, Typed Racket provides
+two alternatives. All together, the three options are Deep, Shallow, and Optional types.
+
+@itemlist[#:style 'ordered
+  @item{
+    @emph{Deep} types get enforced with comprehensive contract checks.
+  }
+  @item{
+    @emph{Shallow} types get checked in typed code with lightweight assertions
+    called @emph{shape checks}.
+  }
+  @item{
+    @emph{Optional} types do not get enforced in any way. They do not ensure
+    safe typed-untyped interactions.
+  }
+]
+
+@margin-note{See also: @secref["behavior-of-types" #:doc '(lib
+"typed-racket/scribblings/ts-reference.scrbl")] in the Typed Racket Reference.}
+The next subsections give examples of Deep, Shallow, and Optional behaviors.
+
+
+@subsection{Deep Types: Completely Reliable}
+
+When the @racket[_client] program above is run, standard Typed
+Racket (aka. Deep Typed Racket) enforces the @racket[require/typed]
+interface with a contract.
+This contract detects a failed type assumption when the @racket[_client]
+calls the untyped @racket[_increment] function:
 
 @examples[#:label #f #:eval the-eval (eval:error (require 'client))]
 
-we find that the contract system checks the assumption made by the typed
-module and correctly finds that the assumption failed because of the
-implementation in the untyped module (hence it is @emph{blamed} in the
-error message).
+Because the implementation in the untyped module broke the contract
+by returning a string instead of an integer, the error message
+@emph{blames} it.
 
-In the same fashion, Typed Racket checks all functions and other values
+@margin-note{For general information on Racket's contract system,
+see @secref[#:doc '(lib "scribblings/guide/guide.scrbl")]{contracts}.}
+In general, Deep Typed Racket checks all functions and other values
 that pass from a typed module to untyped module or vice versa with
 contracts. This means that, for example, Typed Racket can safely optimize
 programs (see @secref["optimization"]) with the assurance that the program
@@ -189,7 +236,121 @@ have a non-trivial performance impact, especially with the use of first-class
 functions or other higher-order data such as vectors.
 
 Note that no contract overhead is ever incurred for uses of typed
-values from another typed module.
+values from another Deep-typed module.
+
+
+@subsection{Shallow Types: Sound Types, Low-Cost Interactions}
+
+Changing the module language of the @racket[_client] program
+from @racketmodname[typed/racket] to @racketmodname[typed/racket/shallow]
+changes the way in which typed-untyped interactions are protected.
+Instead of contracts, Typed Racket uses shape checks to enforce
+these Shallow types.
+
+With Shallow types, the @racket[_client] program from above still detects an
+error when an untyped function returns a string instead of an integer:
+
+@examples[#:label #f #:eval shallow-eval
+(module client typed/racket/shallow
+
+  (require/typed 'increment [increment (-> Integer Integer)])
+
+  (increment 5))
+
+(eval:error (require 'client))
+]
+
+The compiled @racket[_client] module has two shape checks in total:
+
+@itemlist[#:style 'ordered
+  @item{
+    A shape check at the @racket[require/typed] boundary confirms that
+    @racket[increment] is a function that expects one argument.
+  }
+
+  @item{
+    A shape check after the call @racket[(increment 5)] looks for an integer.
+    This check fails.
+  }
+]
+
+Such checks work together within one typed module to enforce the assumptions that
+it makes about untyped code.
+
+In general, a shape check ensures that a value matches the top-level constructor
+of a type.
+Shape checks are always yes-or-no predicates (unlike contracts, which may wrap a
+value) and typically run in constant time.
+Because they ensure the validity of type constructors, shape checks allow Typed
+Racket to safely optimize some programs---though not to the same extent as Deep
+types.
+
+@bold{Important caveats}: (1) The number of shape checks in a module grows in
+proportion to its size. For example, every function call in Shallow-typed code
+gets checked---unless Typed Racket is certain that it can trust the function.
+Shallow types are therefore a poor choice for large, computationally-heavy
+modules.
+(2) Shallow types are only enforced in their immediate, local context.
+For example, if typed code were to cast @racket[increment] to expect a string,
+then the function could be called without an error.
+
+
+@subsection{Optional Types: It's Just Racket}
+
+A third option for the @racket[_client] program is to use Optional types, which
+are provided by the language @racketmodname[typed/racket/optional]:
+
+@examples[#:label #f #:eval optional-eval
+(module client typed/racket/optional
+
+  (require/typed 'increment [increment (-> Integer Integer)])
+
+  (increment 5))
+]
+
+Optional types do not ensure safe typed-untyped interactions.
+In fact, they do nothing to check types at run-time.
+A call to the increment function does not raise an error:
+
+@examples[#:label #f #:eval the-eval (require 'client)]
+
+Optional types cannot detect incorrect type assumptions
+and therefore enable zero type-driven optimizations.
+But, they also add no costs to slow a program down.
+In general, the behavior of an Optionally-typed program is the same as that of
+a Racket program that completely ignores type annotations.
+
+
+@subsection{When to Use Deep, Shallow, or Optional?}
+
+@itemlist[
+  @item{
+    @emph{Deep} types maximize the benefits of static checking
+    and type-driven optimizations.
+    Use them for tightly-connected groups of typed modules.
+    Avoid them when untyped, higher-order values frequently
+    cross boundaries into typed code. Expensive boundary types
+    include @racket[Vectorof], @racket[->], and @racket[Object].
+  }
+  @item{
+    @emph{Shallow} types are best for small typed modules that frequently
+    interact with untyped code.
+    This is because Shallow shape checks run quickly: constant-time for
+    most types, and linear time (in the size of the type, not the value)
+    for a few exceptions such as @racket[U] and @racket[case->].
+    Avoid Shallow types in large typed modules that frequently call functions
+    or access data structures because these operations may incur shape checks
+    and their net cost may be significant.
+  }
+  @item{
+    @emph{Optional} types enable the typechecker and nothing else. Use them when
+    you do not want types enforced at run-time.
+  }
+]
+
+
 
 @close-eval[the-eval]
+@close-eval[shallow-eval]
+@close-eval[optional-eval]
 

--- a/typed-racket-doc/typed-racket/scribblings/guide/typed-untyped-interaction.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/typed-untyped-interaction.scrbl
@@ -26,8 +26,9 @@ Untyped code can freely import bindings from typed code (@secref{typed-in-untype
 At run-time, combining typed and untyped code is complicated because there is a
 tradeoff between strong type guarantees and the performance cost of checking
 that untyped code matches the types.
-Typed Racket provides strong @emph{Deep} type guarantees by default, but offers two
-weaker options as well: Shallow and Optional types
+Typed Racket provides strong @emph{Deep} type guarantees by
+default, but offers two weaker options as well: @emph{Shallow}
+and @emph{Optional} types
 (@secref{protecting-interaction}).
 
 
@@ -191,14 +192,14 @@ two alternatives. All together, the three options are Deep, Shallow, and Optiona
 
 @itemlist[#:style 'ordered
   @item{
-    @emph{Deep} types get enforced with comprehensive contract checks.
+    @tr-rtech{Deep types} get enforced with rigorous contract checks.
   }
   @item{
-    @emph{Shallow} types get checked in typed code with lightweight assertions
-    called @emph{shape checks}.
+    @tr-rtech{Shallow types} get checked in typed code with lightweight assertions
+    called @tech{shape checks}.
   }
   @item{
-    @emph{Optional} types do not get enforced in any way. They do not ensure
+    @tr-rtech{Optional types} do not get enforced in any way. They do not ensure
     safe typed-untyped interactions.
   }
 ]
@@ -220,7 +221,7 @@ calls the untyped @racket[_increment] function:
 
 Because the implementation in the untyped module broke the contract
 by returning a string instead of an integer, the error message
-@emph{blames} it.
+blames it.
 
 @margin-note{For general information on Racket's contract system,
 see @secref[#:doc '(lib "scribblings/guide/guide.scrbl")]{contracts}.}
@@ -244,7 +245,7 @@ values from another Deep-typed module.
 Changing the module language of the @racket[_client] program
 from @racketmodname[typed/racket] to @racketmodname[typed/racket/shallow]
 changes the way in which typed-untyped interactions are protected.
-Instead of contracts, Typed Racket uses shape checks to enforce
+Instead of contracts, Typed Racket uses @deftech{shape checks} to enforce
 these Shallow types.
 
 With Shallow types, the @racket[_client] program from above still detects an
@@ -277,8 +278,8 @@ The compiled @racket[_client] module has two shape checks in total:
 Such checks work together within one typed module to enforce the assumptions that
 it makes about untyped code.
 
-In general, a shape check ensures that a value matches the top-level constructor
-of a type.
+A design guideline for a shape checks is to ensure that a value matches the
+top-level constructor of a type.
 Shape checks are always yes-or-no predicates (unlike contracts, which may wrap a
 value) and typically run in constant time.
 Because they ensure the validity of type constructors, shape checks allow Typed
@@ -315,17 +316,17 @@ A call to the increment function does not raise an error:
 @examples[#:label #f #:eval the-eval (require 'client)]
 
 Optional types cannot detect incorrect type assumptions
-and therefore enable zero type-driven optimizations.
+and therefore do not enable type-driven optimizations.
 But, they also add no costs to slow a program down.
-In general, the behavior of an Optionally-typed program is the same as that of
-a Racket program that completely ignores type annotations.
+The run-time behavior is very similar to untyped Racket
+and @racketmodname[typed/racket/no-check].
 
 
 @subsection{When to Use Deep, Shallow, or Optional?}
 
 @itemlist[
   @item{
-    @emph{Deep} types maximize the benefits of static checking
+    @tr-rtech{Deep types} maximize the benefits of static checking
     and type-driven optimizations.
     Use them for tightly-connected groups of typed modules.
     Avoid them when untyped, higher-order values frequently
@@ -333,7 +334,7 @@ a Racket program that completely ignores type annotations.
     include @racket[Vectorof], @racket[->], and @racket[Object].
   }
   @item{
-    @emph{Shallow} types are best for small typed modules that frequently
+    @tr-rtech{Shallow types} are best for small typed modules that frequently
     interact with untyped code.
     This is because Shallow shape checks run quickly: constant-time for
     most types, and linear time (in the size of the type, not the value)
@@ -343,7 +344,7 @@ a Racket program that completely ignores type annotations.
     and their net cost may be significant.
   }
   @item{
-    @emph{Optional} types enable the typechecker and nothing else. Use them when
+    @tr-rtech{Optional types} enable the typechecker and nothing else. Use them when
     you do not want types enforced at run-time.
   }
 ]

--- a/typed-racket-doc/typed-racket/scribblings/reference/behavior-of-types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/behavior-of-types.scrbl
@@ -44,10 +44,10 @@ because they can detect when a typed-untyped interaction goes wrong. On the othe
 constraints must be enforced with run-time checks, which affect run-time
 performance. Stronger constraints generally impose a higher performance cost.
 
-By default, Typed Racket provides @emph{Deep} types that strictly constrain the
+By default, Typed Racket provides @tech[#:key "deep type"]{Deep} types that strictly constrain the
 behavior of untyped code. But because these constraints can be expensive,
-Typed Racket offers two alternatives: @emph{Shallow} and
-@emph{Optional} types.
+Typed Racket offers two alternatives: @tech[#:key "shallow type"]{Shallow} and
+@tech[#:key "optional type"]{Optional} types.
 All three use the same static types and static checks, but
 they progressively weaken the run-time behavior of types.
 
@@ -62,7 +62,7 @@ they progressively weaken the run-time behavior of types.
 
 @itemlist[
 @item{
-  @emph{Deep} types enforce strong, compositional guarantees.
+  @deftech{Deep types} enforce strong, compositional guarantees.
   If a value is annotated with a Deep type, then all of its interactions with
   other code must match the type.
   For example, a value with the type @racket[(Listof String)] must be a list
@@ -72,7 +72,7 @@ they progressively weaken the run-time behavior of types.
               @racketmodname[typed/racket/deep] @racketmodname[typed/racket/base/deep]]
 }
 @item{
-  @emph{Shallow} types enforce the outer shape of values.
+  @deftech{Shallow types} enforce the outer shape of values.
   For example, the Shallow type @racket[(Listof String)] checks only for lists --- it does not check
   whether the list elements are strings.
   This enforcement may seem weak at first glance, but Shallow types can work
@@ -83,7 +83,7 @@ they progressively weaken the run-time behavior of types.
   @langs-from[@racketmodname[typed/racket/shallow] @racketmodname[typed/racket/base/shallow]]
 }
 @item{
-  @emph{Optional} types enforce nothing and add zero run-time cost.
+  @deftech{Optional types} enforce nothing and add zero run-time cost.
   These types are useful for finding bugs in typed code at compile-time, but they cannot
   detect interaction errors at run-time.
 
@@ -262,7 +262,7 @@ Shallow, or Optional.
 
 Across these forms, the changes are roughly the same.
 Deep types get enforced as (higher-order) contracts,
-Shallow types get enforced as shape checks,
+Shallow types get enforced as @tr-gtech{shape checks},
 and Optional types get enforced with nothing.
 The key point to understand is @emph{which} types get enforced at run-time.
 

--- a/typed-racket-doc/typed-racket/scribblings/reference/behavior-of-types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/behavior-of-types.scrbl
@@ -1,0 +1,470 @@
+#lang scribble/manual
+
+@begin[(require "../utils.rkt" scribble/example racket/sandbox racket/list)
+       (require (only-in scribble/eval interaction-eval interaction/no-prompt))
+       (require (for-label typed/untyped-utils (only-meta-in 0 [except-in typed/racket for])))]
+
+@(define-syntax-rule (module-example #:eval ev #:label lbl lang-datum mod-code ... ex-code)
+   (list
+     (if lbl (list lbl) '())
+     (racketmod lang-datum mod-code ...)
+     (interaction-eval #:eval ev mod-code ...)
+     (interaction/no-prompt #:eval ev ex-code)))
+
+@(define deep-eval (make-base-eval #:lang 'typed/racket))
+@(define shallow-eval (make-base-eval #:lang 'typed/racket/shallow))
+@(define optional-eval (make-base-eval #:lang 'typed/racket/optional))
+
+@title[#:tag "behavior-of-types"]{Deep, Shallow, and Optional Semantics}
+
+@(define-syntax-rule @defmodulelang/hidden[name]
+   (list
+      (section #:style '(hidden toc-hidden unnumbered)
+               (symbol->string 'name))
+      @defmodulelang[name]))
+
+@defmodulelang/hidden[typed/racket/deep]
+@defmodulelang/hidden[typed/racket/base/deep]
+@defmodulelang/hidden[typed/racket/shallow]
+@defmodulelang/hidden[typed/racket/base/shallow]
+@defmodulelang/hidden[typed/racket/optional]
+@defmodulelang/hidden[typed/racket/base/optional]
+
+@margin-note{See also: @secref["typed-untyped-interaction" #:doc '(lib
+"typed-racket/scribblings/ts-guide.scrbl")] in the Typed Racket Guide.}
+Typed Racket allows the combination of both typed and untyped code in
+a single program.
+Untyped code can freely import typed identifiers.
+Typed code can import untyped identifiers by giving them types (via
+@racket[require/typed]).
+
+Allowing typed/untyped combinations raises questions about @emph{whether} and @emph{how} types should
+constrain the behavior of untyped code. On one hand, strong type constraints are useful
+because they can detect when a typed-untyped interaction goes wrong. On the other hand,
+constraints must be enforced with run-time checks, which affect run-time
+performance. Stronger constraints generally impose a higher performance cost.
+
+By default, Typed Racket provides @emph{Deep} types that strictly constrain the
+behavior of untyped code. But because these constraints can be expensive,
+Typed Racket offers two alternatives: @emph{Shallow} and
+@emph{Optional} types.
+All three use the same static types and static checks, but
+they progressively weaken the run-time behavior of types.
+
+@(define (langs-from . lang-name*)
+   (add-between
+     lang-name*
+     (list ", ")
+     #:splice? #true
+     #:before-first (list "Available in: ")
+     #:before-last (list ", and ")
+     #:after-last (list ".")))
+
+@itemlist[
+@item{
+  @emph{Deep} types enforce strong, compositional guarantees.
+  If a value is annotated with a Deep type, then all of its interactions with
+  other code must match the type.
+  For example, a value with the type @racket[(Listof String)] must be a list
+  that contains only strings; otherwise, Typed Racket raises an error.
+
+  @langs-from[@racketmodname[typed/racket] @racketmodname[typed/racket/base]
+              @racketmodname[typed/racket/deep] @racketmodname[typed/racket/base/deep]]
+}
+@item{
+  @emph{Shallow} types enforce the outer shape of values.
+  For example, the Shallow type @racket[(Listof String)] checks only for lists --- it does not check
+  whether the list elements are strings.
+  This enforcement may seem weak at first glance, but Shallow types can work
+  together to provide a decent safety net.
+  If Shallow-typed code gets an element from a list and expects a
+  @racket[String], then another check will make sure the element is really a string.
+
+  @langs-from[@racketmodname[typed/racket/shallow] @racketmodname[typed/racket/base/shallow]]
+}
+@item{
+  @emph{Optional} types enforce nothing and add zero run-time cost.
+  These types are useful for finding bugs in typed code at compile-time, but they cannot
+  detect interaction errors at run-time.
+
+  @langs-from[@racketmodname[typed/racket/optional] @racketmodname[typed/racket/base/optional]]
+}
+]
+
+@section{Example Interactions}
+
+The examples below show how Deep, Shallow, and Optional change the run-time behavior (or, the semantics) of types.
+
+@subsection{Checking Immutable Data: Importing a List}
+
+When typed code imports an untyped list:
+@itemlist[
+  @item{Deep types check each element of the list at the boundary to untyped code;}
+  @item{Shallow types check for a list, and check elements when they are accessed; and}
+  @item{Optional types check nothing.}
+]
+
+The following examples import the function @racket[string->list], which returns a list of characters,
+and use an incorrect type that expects a list of strings.
+Both Deep and Shallow types catch the error at some point.
+Optional types do not catch the error.
+
+Deep types prevent a list of characters from entering typed code with the type @racket[(Listof String)]:
+
+@module-example[#:eval deep-eval #:label #f
+  typed/racket (code:comment "or #lang typed/racket/deep")
+
+  (require/typed racket/base
+    [string->list (-> String (Listof String))])
+  (string->list "racket")
+]
+
+Shallow types allow a list of characters to have the type @racket[(Listof String)], but detect an
+error if typed code reads an element from the list:
+
+@module-example[#:eval shallow-eval #:label #f
+  typed/racket/shallow
+
+  (require/typed racket/base
+    [string->list (-> String (Listof String))])
+
+  (define lst (string->list "racket"))
+  (first lst)
+]
+
+Optional types do not detect any error in this example:
+
+@module-example[#:eval optional-eval #:label #f
+  typed/racket/optional
+
+  (require/typed racket/base
+    [string->list (-> String (Listof String))])
+
+  (define lst (string->list "racket"))
+  (first lst)
+]
+
+
+@subsection{Checking Mutable Data: Importing a Vector}
+
+When typed code imports an untyped vector:
+@itemlist[
+  @item{Deep types wrap the vector in a contract that checks future reads and writes;}
+  @item{Shallow types check for a vector at the boundary, and check elements on demand (same as for lists); and}
+  @item{Optional types check nothing.}
+]
+
+The following example imports @racket[make-vector] with an incorrect type that expects
+a vector of strings as its output.
+When @racket[make-vector] returns a vector of numbers instead, both Deep and Shallow
+types catch the error when reading from the vector.
+Optional types do not catch the error.
+
+@module-example[#:eval deep-eval #:label "Deep catches a bad vector element:"
+  typed/racket (code:comment "or #lang typed/racket/deep")
+
+  (require/typed racket/base
+    [make-vector (-> Integer (Vectorof String))])
+
+  (define vec (make-vector 10))
+  (vector-ref vec 0)
+]
+
+@module-example[#:eval shallow-eval #:label "Shallow catches a bad vector element:"
+  typed/racket/shallow
+
+  (require/typed racket/base
+    [make-vector (-> Integer (Vectorof String))])
+
+  (define vec (make-vector 10))
+  (vector-ref vec 0)
+]
+
+@module-example[#:eval optional-eval #:label "Optional does not catch a bad element:"
+  typed/racket/optional
+
+  (require/typed racket/base
+    [make-vector (-> Integer (Vectorof String))])
+
+  (define vec (make-vector 10))
+  (vector-ref vec 0)
+]
+
+
+@subsection{Checking Functions that Cross Multiple Boundaries}
+
+Deep types can detect some errors that Shallow types miss,
+especially when a program contains several modules.
+This is because every module in a program can trust that every Deep type is a true claim,
+but only the one module that defines a Shallow type can depend on the type.
+In short, Deep types are @emph{permanent} whereas Shallow types are @emph{temporary}.
+
+The following example uses three modules to create a situation where Deep types catch
+an error that Shallow types miss.
+First, the untyped module @racketmodname[racket/base] provides the standard @racket[string-length] function.
+Second, a typed @racket[_interface] module imports @racket[string-length] with an incorrect type and reprovides with a new name: @racket[strlen].
+Third, a typed client module imports @racket[strlen] with a correct type and calls it on a string.
+
+Deep types raise an error when @racket[strlen] is called because of the incorrect type in the interface:
+
+@module-example[#:eval deep-eval #:label #f
+  typed/racket (code:comment "or #lang typed/racket/deep")
+
+  (module interface typed/racket
+    (require/typed racket/base
+      [string-length (-> String Void)])
+    (define strlen string-length)
+    (provide strlen))
+
+  (require/typed 'interface
+    [strlen (-> String Natural)])
+  (strlen "racket")
+]
+
+Shallow types do not raise an error because the interface type is not enforced for the outer client module:
+
+@module-example[#:eval shallow-eval #:label #f
+  typed/racket/shallow
+
+  (module interface typed/racket/shallow
+    (require/typed racket/base
+      [string-length (-> String Void)])
+    (define strlen string-length)
+    (provide strlen))
+
+  (require/typed 'interface
+    [strlen (-> String Natural)])
+  (strlen "racket")
+]
+
+Optional types do not raise an error either:
+
+@module-example[#:eval optional-eval #:label #f
+  typed/racket/optional
+
+  (module interface typed/racket/optional
+    (require/typed racket/base
+      [string-length (-> String Void)])
+    (define strlen string-length)
+    (provide strlen))
+
+  (require/typed 'interface
+    [strlen (-> String Natural)])
+  (strlen "racket")
+]
+
+
+@section{Forms that Depend on the Behavior of Types}
+
+The following Typed Racket forms use types to create run-time checks.
+Consequently, their behavior changes depending on whether types are Deep,
+Shallow, or Optional.
+
+Across these forms, the changes are roughly the same.
+Deep types get enforced as (higher-order) contracts,
+Shallow types get enforced as shape checks,
+and Optional types get enforced with nothing.
+The key point to understand is @emph{which} types get enforced at run-time.
+
+@itemlist[
+  @item{
+    @racket[require/typed] imports bindings from another module and attaches
+    types to the bindings. The attached types get enforced.
+  }
+
+  @item{
+    @racket[cast] assigns a type to an expression. The assigned type gets enforced.
+  }
+
+  @item{
+    @racket[with-type] creates a typed region in untyped code. Types at the boundary
+    between this region and untyped code get enforced.
+  }
+]
+
+The following forms modify the contracts that Deep Typed Racket generates.
+Uses of these forms may need to change to accommodate Shallow and Optional
+clients.
+
+@itemlist[
+  @item{
+    @racket[require/untyped-contract] brings an identifier from Deep-typed code
+    to untyped code using a subtype of its actual type.
+    If the required identifier travels from untyped code to a Shallow or Optional
+    client, this client must work with the subtype. A Deep client would be able
+    to use the normal type.
+  }
+  @item{
+    @racket[define-typed/untyped-identifier] accepts four identifiers to
+    fine-tune its behavior for Deep, untyped, Shallow, and Optional clients.
+  }
+]
+
+
+@subsection{Example: Casts in Deep, Shallow, and Optional}
+
+To give one example of a form that depends on the behavior of types,
+@racket[cast] checks full types in Deep mode, checks shapes in Shallow mode,
+and checks nothing in Optional mode.
+
+@examples[#:eval deep-eval #:label "Deep detects a bad cast:"
+  (code:comment "#lang typed/racket")
+  (code:comment "or #lang typed/racket/deep")
+  (eval:error (cast (list 42) (Listof String)))
+]
+
+@examples[#:eval shallow-eval #:label "Shallow allows one bad cast but detects a shape-level one:"
+  (code:comment "#lang typed/racket/shallow")
+  (cast (list 42) (Listof String))
+  (eval:error (cast (list 42) Number))
+]
+
+@examples[#:eval optional-eval #:label "Optional lets any cast succeed:"
+  (code:comment "#lang typed/racket/optional")
+  (cast (list 42) (Listof String))
+  (cast (list 42) Number)
+]
+
+
+@section[#:tag "how-to-choose"]{How to Choose Between Deep, Shallow, and Optional}
+
+Deep, Shallow, and Optional types have complementary strengths
+and weaknesses.
+Deep types give strong type guarantees and enable full type-directed optimizations,
+but may pay a high cost at boundaries.
+In particular, the costs for higher-order types are high.
+Examples include @racket[HashTable], @racket[->*], and @racket[Object].
+Shallow types give weak guarantees, but come at a lower cost.
+The cost is constant-time for many types, including @racket[HashTable] and @racket[->*],
+and linear-time for a few others such as @racket[U] and @racket[Object].
+Optional types give no guarantees, but come at no cost.
+
+Based on these tradeoffs, this section offers some advice about when to choose
+one style over the others.
+
+
+@subsection{When to Use Deep Types}
+
+Deep types are best in the following situations:
+
+@itemlist[
+  @item{
+    For large blocks of typed code, to take full advantage of type-directed
+    optimizations within each block.
+  }
+  @item{
+    For tightly-connected groups of typed modules, because Deep types pay no
+    cost to interact with one another.
+  }
+  @item{
+    For modules in which you want the types to be fully enforced,
+    perhaps for predicting the behavior of typed-untyped interactions
+    or for debugging.
+  }
+]
+
+
+@subsection{When to Use Shallow Types}
+
+Shallow types are best in the following situations:
+
+@itemlist[
+  @item{
+    For typed code that frequently interacts with untyped code, especially
+    when it sends large immutable values or higher-order values (vectors, functions, etc.)
+    across boundaries.
+  }
+
+  @item{
+    For large blocks of typed code that primarily uses basic values (numbers, strings, etc.)
+    or monomorphic data structures.
+    In such cases, Shallow types get the full benefit of type-directed
+    optimizations and few run-time costs.
+  }
+  @item{
+    For boundaries where Deep enforcement (via contracts) is too restrictive.
+    For example, Deep code can never call a function that has the type
+    @racket[Procedure], but Shallow can after a cast.
+  }
+  @item{
+    For boundaries where Deep cannot convert the types to contracts,
+    such as for a higher-order syntax object such as @racket[(Syntaxof (Boxof Real))].
+  }
+]
+
+
+@subsection{When to Use Optional Types}
+
+Optional types are best in the following situations:
+
+@itemlist[
+  @item{
+    For typed-to-untyped migrations where performance needs
+    to be predictable, because an Optionally-typed program behaves just like a
+    Racket program that ignores all the types.
+  }
+
+  @item{
+    For boundaries that neither Deep nor Shallow can express.
+    For example, only Optional can use occurrence types at a boundary.
+  }
+
+  @item{
+    For prototyping; that is, for testing whether an idea can type-check
+    without testing whether it interacts well with untyped code.
+  }
+]
+
+
+@subsection{General Tips}
+
+@itemlist[
+  @item{
+    Deep, Shallow, and Optional use the same compile-time type checks, so
+    switching a module from one style to another is usually a one-line change
+    (to the @hash-lang[] line).
+  }
+  @item{
+    When converting a Racket program to Typed Racket, try Deep types at first
+    and change to Shallow if run-time performance becomes a bottleneck
+    (or, if contract wrappers raise a correctness issue).
+  }
+
+]
+
+
+@section{Related Gradual Typing Work}
+
+Shallow Typed Racket implements the @emph{Transient} semantics for gradual
+languages @cite["Programming-2022" "PLDI-2022"],
+which was invented by Michael M. Vitousek @cite["RP:DLS-2014" "RP:POPL-2017" "RP:Vitousek-2019" "RP:DLS-2019"].
+Transient protects typed code by rewriting it to defensively check the shape of values
+whenever it calls a function, reads from a data structure, or otherwise receives input
+that may have come from an untyped source. Because of the rewriting, Transient is able
+to enforce type soundness without higher-order contracts.
+
+Deep Typed Racket implements the standard semantics for gradual languages,
+which is known variously as Guarded @cite{RP:POPL-2017},
+Natural @cite{TOPLAS-2009}, and
+Behavioral @cite{KafKa-2018}.
+This @emph{Guarded} semantics eagerly checks untyped values when possible and otherwise
+creates wrappers to defer checks.
+
+Typed Racket uses the names ``Shallow'' and ``Deep'' rather than ``Transient''
+and ``Guarded'' to emphasize the guarantees that such types provide instead
+than the method used to implement these guarantees.
+Shallow types provide a type soundness guarantee;
+Deep types provide type soundness and complete monitoring @cite{OOPSLA-2019}.
+
+Optional types are a widely-used approach to gradual typing,
+despite their unsound support for typed-untyped interactions.
+Optionally-typed languages include the following:
+@hyperlink["https://www.typescriptlang.org"]{TypeScript},
+@hyperlink["https://flow.org"]{Flow},
+@hyperlink["http://mypy-lang.org"]{mypy},
+and Typed Clojure @cite["ESOP-2016" "Bonnaire-Sergeant-2019"].
+
+@close-eval[deep-eval]
+@close-eval[shallow-eval]
+@close-eval[optional-eval]
+

--- a/typed-racket-doc/typed-racket/scribblings/reference/utilities.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/utilities.scrbl
@@ -156,10 +156,19 @@ Because of limitations in the macro expander, @racket[require/untyped-contract]
 cannot currently be used in typed code.
 }
 
-@defform[(define-typed/untyped-identifier name typed-name untyped-name)]{
-Defines an identifier @racket[name] that expands to @racket[typed-name] in typed
-contexts and to @racket[untyped-name] in untyped contexts. Each subform must be
-an identifier.
+@deftogether[(
+  @defform[(define-typed/untyped-identifier name typed-name untyped-name)]
+  @defform[#:link-target? #f (define-typed/untyped-identifier name deep-name untyped-name shallow-name optional-name)]
+)]{
+Defines an identifier @racket[name] that expands to one of the following identifiers
+depending on context. When two identifiers are provided, @racket[name] expands
+to @racket[typed-name] in typed contexts and to @racket[untyped-name] in untyped contexts
+(more precisely, everywhere else). When four identifiers are provided,
+@racket[name] expands to @racket[deep-name] in Deep-typed contexts,
+to @racket[untyped-name] in untyped contexts,
+to @racket[shallow-name] in Shallow-typed contexts,
+and to @racket[optional-name] in Optionally-typed contexts.
+@Secref{behavior-of-types} explains these different contexts.
 
 Suppose we define and provide a Typed Racket function with this type:
 @racketblock[(: my-filter (All (a) (-> (-> Any Any : a) (Listof Any) (Listof a))))]

--- a/typed-racket-doc/typed-racket/scribblings/ts-reference.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/ts-reference.scrbl
@@ -35,6 +35,7 @@ For technical details, refer to the @secref{tr-bibliography}.
 @include-section["reference/typed-units.scrbl"]
 @include-section["reference/utilities.scrbl"]
 @include-section["reference/exploring-types.scrbl"]
+@include-section["reference/behavior-of-types.scrbl"]
 @include-section["reference/no-check.scrbl"]
 @include-section["reference/typed-regions.scrbl"]
 @include-section["reference/optimization.scrbl"]
@@ -47,16 +48,18 @@ For technical details, refer to the @secref{tr-bibliography}.
    (list (linebreak) (linebreak) str* (linebreak) (linebreak)))
 
 @(define DLS "Dynamic Languages Symposium")
-@(define SFP "Workshop on Scheme and Functional Programming")
-@(define POPL "Symposium on Principles of Programming Languages")
+@(define ECOOP "European Conference on Object-Oriented Programming")
 @(define ESOP "European Symposium on Programming")
 @(define ICFP "International Conference on Functional Programming")
-@(define PHD-DISSERTATION "Ph.D. dissertation")
-@(define PLDI "Conference on Programming Language Design and Implementation")
 @(define OOPSLA "Conference on Object-Oriented Programming, Systems, Languages, and Applications")
 @(define PADL "International Symposium on Practical Aspects of Declarative Languages")
-@(define ECOOP "European Conference on Object-Oriented Programming")
+@(define PHD-DISSERTATION "Ph.D. dissertation")
+@(define PLDI "Conference on Programming Language Design and Implementation")
+@(define POPL "Symposium on Principles of Programming Languages")
+@(define Programming "The Art, Science, and Engineering of Programming")
+@(define SFP "Workshop on Scheme and Functional Programming")
 @(define SNAPL "Summit oN Advances in Programming Languages")
+@(define TOPLAS "ACM Transactions on Programming Languages and Systems")
 
 @(bibliography #:tag "tr-bibliography"
    (bib-entry #:key "DLS-2006"
@@ -99,6 +102,12 @@ For technical details, refer to the @secref{tr-bibliography}.
               #:note @bib-note{
                        Explains how to type-check a polymorphic function that
                        accepts any number of arguments (such as @racket[map]).})
+   (bib-entry #:key "TOPLAS-2009"
+              #:author "Jacob Matthews and Robert Bruce Findler"
+              #:title "Operational Semantics for Multi-Language Programs"
+              #:location TOPLAS
+              #:date "2009"
+              #:url "https://users.cs.northwestern.edu/~robby/pubs/papers/toplas09-mf.pdf")
    (bib-entry #:key "ICFP-2010"
               #:author "Sam Tobin-Hochstadt and Matthias Felleisen"
               #:title "Logical Types for Untyped Languages"
@@ -151,6 +160,12 @@ For technical details, refer to the @secref{tr-bibliography}.
               #:note @bib-note{
                        Shows how to type check the @racket[%] and @racket[fcontrol]
                        operators in the presence of continuation marks.})
+   (bib-entry #:key "RP:DLS-2014"
+              #:author "Michael M. Vitousek, Andrew Kent, Jeremy G. Siek, and Jim Baker"
+              #:title "Design and Evaluation of Gradual Typing for Python"
+              #:location DLS
+              #:date "2014"
+              #:url "https://dl.acm.org/doi/10.1145/2775052.2661101")
    (bib-entry #:key "ECOOP-2015"
               #:author "Asumu Takikawa, Daniel Feltey, Earl Dean, Robert Bruce Findler, Matthew Flatt, Sam Tobin-Hochstadt, and Matthias Felleisen"
               #:title "Toward Practical Gradual Typing"
@@ -161,6 +176,12 @@ For technical details, refer to the @secref{tr-bibliography}.
                        Presents an implementation, experience report, and
                        performance evaluation for gradually-typed first-class
                        classes.})
+   (bib-entry #:key "ESOP-2016"
+              #:author "Ambrose Bonnaire--Sergeant, Rowan Davies, and Sam Tobin-Hochstadt"
+              #:title "Practical Optional Types for Clojure"
+              #:location ESOP
+              #:date "2016"
+              #:url "https://link.springer.com/chapter/10.1007/978-3-662-49498-1_4")
    (bib-entry #:key "PLDI-2016"
               #:author "Andrew Kent and Sam Tobin-Hochstadt"
               #:title "Occurrence Typing Modulo Theories"
@@ -176,6 +197,12 @@ For technical details, refer to the @secref{tr-bibliography}.
               #:location PHD-DISSERTATION
               #:date "2016"
               #:url "https://www2.ccs.neu.edu/racket/pubs/dissertation-takikawa.pdf")
+   (bib-entry #:key "RP:POPL-2017"
+              #:author "Michael M. Vitousek, Cameron Swords, and Jeremy G. Siek"
+              #:title "Big Types in Little Runtime: Open-World Soundness and Collaborative Blame for Gradual Type Systems"
+              #:location POPL
+              #:date "2017"
+              #:url "https://dl.acm.org/doi/abs/10.1145/3009837.3009849")
    (bib-entry #:key "POPL-2017"
               #:author "Stephen Chang, Alex Knauth, and Emina Torlak"
               #:title "Symbolic Types for Lenient Symbolic Execution"
@@ -194,6 +221,66 @@ For technical details, refer to the @secref{tr-bibliography}.
               #:url "https://www2.ccs.neu.edu/racket/pubs/typed-racket.pdf"
               #:note @bib-note{
                        Reflects on origins and successes; looks ahead to
-                       current and future challenges.}))
+                       current and future challenges.})
+   (bib-entry #:key "KafKa-2018"
+              #:author "Benjamin W. Chung, Paley Li, Francesco Zappa Nardelli, and Jan Vitek"
+              #:title "KafKa: Gradual Typing for Objects"
+              #:location ECOOP
+              #:date "2018"
+              #:url "https://drops.dagstuhl.de/opus/volltexte/2018/9217/")
+   (bib-entry #:key "Kent-2019"
+              #:author "Andrew M. Kent"
+              #:title "Advanced Logical Type Systems for Untyped Languages"
+              #:location PHD-DISSERTATION
+              #:date "2019"
+              #:url "https://pnwamk.github.io/docs/dissertation.pdf")
+   (bib-entry #:key "RP:Vitousek-2019"
+              #:author "Michael M. Vitousek"
+              #:title "Gradual Typing for Python, Unguarded"
+              #:location PHD-DISSERTATION
+              #:date "2019"
+              #:url "https://hdl.handle.net/2022/23172")
+   (bib-entry #:key "OOPSLA-2019"
+              #:author "Ben Greenman, Matthias Felleisen, and Christos Dimoulas"
+              #:title "Complete Monitors for Gradual Types"
+              #:location OOPSLA
+              #:date "2019"
+              #:url "https://www2.ccs.neu.edu/racket/pubs/oopsla19-gfd.pdf")
+   (bib-entry #:key "RP:DLS-2019"
+              #:author "Michael M. Vitousek, Jeremy G. Siek, and Avik Chaudhuri"
+              #:title "Optimizing and Evaluating Transient Gradual Typing"
+              #:location DLS
+              #:date "2019"
+              #:url "https://dl.acm.org/doi/10.1145/3359619.3359742")
+   (bib-entry #:key "Bonnaire-Sergeant-2019"
+              #:author "Ambrose Bonnaire--Sergeant"
+              #:title "Typed Clojure in Theory and Practice"
+              #:location PHD-DISSERTATION
+              #:date "2019"
+              #:url "https://scholarworks.iu.edu/dspace/handle/2022/23207")
+   (bib-entry #:key "Greenman-2020"
+              #:author "Ben Greenman"
+              #:title "Deep and Shallow Types"
+              #:location PHD-DISSERTATION
+              #:date "2020"
+              #:url "http://hdl.handle.net/2047/D20398329")
+   (bib-entry #:key "Programming-2022"
+              #:author "Ben Greenman, Lukas Lazarek, Christos Dimoulas, and Matthias Felleisen"
+              #:title "A Transient Semantics for Typed Racket"
+              #:location (string-append Programming " 6.2")
+              #:date "2022"
+              #:url "https://www2.ccs.neu.edu/racket/pubs/programming-gldf.pdf"
+              #:note @bib-note{
+                       Reports on the difficulties of adapting the Transient semantics of Reticulated Python
+                       to the rich migratory type system and established complier infrastructure of Typed Racket.})
+   (bib-entry #:key "PLDI-2022"
+              #:author "Ben Greenman"
+              #:title "Deep and Shallow Types for Gradual Languages"
+              #:location PLDI
+              #:date "2022"
+              #:url "http://cs.brown.edu/~bgreenma/publications/apples-to-apples/g-pldi-2022.pdf"
+              #:note @bib-note{
+                       Presents a language design that combines Deep and Shallow types, and reports on its
+                       implementation in Typed Racket.}))
 
 @index-section[]

--- a/typed-racket-doc/typed-racket/scribblings/utils.rkt
+++ b/typed-racket-doc/typed-racket/scribblings/utils.rkt
@@ -13,6 +13,12 @@
 (define (rtech . x)
   (apply tech x #:doc '(lib "scribblings/reference/reference.scrbl")))
 
+(define (tr-gtech . x)
+  (apply tech x #:doc '(lib "typed-racket/scribblings/ts-guide.scrbl")))
+
+(define (tr-rtech . x)
+  (apply tech x #:doc '(lib "typed-racket/scribblings/ts-reference.scrbl")))
+
 (define (tr-guide-secref tag)
   (secref tag #:doc '(lib "typed-racket/scribblings/ts-guide.scrbl")))
 

--- a/typed-racket-lib/typed-racket/base-env/base-contracted.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-contracted.rkt
@@ -42,4 +42,4 @@
       ;;       support this (it needs a #:rest argument)
       ;;
       ;;       Also, this type works better with inference.
-      (-> (-Prompt-Tagof Univ (-> Univ ManyUniv)))))))
+      (-> (-Prompt-Tagof Univ (-> Univ ManyUniv :T+ #true)) :T+ #true)))))

--- a/typed-racket-lib/typed-racket/base-env/base-env-indexing-abs.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-indexing-abs.rkt
@@ -243,7 +243,7 @@
 
    ;; flvector ops
 
-   [flvector? (make-pred-ty -FlVector #t)]
+   [flvector? (unsafe-shallow:make-pred-ty -FlVector)]
    [flvector (->* (list) -Flonum -FlVector)]
    [make-flvector (cl->* (-> index-type -FlVector)
                          (-> index-type -Flonum -FlVector))]
@@ -264,7 +264,7 @@
    [unsafe-flvector-set! (-> -FlVector index-type -Flonum -Void)]
 
    ;; Section 4.2.5.2 (ExtFlonum Vectors)
-   [extflvector? (make-pred-ty -ExtFlVector #t)]
+   [extflvector? (unsafe-shallow:make-pred-ty -ExtFlVector)]
    [extflvector (->* (list) -ExtFlonum -ExtFlVector)]
    [make-extflvector (cl->* (-> index-type -ExtFlVector)
                             (-> index-type -ExtFlonum -ExtFlVector))]
@@ -285,7 +285,7 @@
    [unsafe-extflvector-set! (-> -ExtFlVector index-type -ExtFlonum -Void)]
 
    ;; Section 4.2.4.2 (Fixnum vectors)
-   [fxvector? (make-pred-ty -FxVector #t)]
+   [fxvector? (unsafe-shallow:make-pred-ty -FxVector)]
    [fxvector (->* (list) -Fixnum -FxVector)]
    [make-fxvector (cl->* (-> index-type -FxVector)
                          (-> index-type -Fixnum -FxVector))]

--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -782,27 +782,27 @@
   (-> N B : (-PS (-is-type 0 (Un -RealZeroNoNan -InexactComplex -InexactImaginary))
                  (-not-type 0 -RealZeroNoNan)))]
 
-[number? (make-pred-ty N #t)]
-[integer? (asym-pred Univ B (-PS (-is-type 0 (Un -Int -Flonum -SingleFlonum)) ; inexact-integers exist...
-                                 (-not-type 0 -Int)) #t)]
-[exact-integer? (make-pred-ty -Int #t)]
-[real? (make-pred-ty -Real #t)]
-[flonum? (make-pred-ty -Flonum #t)]
-[single-flonum? (make-pred-ty -SingleFlonum #t)]
-[double-flonum? (make-pred-ty -Flonum #t)]
-[inexact-real? (make-pred-ty -InexactReal #t)]
-[complex? (make-pred-ty N #t)]
+[number? (unsafe-shallow:make-pred-ty N)]
+[integer? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (Un -Int -Flonum -SingleFlonum)) ; inexact-integers exist...
+                                 (-not-type 0 -Int)))]
+[exact-integer? (unsafe-shallow:make-pred-ty -Int)]
+[real? (unsafe-shallow:make-pred-ty -Real)]
+[flonum? (unsafe-shallow:make-pred-ty -Flonum)]
+[single-flonum? (unsafe-shallow:make-pred-ty -SingleFlonum)]
+[double-flonum? (unsafe-shallow:make-pred-ty -Flonum)]
+[inexact-real? (unsafe-shallow:make-pred-ty -InexactReal)]
+[complex? (unsafe-shallow:make-pred-ty N)]
 ;; `rational?' includes all Reals, except infinities and NaN.
-[rational? (asym-pred Univ B (-PS (-is-type 0 -Real) (-not-type 0 -Rat)) #t)]
-[exact? (make-pred-ty -ExactNumber #t)]
-[inexact? (make-pred-ty (Un -InexactReal -InexactImaginary -InexactComplex) #t)]
-[fixnum? (make-pred-ty -Fixnum #t)]
-[fixnum-for-every-system? (asym-pred Univ B (-PS (-is-type 0 -Fixnum) -tt) #t)]
-[index? (make-pred-ty -Index #t)]
+[rational? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 -Real) (-not-type 0 -Rat)))]
+[exact? (unsafe-shallow:make-pred-ty -ExactNumber)]
+[inexact? (unsafe-shallow:make-pred-ty (Un -InexactReal -InexactImaginary -InexactComplex))]
+[fixnum? (unsafe-shallow:make-pred-ty -Fixnum)]
+[fixnum-for-every-system? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 -Fixnum) -tt))]
+[index? (unsafe-shallow:make-pred-ty -Index)]
 [positive? (-> -Real B : (-PS (-is-type 0 -PosRealNoNan) (-is-type 0 -NonPosReal)))]
 [negative? (-> -Real B : (-PS (-is-type 0 -NegRealNoNan) (-is-type 0 -NonNegReal)))]
-[exact-positive-integer? (make-pred-ty -Pos #t)]
-[exact-nonnegative-integer? (make-pred-ty -Nat #t)]
+[exact-positive-integer? (unsafe-shallow:make-pred-ty -Pos)]
+[exact-nonnegative-integer? (unsafe-shallow:make-pred-ty -Nat)]
 
 [odd? (-> -Int B : (-PS (-not-type 0 -Zero) (-not-type 0 -One)))]
 [even? (-> -Int B : (-PS (-not-type 0 -One) (-not-type 0 -Zero)))]
@@ -1901,18 +1901,18 @@
   (-> (Un -NonPosRat -NonPosFlonum -NonPosSingleFlonum -NonPosInexactReal -NonPosReal) -NonPosInt)
   (-> (Un -Rat -Flonum -SingleFlonum -InexactReal -Real) -Int))]
 
-[nan? (make-pred-ty (list -Real) B -InexactRealNan #t)]
+[nan? (unsafe-shallow:make-pred-ty (list -Real) B -InexactRealNan)]
 
-[infinite? (make-pred-ty (list -Real) B (Un -PosInfinity -NegInfinity) #t)]
-[positive-integer? (asym-pred Univ B (-PS (-is-type 0 (Un -PosInt -PosFlonum -PosSingleFlonum))
-                                          (-not-type 0 -PosInt)) #t)]
-[negative-integer? (asym-pred Univ B (-PS (-is-type 0 (Un -NegInt -NegFlonum -NegSingleFlonum))
-                                          (-not-type 0 -NegInt)) #t)]
-[nonpositive-integer? (asym-pred Univ B (-PS (-is-type 0 (Un -NonPosInt -NonPosFlonum -NonPosSingleFlonum))
-                                             (-not-type 0 -NonPosInt)) #t)]
-[nonnegative-integer? (asym-pred Univ B (-PS (-is-type 0 (Un -Nat -NonNegFlonum -NonNegSingleFlonum))
-                                             (-not-type 0 -Nat)) #t)]
-[natural? (make-pred-ty -Nat #t)]
+[infinite? (unsafe-shallow:make-pred-ty (list -Real) B (Un -PosInfinity -NegInfinity))]
+[positive-integer? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (Un -PosInt -PosFlonum -PosSingleFlonum))
+                                          (-not-type 0 -PosInt)))]
+[negative-integer? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (Un -NegInt -NegFlonum -NegSingleFlonum))
+                                          (-not-type 0 -NegInt)))]
+[nonpositive-integer? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (Un -NonPosInt -NonPosFlonum -NonPosSingleFlonum))
+                                             (-not-type 0 -NonPosInt)))]
+[nonnegative-integer? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (Un -Nat -NonNegFlonum -NonNegSingleFlonum))
+                                             (-not-type 0 -Nat)))]
+[natural? (unsafe-shallow:make-pred-ty -Nat)]
 
 ;; racket/fixnum
 [fx+ (fx+-type)]
@@ -2038,7 +2038,7 @@
 [unsafe-flrandom (flrandom-type)]
 
 ; racket/extflonum
-[extflonum? (make-pred-ty -ExtFlonum #t)]
+[extflonum? (unsafe-shallow:make-pred-ty -ExtFlonum)]
 [extflonum-available? (-> B)]
 [pi.t -PosExtFlonum]
 

--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -1,4 +1,5 @@
 #lang s-exp "env-lang.rkt"
+#:default-T+ #true
 
 (begin
   (require
@@ -781,27 +782,27 @@
   (-> N B : (-PS (-is-type 0 (Un -RealZeroNoNan -InexactComplex -InexactImaginary))
                  (-not-type 0 -RealZeroNoNan)))]
 
-[number? (make-pred-ty N)]
+[number? (make-pred-ty N #t)]
 [integer? (asym-pred Univ B (-PS (-is-type 0 (Un -Int -Flonum -SingleFlonum)) ; inexact-integers exist...
-                                 (-not-type 0 -Int)))]
-[exact-integer? (make-pred-ty -Int)]
-[real? (make-pred-ty -Real)]
-[flonum? (make-pred-ty -Flonum)]
-[single-flonum? (make-pred-ty -SingleFlonum)]
-[double-flonum? (make-pred-ty -Flonum)]
-[inexact-real? (make-pred-ty -InexactReal)]
-[complex? (make-pred-ty N)]
+                                 (-not-type 0 -Int)) #t)]
+[exact-integer? (make-pred-ty -Int #t)]
+[real? (make-pred-ty -Real #t)]
+[flonum? (make-pred-ty -Flonum #t)]
+[single-flonum? (make-pred-ty -SingleFlonum #t)]
+[double-flonum? (make-pred-ty -Flonum #t)]
+[inexact-real? (make-pred-ty -InexactReal #t)]
+[complex? (make-pred-ty N #t)]
 ;; `rational?' includes all Reals, except infinities and NaN.
-[rational? (asym-pred Univ B (-PS (-is-type 0 -Real) (-not-type 0 -Rat)))]
-[exact? (make-pred-ty -ExactNumber)]
-[inexact? (make-pred-ty (Un -InexactReal -InexactImaginary -InexactComplex))]
-[fixnum? (make-pred-ty -Fixnum)]
-[fixnum-for-every-system? (asym-pred Univ B (-PS (-is-type 0 -Fixnum) -tt))]
-[index? (make-pred-ty -Index)]
+[rational? (asym-pred Univ B (-PS (-is-type 0 -Real) (-not-type 0 -Rat)) #t)]
+[exact? (make-pred-ty -ExactNumber #t)]
+[inexact? (make-pred-ty (Un -InexactReal -InexactImaginary -InexactComplex) #t)]
+[fixnum? (make-pred-ty -Fixnum #t)]
+[fixnum-for-every-system? (asym-pred Univ B (-PS (-is-type 0 -Fixnum) -tt) #t)]
+[index? (make-pred-ty -Index #t)]
 [positive? (-> -Real B : (-PS (-is-type 0 -PosRealNoNan) (-is-type 0 -NonPosReal)))]
 [negative? (-> -Real B : (-PS (-is-type 0 -NegRealNoNan) (-is-type 0 -NonNegReal)))]
-[exact-positive-integer? (make-pred-ty -Pos)]
-[exact-nonnegative-integer? (make-pred-ty -Nat)]
+[exact-positive-integer? (make-pred-ty -Pos #t)]
+[exact-nonnegative-integer? (make-pred-ty -Nat #t)]
 
 [odd? (-> -Int B : (-PS (-not-type 0 -Zero) (-not-type 0 -One)))]
 [even? (-> -Int B : (-PS (-not-type 0 -One) (-not-type 0 -Zero)))]
@@ -1900,18 +1901,18 @@
   (-> (Un -NonPosRat -NonPosFlonum -NonPosSingleFlonum -NonPosInexactReal -NonPosReal) -NonPosInt)
   (-> (Un -Rat -Flonum -SingleFlonum -InexactReal -Real) -Int))]
 
-[nan? (make-pred-ty (list -Real) B -InexactRealNan)]
+[nan? (make-pred-ty (list -Real) B -InexactRealNan #t)]
 
-[infinite? (make-pred-ty (list -Real) B (Un -PosInfinity -NegInfinity))]
+[infinite? (make-pred-ty (list -Real) B (Un -PosInfinity -NegInfinity) #t)]
 [positive-integer? (asym-pred Univ B (-PS (-is-type 0 (Un -PosInt -PosFlonum -PosSingleFlonum))
-                                          (-not-type 0 -PosInt)))]
+                                          (-not-type 0 -PosInt)) #t)]
 [negative-integer? (asym-pred Univ B (-PS (-is-type 0 (Un -NegInt -NegFlonum -NegSingleFlonum))
-                                          (-not-type 0 -NegInt)))]
+                                          (-not-type 0 -NegInt)) #t)]
 [nonpositive-integer? (asym-pred Univ B (-PS (-is-type 0 (Un -NonPosInt -NonPosFlonum -NonPosSingleFlonum))
-                                             (-not-type 0 -NonPosInt)))]
+                                             (-not-type 0 -NonPosInt)) #t)]
 [nonnegative-integer? (asym-pred Univ B (-PS (-is-type 0 (Un -Nat -NonNegFlonum -NonNegSingleFlonum))
-                                             (-not-type 0 -Nat)))]
-[natural? (make-pred-ty -Nat)]
+                                             (-not-type 0 -Nat)) #t)]
+[natural? (make-pred-ty -Nat #t)]
 
 ;; racket/fixnum
 [fx+ (fx+-type)]
@@ -2037,7 +2038,7 @@
 [unsafe-flrandom (flrandom-type)]
 
 ; racket/extflonum
-[extflonum? (make-pred-ty -ExtFlonum)]
+[extflonum? (make-pred-ty -ExtFlonum #t)]
 [extflonum-available? (-> B)]
 [pi.t -PosExtFlonum]
 

--- a/typed-racket-lib/typed-racket/base-env/base-env-uncontracted.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-uncontracted.rkt
@@ -1,0 +1,8 @@
+#lang s-exp typed-racket/base-env/extra-env-lang
+
+;; This file provides types for the bindings from base-contracted.rkt
+;; for non-Deep versions of TR that don't need to wrap the bindings
+
+(type-environment
+ [default-continuation-prompt-tag
+   (-> (make-Prompt-Tagof Univ (-> Univ ManyUniv :T+ #t)) :T+ #t)])

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -71,18 +71,18 @@
                                    #f)]
 
 ;; Section 4.2 (Booleans)
-[boolean? (make-pred-ty B #t)]
-[not (make-pred-ty (-val #f) #t)]
+[boolean? (unsafe-shallow:make-pred-ty B)]
+[not (unsafe-shallow:make-pred-ty (-val #f))]
 
-[immutable? (asym-pred Univ B (-PS (-is-type 0 (Un -Bytes -BoxTop -String (-Immutable-HT Univ Univ) (-ivec Univ)))
-                                   (-not-type 0 (Un (-Immutable-HT Univ Univ) (-ivec Univ)))) #t)]
+[immutable? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (Un -Bytes -BoxTop -String (-Immutable-HT Univ Univ) (-ivec Univ)))
+                                   (-not-type 0 (Un (-Immutable-HT Univ Univ) (-ivec Univ)))))]
 
 ;; Section 4.1.1 (racket/bool)
 [true (-val #t)]
 [false (-val #f)]
 [boolean=? (B B . -> . B)]
 [symbol=? (Sym Sym . -> . B)]
-[false? (make-pred-ty (-val #f) #t)]
+[false? (unsafe-shallow:make-pred-ty (-val #f))]
 [xor (-> Univ Univ Univ)]
 
 ;; Section 4.3 (Numbers)
@@ -98,7 +98,7 @@
 
 [random-seed (-> -PosInt -Void)]
 [make-pseudo-random-generator (-> -Pseudo-Random-Generator)]
-[pseudo-random-generator? (make-pred-ty -Pseudo-Random-Generator #t)]
+[pseudo-random-generator? (unsafe-shallow:make-pred-ty -Pseudo-Random-Generator)]
 [current-pseudo-random-generator (-Param -Pseudo-Random-Generator -Pseudo-Random-Generator)]
 [pseudo-random-generator->vector
  (-> -Pseudo-Random-Generator (-vec* -PosInt -PosInt -PosInt -PosInt -PosInt -PosInt))]
@@ -122,7 +122,7 @@
 [extfl->floating-point-bytes (->opt -ExtFlonum [Univ -Bytes -Nat] -Bytes)]
 
 ;; Section 4.4 (Strings)
-[string? (make-pred-ty -String #t)]
+[string? (unsafe-shallow:make-pred-ty -String)]
 ;make-string (in Index)
 [string (->* '() -Char -String)]
 [string->immutable-string (-> -String -String)]
@@ -204,7 +204,7 @@
            #:repeat? Univ #f
            -String)]
 
-[non-empty-string? (asym-pred Univ -Boolean (-PS (-is-type 0 -String) -tt) #t)]
+[non-empty-string? (unsafe-shallow:asym-pred Univ -Boolean (-PS (-is-type 0 -String) -tt))]
 [string-contains? (-> -String -String -Boolean)]
 [string-prefix? (-> -String -String -Boolean)]
 [string-suffix? (-> -String -String -Boolean)]
@@ -319,11 +319,11 @@
 
 ;; Section 4.5 (Byte Strings)
 [bytes (->* (list) -Integer -Bytes)]
-[bytes? (make-pred-ty -Bytes #t)]
+[bytes? (unsafe-shallow:make-pred-ty -Bytes)]
 [make-bytes (cl-> [(-Integer -Integer) -Bytes]
                   [(-Integer) -Bytes])]
 [bytes->immutable-bytes (-> -Bytes -Bytes)]
-[byte? (make-pred-ty -Byte #t)]
+[byte? (unsafe-shallow:make-pred-ty -Byte)]
 [bytes-append (->* (list) -Bytes -Bytes)]
 [bytes-length (-> -Bytes -Index)]
 [unsafe-bytes-length (-> -Bytes -Index)]
@@ -381,7 +381,7 @@
               -Nat
               (one-of/c 'complete 'continues)))))]
 
-[bytes-converter? (make-pred-ty -Bytes-Converter #t)]
+[bytes-converter? (unsafe-shallow:make-pred-ty -Bytes-Converter)]
 
 [locale-string-encoding (-> -String)]
 
@@ -389,7 +389,7 @@
 [bytes-join ((-lst -Bytes) -Bytes . -> . -Bytes)]
 
 ;; Section 4.6 (Characters)
-[char? (make-pred-ty -Char #t)]
+[char? (unsafe-shallow:make-pred-ty -Char)]
 [char=? (->* (list -Char -Char) -Char B)]
 [char<=? (->* (list -Char -Char) -Char B)]
 [char>=? (->* (list -Char -Char) -Char B)]
@@ -427,7 +427,7 @@
 [char-utf-8-length (-> -Char (apply Un (map -val '(1 2 3 4 5 6))))]
 
 ;; Section 4.7 (Symbols)
-[symbol? (make-pred-ty Sym #t)]
+[symbol? (unsafe-shallow:make-pred-ty Sym)]
 [symbol-interned? (-> Sym B)]
 [symbol-unreadable? (-> Sym B)]
 [symbol->string (Sym . -> . -String)]
@@ -440,10 +440,10 @@
 [symbol->immutable-string (Sym . -> . -String)]
 
 ;; Section 4.8 (Regular Expressions)
-[regexp? (make-pred-ty -Regexp #t)]
-[pregexp? (make-pred-ty -PRegexp #t)]
-[byte-regexp? (make-pred-ty -Byte-Regexp #t)]
-[byte-pregexp? (make-pred-ty -Byte-PRegexp #t)]
+[regexp? (unsafe-shallow:make-pred-ty -Regexp)]
+[pregexp? (unsafe-shallow:make-pred-ty -PRegexp)]
+[byte-regexp? (unsafe-shallow:make-pred-ty -Byte-Regexp)]
+[byte-pregexp? (unsafe-shallow:make-pred-ty -Byte-PRegexp)]
 [regexp (-String . -> . -Base-Regexp)]
 [pregexp (-String . -> . -PRegexp)]
 [byte-regexp (-Bytes . -> . -Byte-Base-Regexp)]
@@ -498,7 +498,7 @@
   [-> -Bytes -Bytes])]
 
 ;; Section 4.9 (Keywords)
-[keyword? (make-pred-ty -Keyword #t)]
+[keyword? (unsafe-shallow:make-pred-ty -Keyword)]
 [string->keyword (-String . -> . -Keyword)]
 [keyword->string (-Keyword . -> . -String)]
 [keyword<? (->* (list -Keyword -Keyword) -Keyword B)]
@@ -654,18 +654,18 @@
                      [(a (-lst a)) (-lst a)]))]
 #;[*list? (make-pred-ty (-lst Univ))]
 
-[null? (make-pred-ty -Null #t)]
+[null? (unsafe-shallow:make-pred-ty -Null)]
 [null -Null]
-[cons? (make-pred-ty (-pair Univ Univ) #t)]
-[pair? (make-pred-ty (-pair Univ Univ) #t)]
-[empty? (make-pred-ty -Null #t)]
+[cons? (unsafe-shallow:make-pred-ty (-pair Univ Univ))]
+[pair? (unsafe-shallow:make-pred-ty (-pair Univ Univ))]
+[empty? (unsafe-shallow:make-pred-ty -Null)]
 [empty -Null]
 
 [ormap (-polydots (a c b) (->... (list (->... (list a) (b b) c) (-lst a)) ((-lst b) b) (Un c (-val #f))))]
 [andmap (-polydots (a c d b) (cl->*
-                              (make-pred-ty (list (make-pred-ty (list a) c d #f) (-lst a)) c (-lst d)
+                              (unsafe-shallow:make-pred-ty (list (make-pred-ty (list a) c d) (-lst a)) c (-lst d)
                                             ;; predicate on second argument
-                                            (-arg-path 1) #t)
+                                            (-arg-path 1))
                               (->... (list (->... (list a) (b b) c) (-lst a)) ((-lst b) b) (Un c (-val #t)))))]
 
 [reverse (-poly (a) (-> (-lst a) (-lst a)))]
@@ -711,7 +711,7 @@
                        . -> .
                        (-lst -Index)))]
 
-[list? (make-pred-ty (-lst Univ) #t)]
+[list? (unsafe-shallow:make-pred-ty (-lst Univ))]
 [list (-poly (a) (->* '() a (-lst a)))]
 [map (-polydots (c a b)
                 (cl->*
@@ -736,7 +736,7 @@
                      [((a b c . -> . c :T+ #f) c (-lst a) (-lst b)) c :T+ #f]
                      [((a b c d . -> . d :T+ #f) d (-lst a) (-lst b) (-lst c)) d :T+ #f]))]
 [filter (-poly (a b) (cl->*
-                      ((asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
+                      ((unsafe-shallow:asym-pred a Univ (-PS (-is-type 0 b) -tt))
                        (-lst a)
                        . -> .
                        (-lst b))
@@ -776,7 +776,7 @@
                    -Index))]
 [partition
  (-poly (a b) (cl->*
-               (-> (asym-pred b Univ (-PS (-is-type 0 a) -tt) #t) (-lst b) (-values (list (-lst a) (-lst b))))
+               (-> (unsafe-shallow:asym-pred b Univ (-PS (-is-type 0 a) -tt)) (-lst b) (-values (list (-lst a) (-lst b))))
                (-> (-> a Univ) (-lst a) (-values (list (-lst a) (-lst a))))))]
 
 [last   (-poly (a) ((-lst a) . -> . a :T+ #f))]
@@ -794,7 +794,7 @@
  (-poly (a b)
    (cl->*
     (-> (-lst a)
-        (asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
+        (unsafe-shallow:asym-pred a Univ (-PS (-is-type 0 b) -tt))
         (-lst b))
     (-> (-lst a) (-> a Univ) (-lst a))))]
 [dropf (-poly (a) (-> (-lst a) (-> a Univ) (-lst a)))]
@@ -802,14 +802,14 @@
  (-poly (a b)
    (cl->*
     (-> (-lst a)
-        (asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
+        (unsafe-shallow:asym-pred a Univ (-PS (-is-type 0 b) -tt))
         (-values (list (-lst b) (-lst a))))
     (-> (-lst a) (-> a Univ) (-values (list (-lst a) (-lst a))))))]
 [takef-right
  (-poly (a b)
    (cl->*
     (-> (-lst a)
-        (asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
+        (unsafe-shallow:asym-pred a Univ (-PS (-is-type 0 b) -tt))
         (-lst b))
     (-> (-lst a) (-> a Univ) (-lst a))))]
 [dropf-right (-poly (a) (-> (-lst a) (-> a Univ) (-lst a)))]
@@ -817,7 +817,7 @@
  (-poly (a b)
    (cl->*
     (-> (-lst a)
-        (asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
+        (unsafe-shallow:asym-pred a Univ (-PS (-is-type 0 b) -tt))
         (-values (list (-lst a) (-lst b))))
     (-> (-lst a) (-> a Univ) (-values (list (-lst a) (-lst a))))))]
 
@@ -885,7 +885,7 @@
 [unsafe-set-mcdr! (-poly (a b)
                          (cl->* (-> (-mpair a b) b -Void)
                                 (-> (-mlst a) (-mlst a) -Void)))]
-[mpair? (make-pred-ty -MPairTop #t)]
+[mpair? (unsafe-shallow:make-pred-ty -MPairTop)]
 ;; mlist is a macro that under the hood uses -mlist, which is annotated in
 ;; base-special-env.rkt
 
@@ -894,7 +894,7 @@
 [mappend (-poly (a) (->* (list) (-mlst a) (-mlst a)))]
 
 ;; Section 4.12 (Vectors)
-[vector? (make-pred-ty -VectorTop #t)]
+[vector? (unsafe-shallow:make-pred-ty -VectorTop)]
 [vector->list (-poly (a) (cl->* (-> (-vec a) (-lst a))
                                 (-> -VectorTop (-lst Univ))))]
 [list->vector (-poly (a) (-> (-lst a) (-mvec a)))]
@@ -923,7 +923,7 @@
                           . ->... .
                           -Index))]
 [vector-filter (-poly (a b) (cl->*
-                              ((asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
+                              ((unsafe-shallow:asym-pred a Univ (-PS (-is-type 0 b) -tt))
                                (-vec a)
                                . -> .
                                (-mvec b))
@@ -967,14 +967,14 @@
                            (-BoxTop . -> . Univ)))]
 [unsafe-set-box*! (-poly (a) ((-box a) a . -> . -Void))]
 [unsafe-box*-cas! (-poly (a) ((-box a) a a . -> . -Boolean))]
-[box? (make-pred-ty -BoxTop #t)]
+[box? (unsafe-shallow:make-pred-ty -BoxTop)]
 
 ;; Section 4.14 (Hash Tables)
-[hash? (make-pred-ty -HashTableTop #t)]
+[hash? (unsafe-shallow:make-pred-ty -HashTableTop)]
 [hash-eq? (-> -HashTableTop B)]
 [hash-eqv? (-> -HashTableTop B)]
 [hash-equal? (-> -HashTableTop B)]
-[hash-weak? (asym-pred -HashTableTop B (-PS (-is-type 0 -Weak-HashTableTop) (-not-type 0 -Weak-HashTableTop)) #t)]
+[hash-weak? (unsafe-shallow:asym-pred -HashTableTop B (-PS (-is-type 0 -Weak-HashTableTop) (-not-type 0 -Weak-HashTableTop)))]
 [hash (-poly (a b) (->* (list) (make-Rest (list a b)) (-Immutable-HT a b)))]
 [hasheqv (-poly (a b) (->* (list) (make-Rest (list a b)) (-Immutable-HT a b)))]
 [hasheq (-poly (a b) (->* (list) (make-Rest (list a b)) (-Immutable-HT a b)))]
@@ -1131,7 +1131,7 @@
 [hash-union! (-poly (a b) (->* (list (-Mutable-HT a b))  (-HT a b) -Void))]
 
 ;; Section 4.15 (Sequences and Streams)
-[sequence? (make-pred-ty -SequenceTop #t)]
+[sequence? (unsafe-shallow:make-pred-ty -SequenceTop)]
 [in-sequences
  (-polydots (a) (->* '() (-seq-dots '() a 'a) (-seq-dots '() a 'a)))]
 [in-cycle
@@ -1178,7 +1178,7 @@
 [sequence-count (-polydots (a) ((->... '() (a a) Univ) (-seq-dots '() a 'a) . -> . -Nat))]
 [sequence-filter (-polydots (a b c)
                    (cl->*
-                    ((asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
+                    ((unsafe-shallow:asym-pred a Univ (-PS (-is-type 0 b) -tt))
                      (-seq a)
                      . -> .
                      (-seq b))
@@ -1209,8 +1209,8 @@
 [proper-subset? (-poly (e) (set-abs -set (-> (-set e) (-set e) B)))]
 [set-map (-poly (e b) (-> (-list-or-set e) (-> e b) (-lst b)))]
 [set-for-each (-poly (e b) (-> (-list-or-set e) (-> e b) -Void))]
-[generic-set? (asym-pred Univ B (-PS -tt (-not-type 0 (-list-or-set Univ))) #t)]
-[set? (make-pred-ty (-set Univ) #t)]
+[generic-set? (unsafe-shallow:asym-pred Univ B (-PS -tt (-not-type 0 (-list-or-set Univ))))]
+[set? (unsafe-shallow:make-pred-ty (-set Univ))]
 [set-equal? (-poly (e) (-> (-set e) B))]
 [set-eqv? (-poly (e) (-> (-set e) B))]
 [set-eq? (-poly (e) (-> (-set e) B))]
@@ -1221,7 +1221,7 @@
 [set->list (-poly (e) (-> (-set e) (-lst e)))]
 
 ;; Section 4.18 (Procedures)
-[procedure? (make-pred-ty top-func #t)]
+[procedure? (unsafe-shallow:make-pred-ty top-func)]
 [compose (-poly (a b c) (-> (-> b c :T+ #f) (-> a b :T+ #f) (-> a c :T+ #f)))]
 [compose1 (-poly (a b c) (-> (-> b c :T+ #f) (-> a b :T+ #f) (-> a c :T+ #f)))]
 [procedure-rename (-poly (a) (-> (-Inter top-func a) -Symbol a))]
@@ -1229,7 +1229,7 @@
 [procedure-closure-contents-eq? (-> top-func top-func -Boolean)]
 ;; keyword-apply - hard to give a type
 [procedure-arity (-> top-func (Un -Nat -Arity-At-Least (-lst (Un -Nat -Arity-At-Least))))]
-[procedure-arity? (make-pred-ty (Un -Nat -Arity-At-Least (-lst (Un -Nat -Arity-At-Least))) #t)]
+[procedure-arity? (unsafe-shallow:make-pred-ty (Un -Nat -Arity-At-Least (-lst (Un -Nat -Arity-At-Least))))]
 [procedure-arity-includes? (->opt top-func -Nat [Univ] B)]
 [procedure-reduce-arity (-> top-func (Un -Nat -Arity-At-Least (-lst (Un -Nat -Arity-At-Least))) top-func)]
 [procedure-keywords (-> top-func (-values (list (-lst -Keyword) (-opt (-lst -Keyword)))))]
@@ -1271,7 +1271,7 @@
 
 ;; Sections 4.19 & 4.20 (Void and Undefined)
 [void (->* '() Univ -Void)]
-[void? (make-pred-ty -Void #t)]
+[void? (unsafe-shallow:make-pred-ty -Void)]
 
 [unsafe-undefined -Unsafe-Undefined]
 
@@ -1299,21 +1299,21 @@
         Univ]
        (-values (list (-poly (a) (-struct-property a #f)) (-> Univ B) (-> Univ Univ))))]
 
-[struct-type-property? (make-pred-ty (-struct-property -Bottom #f) #t)]
+[struct-type-property? (unsafe-shallow:make-pred-ty (-struct-property -Bottom #f))]
 [struct-type-property-accessor-procedure? (-> Univ B)]
 [struct-type-property-predicate-procedure? (->opt Univ [(-opt (-struct-property -Bottom #f))] B)]
 
 ;; Section 5.6 (Structure Utilities)
 [struct->vector (Univ . -> . (-vec Univ))]
 [struct? (-> Univ -Boolean)]
-[struct-type? (make-pred-ty -StructTypeTop #t)]
+[struct-type? (unsafe-shallow:make-pred-ty -StructTypeTop)]
 
 ;; Section 6.2 (Classes)
 [object% (-class)]
 
 ;; Section 6.11 (Object, Class, and Interface Utilities)
-[object? (make-pred-ty (-object) #t)]
-[class? (make-pred-ty -ClassTop #t)]
+[object? (unsafe-shallow:make-pred-ty (-object))]
+[class? (unsafe-shallow:make-pred-ty -ClassTop)]
 ;; TODO: interface?
 ;;       generic?
 [object=? (-> (-object) (-object) -Boolean)]
@@ -1332,7 +1332,7 @@
 ;; TODO: class-info (is this sound to allow?)
 
 ;; Section 7.8 (Unit Utilities)
-[unit? (make-pred-ty -UnitTop #t)]
+[unit? (unsafe-shallow:make-pred-ty -UnitTop)]
 
 ;; Section 9.1
 [exn:misc:match? (-> Univ B)]
@@ -1340,7 +1340,7 @@
 [match:error ((list) Univ . ->* . (Un))]
 ;[match:error (Univ . -> . (Un))]
 [match-equality-test (-Param (Univ Univ . -> . Univ) (Univ Univ . -> . Univ))]
-[matchable? (make-pred-ty (Un -String -Bytes) #t)]
+[matchable? (unsafe-shallow:make-pred-ty (Un -String -Bytes))]
 [syntax-srclocs (Univ . -> . Univ)]
 
 ;; Section 10.1
@@ -1371,7 +1371,7 @@
 [raise-syntax-error (->optkey (-opt Sym) -String [Univ Univ (-lst (-Syntax Univ)) -String] #:exn (-> (-lst (-Syntax Univ)) -String -Cont-Mark-Set -Exn) #f (Un))]
 ;raise-argument-error, raise-type-error, etc. (in index)
 
-[unquoted-printing-string? (make-pred-ty -Unquoted-Printing-String #t)]
+[unquoted-printing-string? (unsafe-shallow:make-pred-ty -Unquoted-Printing-String)]
 [unquoted-printing-string (-> -String -Unquoted-Printing-String)]
 [unquoted-printing-string-value (-> -Unquoted-Printing-String -String)]
 
@@ -1387,13 +1387,13 @@
 
 ;; Section 10.2.5
 [prop:exn:srclocs (-struct-property (-> -Self (-lst -Srcloc)) #'exn:srclocs?)]
-[exn:srclocs? (make-pred-ty (-has-struct-property #'prop:exn:srclocs) #t)]
+[exn:srclocs? (unsafe-shallow:make-pred-ty (-has-struct-property #'prop:exn:srclocs))]
 [exn:srclocs-accessor (-> Univ (-lst Univ))] ;TODO
 
 [srcloc->string (-> -Srcloc -String)]
 
 ;; Section 10.3 (Delayed Evaluation)
-[promise? (make-pred-ty (-Promise Univ) #t)]
+[promise? (unsafe-shallow:make-pred-ty (-Promise Univ))]
 [force (-poly (a) (->acc (list (-Promise a)) a (list -force) #:T+ #f))]
 [promise-forced? (-poly (a) (-> (-Promise a) B))]
 [promise-running? (-poly (a) (-> (-Promise a) B))]
@@ -1452,8 +1452,8 @@
 [call-with-continuation-barrier (-poly (a) (-> (-> a :T+ #f) a :T+ #f))]
 [continuation-prompt-available? (-> -Prompt-TagTop B)]
 [continuation?
- (asym-pred Univ B (-PS (-is-type 0 top-func) -tt) #t)]
-[continuation-prompt-tag? (make-pred-ty -Prompt-TagTop #t)]
+ (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 top-func) -tt))]
+[continuation-prompt-tag? (unsafe-shallow:make-pred-ty -Prompt-TagTop)]
 [dynamic-wind (-poly (a) (-> (-> ManyUniv) (-> a :T+ #f) (-> ManyUniv) a :T+ #f))]
 
 ;; Section 10.5 (Continuation Marks)
@@ -1490,8 +1490,8 @@
          (->opt (-opt -Cont-Mark-Set) Univ [Univ -Prompt-TagTop] Univ)))]
 [call-with-immediate-continuation-mark
  (-poly (a) (->opt Univ (-> Univ a :T+ #f) [Univ] a :T+ #f))]
-[continuation-mark-key? (make-pred-ty -Continuation-Mark-KeyTop #t)]
-[continuation-mark-set? (make-pred-ty -Cont-Mark-Set #t)]
+[continuation-mark-key? (unsafe-shallow:make-pred-ty -Continuation-Mark-KeyTop)]
+[continuation-mark-set? (unsafe-shallow:make-pred-ty -Cont-Mark-Set)]
 [make-continuation-mark-key
  (-poly (a) (->opt [-Symbol] (-Continuation-Mark-Keyof a)))]
 [continuation-mark-set->context
@@ -1509,7 +1509,7 @@
 
 ;; Section 11.1.1
 [thread (-> (-> Univ) -Thread)]
-[thread? (make-pred-ty -Thread #t)]
+[thread? (unsafe-shallow:make-pred-ty -Thread)]
 [current-thread (-> -Thread)]
 [thread/suspend-to-kill (-> (-> Univ) -Thread)]
 [call-in-nested-thread (-poly (a) (->opt (-> a :T+ #f) [-Custodian] a :T+ #f))]
@@ -1540,7 +1540,7 @@
 [thread-rewind-receive (-> (-lst Univ) -Void)]
 
 ;; Section 11.2.1
-[evt? (make-pred-ty (-evt Univ) #t)]
+[evt? (unsafe-shallow:make-pred-ty (-evt Univ))]
 [sync (-poly (a) (->* '() (-evt a) a :T+ #f))]
 [sync/timeout
  (-poly (a b)
@@ -1573,29 +1573,29 @@
 [never-evt (-evt (Un))]
 [system-idle-evt (-> (-evt -Void))]
 [alarm-evt (-> -Real (-mu x (-evt x)))]
-[handle-evt? (asym-pred Univ B (-PS (-is-type 0 (-evt Univ)) -tt) #t)]
+[handle-evt? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (-evt Univ)) -tt))]
 [prop:evt (-struct-property (Un (-evt Univ) (-> -Self ManyUniv) -Nat) #'evt?)]
 [current-evt-pseudo-random-generator
  (-Param -Pseudo-Random-Generator -Pseudo-Random-Generator)]
 
 ;; Section 11.2.2
 [make-channel (-poly (a) (-> (-channel a)))]
-[channel? (make-pred-ty -ChannelTop #t)]
+[channel? (unsafe-shallow:make-pred-ty -ChannelTop)]
 [channel-get (-poly (a) ((-channel a) . -> . a :T+ #f))]
 [channel-try-get (-poly (a) ((-channel a) . -> . (Un a (-val #f)) :T+ #f))]
 [channel-put (-poly (a) ((-channel a) a . -> . -Void))]
 [channel-put-evt (-poly (a) (-> (-channel a) a (-mu x (-evt x))))]
-[channel-put-evt? (asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt) #t)]
+[channel-put-evt? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt))]
 
 ;; Section 11.2.3 (Semaphores)
-[semaphore? (make-pred-ty -Semaphore #t)]
+[semaphore? (unsafe-shallow:make-pred-ty -Semaphore)]
 [make-semaphore (->opt [-Nat] -Semaphore)]
 [semaphore-post (-> -Semaphore -Void)]
 [semaphore-wait (-> -Semaphore -Void)]
 [semaphore-try-wait? (-> -Semaphore B)]
 [semaphore-wait/enable-break (-> -Semaphore -Void)]
 [semaphore-peek-evt (-> -Semaphore (-mu x (-evt x)))]
-[semaphore-peek-evt? (asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt) #t)]
+[semaphore-peek-evt? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt))]
 [call-with-semaphore
  (-polydots (b a)
    (cl->* (->... (list -Semaphore (->... '() [a a] b :T+ #f))
@@ -1610,7 +1610,7 @@
                  [a a] b :T+ #f)))]
 
 ;; Section 11.3.1 (Thread Cells)
-[thread-cell? (make-pred-ty -ThreadCellTop #t)]
+[thread-cell? (unsafe-shallow:make-pred-ty -ThreadCellTop)]
 [make-thread-cell (-poly (a) (->opt a [Univ] (-thread-cell a)))]
 [thread-cell-ref (-poly (a) (-> (-thread-cell a) a :T+ #f))]
 [thread-cell-set! (-poly (a) (-> (-thread-cell a) a -Void))]
@@ -1626,25 +1626,25 @@
 [make-parameter (-poly (a b) (cl-> [(a) (-Param a a)]
                                    [(b (a . -> . b :T+ #f)) (-Param a b)]))]
 [make-derived-parameter (-poly (a b c d) (-> (-Param a b) (-> c a :T+ #f) (-> b d :T+ #f) (-Param c d)))]
-[parameter? (make-pred-ty (-Param -Bottom Univ) #t)]
+[parameter? (unsafe-shallow:make-pred-ty (-Param -Bottom Univ))]
 [parameter-procedure=? (-poly (a b c d) (-> (-Param a b) (-Param c d) B))]
 
 [current-parameterization (-> -Parameterization)]
 [call-with-parameterization (-poly (a) (-> -Parameterization (-> a :T+ #f) a :T+ #f))]
-[parameterization? (make-pred-ty -Parameterization #t)]
+[parameterization? (unsafe-shallow:make-pred-ty -Parameterization)]
 
 ;; Section 11.4 (Futures)
 [future (-poly (A) ((-> A :T+ #f) . -> . (-future A)))]
 [touch (-poly (A) ((-future A) . -> . A :T+ #f))]
 [futures-enabled? (-> -Boolean)]
 [current-future (-> (-opt (-future Univ)))]
-[future? (make-pred-ty (-future Univ) #t)]
+[future? (unsafe-shallow:make-pred-ty (-future Univ))]
 [would-be-future (-poly (A) ((-> A :T+ #f) . -> . (-future A)))]
 [processor-count (-> -PosInt)]
 
 ;; Section 11.4.2 (Future Semaphores)
 [make-fsemaphore (-> -Nat -FSemaphore)]
-[fsemaphore? (make-pred-ty -FSemaphore #t)]
+[fsemaphore? (unsafe-shallow:make-pred-ty -FSemaphore)]
 [fsemaphore-post (-> -FSemaphore -Void)]
 [fsemaphore-wait (-> -FSemaphore -Void)]
 [fsemaphore-try-wait? (-> -FSemaphore B)]
@@ -1652,8 +1652,8 @@
 
 ;; Section 11.5 (Places)
 [place-enabled? (-> -Boolean)]
-[place? (make-pred-ty -Place #t)]
-[place-channel? (make-pred-ty -Place-Channel #t)]
+[place? (unsafe-shallow:make-pred-ty -Place)]
+[place-channel? (unsafe-shallow:make-pred-ty -Place-Channel)]
 ;; FIXME: the `#:at` keyword is for remote places, not supported yet
 [dynamic-place (->key (Un -Module-Path -Path) Sym
                       #:at (-val #f) #f
@@ -1680,7 +1680,7 @@
 ;; Section 12 (Macros)
 
 ;; Section 12.2
-[syntax? (make-pred-ty (-Syntax Univ) #t)]
+[syntax? (unsafe-shallow:make-pred-ty (-Syntax Univ))]
 
 [syntax-source (-> (-Syntax Univ) Univ)]
 [syntax-line (-> (-Syntax Univ) (-opt -PosInt))]
@@ -1723,7 +1723,7 @@
     (->opt ctxt Pre  [srcloc prop cert] A)
     (->opt ctxt Univ [srcloc prop cert] S)))]
 
-[identifier? (make-pred-ty (-Syntax Sym) #t)]
+[identifier? (unsafe-shallow:make-pred-ty (-Syntax Sym))]
 
 [generate-temporaries (-> (Un (-Syntax (-lst Univ)) (-lst Univ)) (-lst (-Syntax Sym)))]
 [identifier-prune-lexical-context (->opt (-Syntax Sym) [(-lst Sym)] (-Syntax Sym))]
@@ -1783,7 +1783,7 @@
  (Ident . ->opt . [(Un -Int (-val #f))] -Symbol)]
 
 ;; Section 12.4
-[set!-transformer? (make-pred-ty (-has-struct-property #'prop:set!-transformer) #t)]
+[set!-transformer? (unsafe-shallow:make-pred-ty (-has-struct-property #'prop:set!-transformer))]
 [make-set!-transformer (-> (-> (-Syntax Univ) (-Syntax Univ)) Univ)]
 [set!-transformer-procedure (-> Univ (-> (-Syntax Univ) (-Syntax Univ)))]
 [prop:set!-transformer (-struct-property (Un -Nat
@@ -1791,7 +1791,7 @@
                                                    [(-Self (-Syntax Univ)) (-Syntax Univ)]))
                                          #'set!-transformer?)]
 
-[rename-transformer? (make-pred-ty (-has-struct-property #'prop:rename-transformer) #t)]
+[rename-transformer? (unsafe-shallow:make-pred-ty (-has-struct-property #'prop:rename-transformer))]
 [make-rename-transformer (->opt (-Syntax Sym) [(-> (-Syntax Sym) (-Syntax Sym))] Univ)]
 [rename-transformer-target (-> Univ (-Syntax Sym))]
 [prop:rename-transformer (-struct-property (Un -Nat (-Syntax Sym) (-> -Self (-Syntax Sym)))
@@ -1845,7 +1845,7 @@
          Univ]
         (-Syntax Univ))]
 
-[internal-definition-context? (make-pred-ty -Internal-Definition-Context #t)]
+[internal-definition-context? (unsafe-shallow:make-pred-ty -Internal-Definition-Context)]
 [syntax-local-make-definition-context (->opt [(-opt -Internal-Definition-Context)] -Internal-Definition-Context)]
 [syntax-local-bind-syntaxes (-> (-lst (-Syntax Sym)) (-opt (-Syntax Univ)) -Internal-Definition-Context -Void)]
 [internal-definition-context-introduce
@@ -1918,9 +1918,9 @@
 [current-locale (-Param -String -String)]
 
 ;; Section 13.1.2
-[input-port? (make-pred-ty -Input-Port #t)]
-[output-port? (make-pred-ty -Output-Port #t)]
-[port? (make-pred-ty -Port #t)]
+[input-port? (unsafe-shallow:make-pred-ty -Input-Port)]
+[output-port? (unsafe-shallow:make-pred-ty -Output-Port)]
+[port? (unsafe-shallow:make-pred-ty -Port)]
 
 [close-input-port (-> -Input-Port -Void)]
 [close-output-port (-> -Output-Port -Void)]
@@ -1932,11 +1932,11 @@
 [current-output-port (-Param -Output-Port -Output-Port)]
 [current-error-port (-Param -Output-Port -Output-Port)]
 
-[file-stream-port? (asym-pred Univ B (-PS (-is-type 0 -Port) -tt) #t)]
-[terminal-port? (asym-pred Univ B (-PS (-is-type 0 -Port) -tt) #t)]
+[file-stream-port? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 -Port) -tt))]
+[terminal-port? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 -Port) -tt))]
 
 [eof (-val eof)]
-[eof-object? (make-pred-ty (-val eof) #t)]
+[eof-object? (unsafe-shallow:make-pred-ty (-val eof))]
 
 ;; Section 13.1.3
 [flush-output (->opt [-Output-Port] -Void)]
@@ -2351,7 +2351,7 @@
 [pretty-print-show-inexactness (-Param Univ B)]
 [pretty-print-abbreviate-read-macros (-Param Univ B)]
 
-[pretty-print-style-table? (make-pred-ty -Pretty-Print-Style-Table #t)]
+[pretty-print-style-table? (unsafe-shallow:make-pred-ty -Pretty-Print-Style-Table)]
 [pretty-print-current-style-table (-Param -Pretty-Print-Style-Table -Pretty-Print-Style-Table)]
 [pretty-print-extend-style-table (-> (-opt -Pretty-Print-Style-Table) (-lst Sym) (-lst Sym) -Pretty-Print-Style-Table)]
 [pretty-print-remap-stylable (-Param (-> Univ (-opt Sym)) (-> Univ (-opt Sym)))]
@@ -2373,7 +2373,7 @@
 ;; Section 13.7
 
 ;; Section 13.7.1
-[readtable? (make-pred-ty -Read-Table #t)]
+[readtable? (unsafe-shallow:make-pred-ty -Read-Table)]
 [make-readtable
  (->* (list (-opt -Read-Table))
       (make-Rest
@@ -2406,14 +2406,14 @@
 ;; Nothing defined here
 
 ;; Section 13.7.3
-[special-comment? (make-pred-ty -Special-Comment #t)]
+[special-comment? (unsafe-shallow:make-pred-ty -Special-Comment)]
 [make-special-comment (-> Univ -Special-Comment)]
 [special-comment-value (-> -Special-Comment Univ)]
 
 ;; Section 13.8
 [prop:custom-write (-struct-property (-> -Self -Output-Port (Un B (-val 1) (-val 0)) ManyUniv)
                                      #'custom-write?)]
-[custom-write? (make-pred-ty (-has-struct-property #'prop:custom-write) #t)]
+[custom-write? (unsafe-shallow:make-pred-ty (-has-struct-property #'prop:custom-write))]
 [custom-write-accessor (-> (-has-struct-property #'prop:custom-write)
                            (-some-res (me) (-> me -Output-Port (Un B (-val 1) (-val 0)) ManyUniv) : #:+ me))]
 
@@ -2422,7 +2422,7 @@
                                                   (-val 'maybe)
                                                   (-val 'always))
                                               #'custom-print-quotable?)]
-[custom-print-quotable? (make-pred-ty (-has-struct-property #'prop:custom-print-quotable) #t)]
+[custom-print-quotable? (unsafe-shallow:make-pred-ty (-has-struct-property #'prop:custom-print-quotable))]
 [custom-print-quotable-accessor (-> (-has-struct-property #'prop:custom-print-quotable)
                                     (Un (-val 'self)
                                         (-val 'never)
@@ -2439,13 +2439,13 @@
 [sha256-bytes (->opt (Un -Bytes -Input-Port) [-Nat (Un -Nat (-val #f))] -Bytes)]
 
 ;; Section 14.1 (Namespaces)
-[namespace? (make-pred-ty -Namespace #t)]
+[namespace? (unsafe-shallow:make-pred-ty -Namespace)]
 [make-namespace (->opt [(one-of/c  'empty 'initial)] -Namespace)]
 [make-empty-namespace (-> -Namespace)]
 [make-base-empty-namespace (-> -Namespace)]
 [make-base-namespace (-> -Namespace)]
 
-[namespace-anchor? (make-pred-ty -Namespace-Anchor #t)]
+[namespace-anchor? (unsafe-shallow:make-pred-ty -Namespace-Anchor)]
 [namespace-anchor->empty-namespace (-> -Namespace-Anchor -Namespace)]
 [namespace-anchor->namespace (-> -Namespace-Anchor -Namespace)]
 
@@ -2468,7 +2468,7 @@
 [namespace-syntax-introduce (-poly (a) (-> (-Syntax a) (-Syntax a)))]
 [module-provide-protected? (-> -Module-Path-Index Sym B)]
 
-[variable-reference? (make-pred-ty -Variable-Reference #t)]
+[variable-reference? (unsafe-shallow:make-pred-ty -Variable-Reference)]
 [variable-reference->empty-namespace (-> -Variable-Reference -Namespace)]
 [variable-reference->namespace (-> -Variable-Reference -Namespace)]
 [variable-reference->resolved-module-path (-> -Variable-Reference (-opt -Resolved-Module-Path))]
@@ -2507,7 +2507,7 @@
 [current-compile (-Param (-> Univ B -Compiled-Expression) (-> Univ B -Compiled-Expression))]
 [compile (-> Univ -Compiled-Expression)]
 [compile-syntax (-> (-Syntax Univ) -Compiled-Expression)]
-[compiled-expression? (make-pred-ty -Compiled-Expression #t)]
+[compiled-expression? (unsafe-shallow:make-pred-ty -Compiled-Expression)]
 
 [compile-enforce-module-constants (-Param B B)]
 [compile-allow-set!-undefined (-Param B B)]
@@ -2516,10 +2516,10 @@
 [load-on-demand-enabled (-Param B B)]
 
 ;; Section 14.4 (Module Names and Loading)
-[resolved-module-path? (make-pred-ty -Resolved-Module-Path #t)]
+[resolved-module-path? (unsafe-shallow:make-pred-ty -Resolved-Module-Path)]
 [make-resolved-module-path (-> (Un -Symbol -Path) -Resolved-Module-Path)]
 [resolved-module-path-name (-> -Resolved-Module-Path (Un -Path -Symbol))]
-[module-path? (asym-pred Univ B (-PS (-is-type 0 -Module-Path) -tt) #t)]
+[module-path? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 -Module-Path) -tt))]
 
 [current-module-name-resolver (-Param (cl->* (-Resolved-Module-Path Univ . -> . Univ)
                                              ((Un -Module-Path -Path)
@@ -2537,7 +2537,7 @@
                                      (-opt -Resolved-Module-Path))]
 [current-module-declare-source (-Param (-opt (Un -Symbol -Path))
                                        (-opt (Un -Symbol -Path)))]
-[module-path-index? (make-pred-ty -Module-Path-Index #t)]
+[module-path-index? (unsafe-shallow:make-pred-ty -Module-Path-Index)]
 [module-path-index-resolve (-> -Module-Path-Index -Resolved-Module-Path)]
 [module-path-index-split (-> -Module-Path-Index
                              (-values
@@ -2547,7 +2547,7 @@
 [module-path-index-join (-> (-opt -Module-Path)
                             (-opt (Un -Module-Path-Index -Resolved-Module-Path))
                             -Module-Path-Index)]
-[compiled-module-expression? (make-pred-ty -Compiled-Module-Expression #t)]
+[compiled-module-expression? (unsafe-shallow:make-pred-ty -Compiled-Module-Expression)]
 [module-compiled-name (-> -Compiled-Module-Expression -Symbol)]
 [module-compiled-imports (-> -Compiled-Module-Expression
                              (-lst (-pair (-opt -Integer)
@@ -2639,12 +2639,12 @@
 [chaperone-of? (Univ Univ . -> . B)]
 
 [make-impersonator-property (-> Sym (-values (list -Impersonator-Property (-> Univ B) (-> Univ Univ))))]
-[impersonator-property? (make-pred-ty -Impersonator-Property #t)]
+[impersonator-property? (unsafe-shallow:make-pred-ty -Impersonator-Property)]
 [impersonator-property-accessor-procedure? (-> Univ B)]
 [impersonator-prop:application-mark -Impersonator-Property]
 
 ;; Section 14.6 (Security Guards)
-[security-guard? (make-pred-ty -Security-Guard #t)]
+[security-guard? (unsafe-shallow:make-pred-ty -Security-Guard)]
 [make-security-guard
  (->opt -Security-Guard
         (-> Sym (-opt -Path) (-lst Sym) ManyUniv)
@@ -2654,7 +2654,7 @@
 [current-security-guard (-Param -Security-Guard -Security-Guard)]
 
 ;; Section 14.7 (Custodians)
-[custodian? (make-pred-ty -Custodian #t)]
+[custodian? (unsafe-shallow:make-pred-ty -Custodian)]
 [make-custodian (->opt [-Custodian] -Custodian)]
 [custodian-shutdown-all (-> -Custodian -Void)]
 [current-custodian (-Param -Custodian -Custodian)]
@@ -2664,16 +2664,16 @@
 [custodian-limit-memory (->opt -Custodian -Nat [-Custodian] -Void)]
 
 [make-custodian-box (-poly (a) (-> -Custodian a (-CustodianBox a)))]
-[custodian-box? (make-pred-ty (-poly (a) (-CustodianBox a)) #t)]
+[custodian-box? (unsafe-shallow:make-pred-ty (-poly (a) (-CustodianBox a)))]
 [custodian-box-value (-poly (a) (-> (-CustodianBox a) a :T+ #f))]
 
 ;; Section 14.8 (Thread Groups)
 [make-thread-group (->opt [-Thread-Group] -Thread-Group)]
-[thread-group? (make-pred-ty -Thread-Group #t)]
+[thread-group? (unsafe-shallow:make-pred-ty -Thread-Group)]
 [current-thread-group (-Param -Thread-Group -Thread-Group)]
 
 ;; Section 14.9 (Structure Inspectors)
-[inspector? (make-pred-ty -Inspector #t)]
+[inspector? (unsafe-shallow:make-pred-ty -Inspector)]
 [make-inspector (->opt [-Inspector] -Inspector)]
 [make-sibling-inspector (->opt [-Inspector] -Inspector)]
 [current-inspector (-Param -Inspector -Inspector)]
@@ -2693,7 +2693,7 @@
 [struct-type-make-predicate
  (-poly (a)
    (cl->*
-    (-> (make-StructType a) (make-pred-ty a #t))
+    (-> (make-StructType a) (unsafe-shallow:make-pred-ty a))
     (-> -StructTypeTop (-> Univ B))))]
 [object-name (-> Univ Univ)]
 
@@ -2701,11 +2701,11 @@
 [current-code-inspector (-Param -Inspector -Inspector)]
 
 ;; Section 15.1 (Path Manipulation)
-[path? (make-pred-ty -Path #t)]
-[path-string? (asym-pred Univ B
+[path? (unsafe-shallow:make-pred-ty -Path)]
+[path-string? (unsafe-shallow:asym-pred Univ B
                          (-PS (-is-type 0 (Un -Path -String))
-                              (-not-type 0 -Path)) #t)]
-[path-for-some-system? (make-pred-ty -SomeSystemPath #t)]
+                              (-not-type 0 -Path)))]
+[path-for-some-system? (unsafe-shallow:make-pred-ty -SomeSystemPath)]
 
 [string->path (-> -String -Path)]
 [bytes->path (cl->* (-> -Bytes -Path) (-> -Bytes -PathConventionType -SomeSystemPath))]
@@ -2850,7 +2850,7 @@
 [filesystem-root-list (-> (-lst -Path))]
 
 ;; Section 15.2.4
-[filesystem-change-evt? (asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt) #t)]
+[filesystem-change-evt? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt))]
 [filesystem-change-evt-cancel (-> (-mu x (-evt x)) -Void)]
 [filesystem-change-evt (-poly (a) (cl->* (-> -Pathlike (-mu x (-evt x)))
                                          (-> -Pathlike (-> a :T+ #f) (Un (-mu x (-evt x)) a))))]
@@ -2906,7 +2906,7 @@
 
 [tcp-accept-ready? (-TCP-Listener . -> . B)]
 [tcp-close (-TCP-Listener . -> . -Void)]
-[tcp-listener? (make-pred-ty -TCP-Listener #t)]
+[tcp-listener? (unsafe-shallow:make-pred-ty -TCP-Listener)]
 
 [tcp-accept-evt
  (-> -TCP-Listener
@@ -2917,7 +2917,7 @@
                 ((Un -TCP-Listener -Port) [(-val #f)] . ->opt . (-values (list -String -String)))
                 ((Un -TCP-Listener -Port) (-val #t) . -> . (-values (list -String -Index -String -Index))))]
 
-[tcp-port? (asym-pred Univ B (-PS (-is-type 0 (Un -Input-Port -Output-Port)) -tt) #t)]
+[tcp-port? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 (Un -Input-Port -Output-Port)) -tt))]
 [port-number? (Univ . -> . B)]
 [listen-port-number? (Univ . -> . B)]
 
@@ -2938,7 +2938,7 @@
 [udp-receive!/enable-break (->opt -UDP-Socket -Bytes [-Int -Int] (-values (list -Nat -String -Nat)))]
 
 [udp-close (-> -UDP-Socket -Void)]
-[udp? (make-pred-ty -UDP-Socket #t)]
+[udp? (unsafe-shallow:make-pred-ty -UDP-Socket)]
 [udp-bound? (-> -UDP-Socket B)]
 [udp-connected? (-> -UDP-Socket B)]
 
@@ -3007,7 +3007,7 @@
 [subprocess-status (-> -Subprocess (Un (-val 'running) -Nat))]
 [subprocess-kill (-> -Subprocess Univ -Void)]
 [subprocess-pid (-> -Subprocess -Nat)]
-[subprocess? (make-pred-ty -Subprocess #t)]
+[subprocess? (unsafe-shallow:make-pred-ty -Subprocess)]
 [current-subprocess-custodian-mode (-Param (one-of/c #f 'kill 'interrupt)
                                            (one-of/c #f 'kill 'interrupt))]
 [subprocess-group-enabled (-Param Univ B)]
@@ -3141,7 +3141,7 @@
 	      (-lst* (-opt -Input-Port) (-opt -Output-Port) -Nat (-opt -Input-Port) fun-type))))))]
 
 ;; Section 15.5 (Logging)
-[logger? (make-pred-ty -Logger #t)]
+[logger? (unsafe-shallow:make-pred-ty -Logger)]
 [make-logger (->opt [(-opt Sym) (-opt -Logger)] -Logger)]
 [logger-name (-> -Logger (-opt Sym))]
 [current-logger (-Param -Logger -Logger)]
@@ -3150,11 +3150,11 @@
                     (->opt -Logger -Log-Level (Un (-val #f) -Symbol) -String Univ [Univ] -Void))]
 [log-level? (->opt -Logger -Log-Level [(-opt -Symbol)] B)]
 
-[log-receiver? (make-pred-ty -Log-Receiver #t)]
+[log-receiver? (unsafe-shallow:make-pred-ty -Log-Receiver)]
 [make-log-receiver (opt-fn (list -Logger -Log-Level) (list (-opt -Symbol)) -Log-Receiver #:rest (make-Rest (list -Log-Level (-opt -Symbol))))]
 
 ;; Section 15.5.4 (Additional Logging Functions, racket/logging)
-[log-level/c (make-pred-ty (one-of/c 'none 'fatal 'error 'warning 'info 'debug) #t)]
+[log-level/c (unsafe-shallow:make-pred-ty (one-of/c 'none 'fatal 'error 'warning 'info 'debug))]
 [with-intercepted-logging
  (-polydots (a)
    (->* (list (-> (-vec* -Symbol -String Univ (-opt -Symbol)) Univ)
@@ -3179,15 +3179,15 @@
  (->opt [(Un (-val #f) (-val 'subprocesses) -Thread)] -Fixnum)]
 
 ;; Section 15.7
-[environment-variables? (make-pred-ty -Environment-Variables #t)]
+[environment-variables? (unsafe-shallow:make-pred-ty -Environment-Variables)]
 [current-environment-variables (-Param -Environment-Variables)]
-[bytes-environment-variable-name? (asym-pred Univ B (-PS (-is-type 0 -Bytes) -tt) #t)]
+[bytes-environment-variable-name? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 -Bytes) -tt))]
 [make-environment-variables (->* null -Bytes -Environment-Variables)]
 [environment-variables-ref (-> -Environment-Variables -Bytes (-opt -Bytes))]
 [environment-variables-set! (->opt -Environment-Variables -Bytes (-opt -Bytes) [(-> Univ)] Univ)]
 [environment-variables-names (-> -Environment-Variables  (-lst -Bytes))]
 [environment-variables-copy (-> -Environment-Variables -Environment-Variables)]
-[string-environment-variable-name? (asym-pred Univ B (-PS (-is-type 0 -String) -tt) #t)]
+[string-environment-variable-name? (unsafe-shallow:asym-pred Univ B (-PS (-is-type 0 -String) -tt))]
 [getenv (-> -String (Un -String (-val #f)))]
 [putenv (-> -String -String B)]
 
@@ -3243,16 +3243,16 @@
    (cl->* (-> (-weak-box a) (-opt a) :T+ #f)
           (-> (-weak-box a) b (Un b a) :T+ #f)
           (->opt -Weak-BoxTop [Univ] Univ)))]
-[weak-box? (make-pred-ty -Weak-BoxTop #t)]
+[weak-box? (unsafe-shallow:make-pred-ty -Weak-BoxTop)]
 
 ;; Section 16.2 (Ephemerons)
 [make-ephemeron (-poly (k v) (-> k v (-Ephemeron v)))]
-[ephemeron? (make-pred-ty (-Ephemeron Univ) #t)]
+[ephemeron? (unsafe-shallow:make-pred-ty (-Ephemeron Univ))]
 [ephemeron-value (-poly (v) (-> (-Ephemeron v) (Un (-val #f) v) :T+ #f))]
 
 ;; Section 16.3 (Wills and Executors)
 [make-will-executor (-> -Will-Executor)]
-[will-executor? (make-pred-ty -Will-Executor #t)]
+[will-executor? (unsafe-shallow:make-pred-ty -Will-Executor)]
 [will-register (-poly (a) (-> -Will-Executor a (-> a ManyUniv) -Void))]
 [will-execute (-> -Will-Executor ManyUniv)]
 [will-try-execute (-> -Will-Executor ManyUniv)]
@@ -3312,7 +3312,7 @@
 ;; Typed Racket Reference
 ;; Section 4
 [assert (-poly (a b) (cl->*
-                      (Univ (make-pred-ty (list a) Univ b #t) . -> . b :T+ #f)
+                      (Univ (unsafe-shallow:make-pred-ty (list a) Univ b) . -> . b :T+ #f)
                       (-> (Un a (-val #f)) a :T+ #f)))]
 [defined? (->* (list Univ) -Boolean : (-PS (-not-type 0 -Undefined) (-is-type 0 -Undefined)))]
 

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1,4 +1,5 @@
 #lang s-exp "env-lang.rkt"
+#:default-T+ #true
 
 ;; This module defines Typed Racket's main base type environment.
 (require
@@ -70,18 +71,18 @@
                                    #f)]
 
 ;; Section 4.2 (Booleans)
-[boolean? (make-pred-ty B)]
-[not (make-pred-ty (-val #f))]
+[boolean? (make-pred-ty B #t)]
+[not (make-pred-ty (-val #f) #t)]
 
 [immutable? (asym-pred Univ B (-PS (-is-type 0 (Un -Bytes -BoxTop -String (-Immutable-HT Univ Univ) (-ivec Univ)))
-                                   (-not-type 0 (Un (-Immutable-HT Univ Univ) (-ivec Univ)))))]
+                                   (-not-type 0 (Un (-Immutable-HT Univ Univ) (-ivec Univ)))) #t)]
 
 ;; Section 4.1.1 (racket/bool)
 [true (-val #t)]
 [false (-val #f)]
 [boolean=? (B B . -> . B)]
 [symbol=? (Sym Sym . -> . B)]
-[false? (make-pred-ty (-val #f))]
+[false? (make-pred-ty (-val #f) #t)]
 [xor (-> Univ Univ Univ)]
 
 ;; Section 4.3 (Numbers)
@@ -97,7 +98,7 @@
 
 [random-seed (-> -PosInt -Void)]
 [make-pseudo-random-generator (-> -Pseudo-Random-Generator)]
-[pseudo-random-generator? (make-pred-ty -Pseudo-Random-Generator)]
+[pseudo-random-generator? (make-pred-ty -Pseudo-Random-Generator #t)]
 [current-pseudo-random-generator (-Param -Pseudo-Random-Generator -Pseudo-Random-Generator)]
 [pseudo-random-generator->vector
  (-> -Pseudo-Random-Generator (-vec* -PosInt -PosInt -PosInt -PosInt -PosInt -PosInt))]
@@ -121,7 +122,7 @@
 [extfl->floating-point-bytes (->opt -ExtFlonum [Univ -Bytes -Nat] -Bytes)]
 
 ;; Section 4.4 (Strings)
-[string? (make-pred-ty -String)]
+[string? (make-pred-ty -String #t)]
 ;make-string (in Index)
 [string (->* '() -Char -String)]
 [string->immutable-string (-> -String -String)]
@@ -203,7 +204,7 @@
            #:repeat? Univ #f
            -String)]
 
-[non-empty-string? (asym-pred Univ -Boolean (-PS (-is-type 0 -String) -tt))]
+[non-empty-string? (asym-pred Univ -Boolean (-PS (-is-type 0 -String) -tt) #t)]
 [string-contains? (-> -String -String -Boolean)]
 [string-prefix? (-> -String -String -Boolean)]
 [string-suffix? (-> -String -String -Boolean)]
@@ -318,11 +319,11 @@
 
 ;; Section 4.5 (Byte Strings)
 [bytes (->* (list) -Integer -Bytes)]
-[bytes? (make-pred-ty -Bytes)]
+[bytes? (make-pred-ty -Bytes #t)]
 [make-bytes (cl-> [(-Integer -Integer) -Bytes]
                   [(-Integer) -Bytes])]
 [bytes->immutable-bytes (-> -Bytes -Bytes)]
-[byte? (make-pred-ty -Byte)]
+[byte? (make-pred-ty -Byte #t)]
 [bytes-append (->* (list) -Bytes -Bytes)]
 [bytes-length (-> -Bytes -Index)]
 [unsafe-bytes-length (-> -Bytes -Index)]
@@ -380,7 +381,7 @@
               -Nat
               (one-of/c 'complete 'continues)))))]
 
-[bytes-converter? (make-pred-ty -Bytes-Converter)]
+[bytes-converter? (make-pred-ty -Bytes-Converter #t)]
 
 [locale-string-encoding (-> -String)]
 
@@ -388,7 +389,7 @@
 [bytes-join ((-lst -Bytes) -Bytes . -> . -Bytes)]
 
 ;; Section 4.6 (Characters)
-[char? (make-pred-ty -Char)]
+[char? (make-pred-ty -Char #t)]
 [char=? (->* (list -Char -Char) -Char B)]
 [char<=? (->* (list -Char -Char) -Char B)]
 [char>=? (->* (list -Char -Char) -Char B)]
@@ -426,7 +427,7 @@
 [char-utf-8-length (-> -Char (apply Un (map -val '(1 2 3 4 5 6))))]
 
 ;; Section 4.7 (Symbols)
-[symbol? (make-pred-ty Sym)]
+[symbol? (make-pred-ty Sym #t)]
 [symbol-interned? (-> Sym B)]
 [symbol-unreadable? (-> Sym B)]
 [symbol->string (Sym . -> . -String)]
@@ -439,10 +440,10 @@
 [symbol->immutable-string (Sym . -> . -String)]
 
 ;; Section 4.8 (Regular Expressions)
-[regexp? (make-pred-ty -Regexp)]
-[pregexp? (make-pred-ty -PRegexp)]
-[byte-regexp? (make-pred-ty -Byte-Regexp)]
-[byte-pregexp? (make-pred-ty -Byte-PRegexp)]
+[regexp? (make-pred-ty -Regexp #t)]
+[pregexp? (make-pred-ty -PRegexp #t)]
+[byte-regexp? (make-pred-ty -Byte-Regexp #t)]
+[byte-pregexp? (make-pred-ty -Byte-PRegexp #t)]
 [regexp (-String . -> . -Base-Regexp)]
 [pregexp (-String . -> . -PRegexp)]
 [byte-regexp (-Bytes . -> . -Byte-Base-Regexp)]
@@ -497,7 +498,7 @@
   [-> -Bytes -Bytes])]
 
 ;; Section 4.9 (Keywords)
-[keyword? (make-pred-ty -Keyword)]
+[keyword? (make-pred-ty -Keyword #t)]
 [string->keyword (-String . -> . -Keyword)]
 [keyword->string (-Keyword . -> . -String)]
 [keyword<? (->* (list -Keyword -Keyword) -Keyword B)]
@@ -507,142 +508,142 @@
 ;; Section 4.10 (Pairs and Lists)
 [car   (-poly (a b)
               (cl->*
-               (->acc (list (-pair a b)) a (list -car))
-               (->* (list (-lst a)) a)))]
+               (->acc (list (-pair a b)) a (list -car) #:T+ #f)
+               (->* (list (-lst a)) a :T+ #f)))]
 [cdr   (-poly (a b)
               (cl->*
-               (->acc (list (-pair a b)) b (list -cdr))
-               (->* (list (-lst a)) (-lst a))))]
+               (->acc (list (-pair a b)) b (list -cdr) #:T+ #f)
+               (->* (list (-lst a)) (-lst a) :T+ #f)))]
 
 ;; these type signatures do not cover all valid uses of these pair accessors
 [caar (-poly (a b c)
-             (cl->* [->acc (list (-pair (-pair a b) c)) a (list -car -car)]
-                    [-> (-lst (-pair a b)) a]
-                    [-> (-pair (-lst a) b) a]
-                    [-> (-lst (-lst a)) a]))]
+             (cl->* [->acc (list (-pair (-pair a b) c)) a (list -car -car) #:T+ #f]
+                    [-> (-lst (-pair a b)) a :T+ #f]
+                    [-> (-pair (-lst a) b) a :T+ #f]
+                    [-> (-lst (-lst a)) a :T+ #f]))]
 [cdar (-poly (a b c)
-             (cl->* [->acc (list (-pair (-pair a b) c)) b (list -cdr -car)]
-                    [-> (-lst (-pair a b)) b]
-                    [-> (-pair (-lst a) b) (-lst a)]
-                    [-> (-lst (-lst a)) (-lst a)]))]
+             (cl->* [->acc (list (-pair (-pair a b) c)) b (list -cdr -car) #:T+ #f]
+                    [-> (-lst (-pair a b)) b :T+ #f]
+                    [-> (-pair (-lst a) b) (-lst a) :T+ #f]
+                    [-> (-lst (-lst a)) (-lst a) :T+ #f]))]
 [cadr (-poly (a b c)
-             (cl->* [->acc (list (-pair a (-pair b c))) b (list -car -cdr)]
-                    [-> (-pair a (-lst b)) b]
-                    [-> (-lst a) a]))]
+             (cl->* [->acc (list (-pair a (-pair b c))) b (list -car -cdr) #:T+ #f]
+                    [-> (-pair a (-lst b)) b :T+ #f]
+                    [-> (-lst a) a :T+ #f]))]
 [cddr  (-poly (a b c)
-              (cl->* [->acc (list (-pair a (-pair b c))) c (list -cdr -cdr)]
-                     [-> (-pair a (-lst b)) (-lst b)]
-                     [-> (-pair a (-pair b (-lst c))) (-lst c)]
-                     [-> (-lst a) (-lst a)]))]
+              (cl->* [->acc (list (-pair a (-pair b c))) c (list -cdr -cdr) #:T+ #f]
+                     [-> (-pair a (-lst b)) (-lst b) :T+ #f]
+                     [-> (-pair a (-pair b (-lst c))) (-lst c) :T+ #f]
+                     [-> (-lst a) (-lst a) :T+ #f]))]
 
 [caaar (-poly (a b c d)
-              (cl->* [->acc (list (-pair (-pair (-pair a b) c) d)) a (list -car -car -car)]
-                     [-> (-lst (-lst (-lst a))) a]))]
+              (cl->* [->acc (list (-pair (-pair (-pair a b) c) d)) a (list -car -car -car) #:T+ #f]
+                     [-> (-lst (-lst (-lst a))) a :T+ #f]))]
 [cdaar (-poly (a b c d)
-              (cl->* [->acc (list (-pair (-pair (-pair a b) c) d)) b (list -cdr -car -car)]
-                     [-> (-lst (-lst (-lst a))) (-lst a)]))]
+              (cl->* [->acc (list (-pair (-pair (-pair a b) c) d)) b (list -cdr -car -car) #:T+ #f]
+                     [-> (-lst (-lst (-lst a))) (-lst a) :T+ #f]))]
 [cadar (-poly (a b c d)
-              (cl->* [->acc (list (-pair (-pair a (-pair b c)) d)) b (list -car -cdr -car)]
-                     [-> (-lst (-lst a)) a]))]
+              (cl->* [->acc (list (-pair (-pair a (-pair b c)) d)) b (list -car -cdr -car) #:T+ #f]
+                     [-> (-lst (-lst a)) a :T+ #f]))]
 [cddar (-poly (a b c d)
-              (cl->* [->acc (list (-pair (-pair a (-pair b c)) d)) c (list -cdr -cdr -car)]
-                     [-> (-lst (-lst a)) (-lst a)]))]
+              (cl->* [->acc (list (-pair (-pair a (-pair b c)) d)) c (list -cdr -cdr -car) #:T+ #f]
+                     [-> (-lst (-lst a)) (-lst a) :T+ #f]))]
 [caadr (-poly (a b c d)
-              (cl->* [->acc (list (-pair a (-pair (-pair b c) d))) b (list -car -car -cdr)]
-                     [-> (-lst (-lst a)) a]))]
+              (cl->* [->acc (list (-pair a (-pair (-pair b c) d))) b (list -car -car -cdr) #:T+ #f]
+                     [-> (-lst (-lst a)) a :T+ #f]))]
 [cdadr (-poly (a b c d)
-              (cl->* [->acc (list (-pair a (-pair (-pair b c) d))) c (list -cdr -car -cdr)]
-                     [-> (-lst (-lst a)) (-lst a)]))]
+              (cl->* [->acc (list (-pair a (-pair (-pair b c) d))) c (list -cdr -car -cdr) #:T+ #f]
+                     [-> (-lst (-lst a)) (-lst a) :T+ #f]))]
 [caddr  (-poly (a b c d)
-              (cl->* [->acc (list (-pair a (-pair b (-pair c d)))) c (list -car -cdr -cdr)]
-                     [-> (-lst a) a]))]
+              (cl->* [->acc (list (-pair a (-pair b (-pair c d)))) c (list -car -cdr -cdr) #:T+ #f]
+                     [-> (-lst a) a :T+ #f]))]
 [cdddr (-poly (a b c d)
-              (cl->* [->acc (list (-pair a (-pair b (-pair c d)))) d (list -cdr -cdr -cdr)]
-                     [-> (-lst a) (-lst a)]))]
+              (cl->* [->acc (list (-pair a (-pair b (-pair c d)))) d (list -cdr -cdr -cdr) #:T+ #f]
+                     [-> (-lst a) (-lst a) :T+ #f]))]
 
 [caaaar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair (-pair (-pair a b) c) d) e)) a (list -car -car -car -car)]
-                      [-> (-lst (-lst (-lst (-lst a)))) a]))]
+               (cl->* [->acc (list (-pair (-pair (-pair (-pair a b) c) d) e)) a (list -car -car -car -car) #:T+ #f]
+                      [-> (-lst (-lst (-lst (-lst a)))) a :T+ #f]))]
 [cdaaar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair (-pair (-pair a b) c) d) e)) b (list -cdr -car -car -car)]
-                      [-> (-lst (-lst (-lst (-lst a)))) (-lst a)]))]
+               (cl->* [->acc (list (-pair (-pair (-pair (-pair a b) c) d) e)) b (list -cdr -car -car -car) #:T+ #f]
+                      [-> (-lst (-lst (-lst (-lst a)))) (-lst a) :T+ #f]))]
 [cadaar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair (-pair a (-pair b c)) d) e)) b (list -car -cdr -car -car)]
-                      [-> (-lst (-lst (-lst a))) a]))]
+               (cl->* [->acc (list (-pair (-pair (-pair a (-pair b c)) d) e)) b (list -car -cdr -car -car) #:T+ #f]
+                      [-> (-lst (-lst (-lst a))) a :T+ #f]))]
 [cddaar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair (-pair b (-pair b c)) d) e)) c (list -cdr -cdr -car -car)]
-                      [-> (-lst (-lst (-lst a))) (-lst a)]))]
+               (cl->* [->acc (list (-pair (-pair (-pair b (-pair b c)) d) e)) c (list -cdr -cdr -car -car) #:T+ #f]
+                      [-> (-lst (-lst (-lst a))) (-lst a) :T+ #f]))]
 [caadar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair a (-pair (-pair b c) d)) e)) b (list -car -car -cdr -car)]
-                      [-> (-lst (-lst (-lst a))) a]))]
+               (cl->* [->acc (list (-pair (-pair a (-pair (-pair b c) d)) e)) b (list -car -car -cdr -car) #:T+ #f]
+                      [-> (-lst (-lst (-lst a))) a :T+ #f]))]
 [cdadar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair a (-pair (-pair b c) d)) e)) c (list -cdr -car -cdr -car)]
-                      [-> (-lst (-lst (-lst a))) (-lst a)]))]
+               (cl->* [->acc (list (-pair (-pair a (-pair (-pair b c) d)) e)) c (list -cdr -car -cdr -car) #:T+ #f]
+                      [-> (-lst (-lst (-lst a))) (-lst a) :T+ #f]))]
 [caddar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair a (-pair b (-pair c d))) e)) c (list -car -cdr -cdr -car)]
-                      [-> (-lst (-lst a)) a]))]
+               (cl->* [->acc (list (-pair (-pair a (-pair b (-pair c d))) e)) c (list -car -cdr -cdr -car) #:T+ #f]
+                      [-> (-lst (-lst a)) a :T+ #f]))]
 [cdddar (-poly (a b c d e)
-               (cl->* [->acc (list (-pair (-pair a (-pair b (-pair c d))) e)) d (list -cdr -cdr -cdr -car)]
-                      [-> (-lst (-lst a)) (-lst a)]))]
+               (cl->* [->acc (list (-pair (-pair a (-pair b (-pair c d))) e)) d (list -cdr -cdr -cdr -car) #:T+ #f]
+                      [-> (-lst (-lst a)) (-lst a) :T+ #f]))]
 [caaadr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair (-pair (-pair b c) d) e))) b (list -car -car -car -cdr)]
-                      [-> (-lst (-lst (-lst a))) a]))]
+               (cl->* [->acc (list (-pair a (-pair (-pair (-pair b c) d) e))) b (list -car -car -car -cdr) #:T+ #f]
+                      [-> (-lst (-lst (-lst a))) a :T+ #f]))]
 [cdaadr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair (-pair (-pair b c) d) e))) c (list -cdr -car -car -cdr)]
-                      [-> (-lst (-lst (-lst a))) (-lst a)]))]
+               (cl->* [->acc (list (-pair a (-pair (-pair (-pair b c) d) e))) c (list -cdr -car -car -cdr) #:T+ #f]
+                      [-> (-lst (-lst (-lst a))) (-lst a) :T+ #f]))]
 [cadadr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair (-pair b (-pair c d)) e))) c (list -car -cdr -car -cdr)]
-                      [-> (-lst (-lst a)) a]))]
+               (cl->* [->acc (list (-pair a (-pair (-pair b (-pair c d)) e))) c (list -car -cdr -car -cdr) #:T+ #f]
+                      [-> (-lst (-lst a)) a :T+ #f]))]
 [cddadr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair (-pair b (-pair c d)) e))) d (list -cdr -cdr -car -cdr)]
-                      [-> (-lst (-lst a)) (-lst a)]))]
+               (cl->* [->acc (list (-pair a (-pair (-pair b (-pair c d)) e))) d (list -cdr -cdr -car -cdr) #:T+ #f]
+                      [-> (-lst (-lst a)) (-lst a) :T+ #f]))]
 [caaddr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair b (-pair (-pair c d) e)))) c (list -car -car -cdr -cdr)]
-                      [-> (-lst (-lst a)) a]))]
+               (cl->* [->acc (list (-pair a (-pair b (-pair (-pair c d) e)))) c (list -car -car -cdr -cdr) #:T+ #f]
+                      [-> (-lst (-lst a)) a :T+ #f]))]
 [cdaddr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair b (-pair (-pair c d) e)))) d (list -cdr -car -cdr -cdr)]
-                      [-> (-lst (-lst a)) (-lst a)]))]
+               (cl->* [->acc (list (-pair a (-pair b (-pair (-pair c d) e)))) d (list -cdr -car -cdr -cdr) #:T+ #f]
+                      [-> (-lst (-lst a)) (-lst a) :T+ #f]))]
 [cadddr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair b (-pair c (-pair d e))))) d (list -car -cdr -cdr -cdr)]
-                      [-> (-lst a) a]))]
+               (cl->* [->acc (list (-pair a (-pair b (-pair c (-pair d e))))) d (list -car -cdr -cdr -cdr) #:T+ #f]
+                      [-> (-lst a) a :T+ #f]))]
 [cddddr (-poly (a b c d e)
-               (cl->* [->acc (list (-pair a (-pair b (-pair c (-pair d e))))) e (list -cdr -cdr -cdr -cdr)]
-                      [-> (-lst a) (-lst a)]))]
+               (cl->* [->acc (list (-pair a (-pair b (-pair c (-pair d e))))) e (list -cdr -cdr -cdr -cdr) #:T+ #f]
+                      [-> (-lst a) (-lst a) :T+ #f]))]
 
 [first (-poly (a b)
               (cl->*
-               (->acc (list (-pair a (-lst b))) a (list -car))
-               (->* (list (-lst a)) a)))]
+               (->acc (list (-pair a (-lst b))) a (list -car) #:T+ #f)
+               (->* (list (-lst a)) a :T+ #f)))]
 [second (-poly (a r t)
-               (cl->* [->acc (list (-lst* a r #:tail (-lst t))) r (list -car -cdr)]
-                      [->* (list (-lst a)) a]))]
+               (cl->* [->acc (list (-lst* a r #:tail (-lst t))) r (list -car -cdr) #:T+ #f]
+                      [->* (list (-lst a)) a :T+ #f]))]
 [third (-poly (a b r t)
-              (cl->* [->acc (list (-lst* a b r #:tail (-lst t))) r (list -car -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+              (cl->* [->acc (list (-lst* a b r #:tail (-lst t))) r (list -car -cdr -cdr) #:T+ #f]
+                     [->* (list (-lst a)) a :T+ #f]))]
 [fourth  (-poly (a b c r t)
-              (cl->* [->acc (list (-lst* a b c r #:tail (-lst t))) r (list -car -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+              (cl->* [->acc (list (-lst* a b c r #:tail (-lst t))) r (list -car -cdr -cdr -cdr) #:T+ #f]
+                     [->* (list (-lst a)) a :T+ #f]))]
 [fifth   (-poly (a b c d r t)
-              (cl->* [->acc (list (-lst* a b c d r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+              (cl->* [->acc (list (-lst* a b c d r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr) #:T+ #f]
+                     [->* (list (-lst a)) a :T+ #f]))]
 [sixth   (-poly (a b c d e r t)
-              (cl->* [->acc (list (-lst* a b c d e r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+              (cl->* [->acc (list (-lst* a b c d e r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr) #:T+ #f]
+                     [->* (list (-lst a)) a :T+ #f]))]
 [seventh (-poly (a b c d e f r t)
-              (cl->* [->acc (list (-lst* a b c d e f r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+              (cl->* [->acc (list (-lst* a b c d e f r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr) #:T+ #f]
+                     [->* (list (-lst a)) a :T+ #f]))]
 [eighth  (-poly (a b c d e f g r t)
-              (cl->* [->acc (list (-lst* a b c d e f g r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+              (cl->* [->acc (list (-lst* a b c d e f g r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr) #:T+ #f]
+                     [->* (list (-lst a)) a :T+ #f]))]
 [ninth   (-poly (a b c d e f g h r t)
-              (cl->* [->acc (list (-lst* a b c d e f g h r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+              (cl->* [->acc (list (-lst* a b c d e f g h r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr) #:T+ #f]
+                     [->* (list (-lst a)) a :T+ #f]))]
 [tenth   (-poly (a b c d e f g h i r t)
-              (cl->* [->acc (list (-lst* a b c d e f g h i r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr)]
-                     [->* (list (-lst a)) a]))]
+              (cl->* [->acc (list (-lst* a b c d e f g h i r #:tail (-lst t))) r (list -car -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr -cdr) #:T+ #f]
+                     [->* (list (-lst a)) a :T+ #f]))]
 [rest (-poly (a b)
              (cl->*
-              (->acc (list (-pair a (-lst b))) (-lst b) (list -cdr))
+              (->acc (list (-pair a (-lst b))) (-lst b) (list -cdr) #:T+ #t)
               (->* (list (-lst a)) (-lst a))))]
 
 [cons (-poly (a b)
@@ -653,18 +654,18 @@
                      [(a (-lst a)) (-lst a)]))]
 #;[*list? (make-pred-ty (-lst Univ))]
 
-[null? (make-pred-ty -Null)]
+[null? (make-pred-ty -Null #t)]
 [null -Null]
-[cons? (make-pred-ty (-pair Univ Univ))]
-[pair? (make-pred-ty (-pair Univ Univ))]
-[empty? (make-pred-ty -Null)]
+[cons? (make-pred-ty (-pair Univ Univ) #t)]
+[pair? (make-pred-ty (-pair Univ Univ) #t)]
+[empty? (make-pred-ty -Null #t)]
 [empty -Null]
 
 [ormap (-polydots (a c b) (->... (list (->... (list a) (b b) c) (-lst a)) ((-lst b) b) (Un c (-val #f))))]
 [andmap (-polydots (a c d b) (cl->*
-                              (make-pred-ty (list (make-pred-ty (list a) c d) (-lst a)) c (-lst d)
+                              (make-pred-ty (list (make-pred-ty (list a) c d #f) (-lst a)) c (-lst d)
                                             ;; predicate on second argument
-                                            (-arg-path 1))
+                                            (-arg-path 1) #t)
                               (->... (list (->... (list a) (b b) c) (-lst a)) ((-lst b) b) (Un c (-val #t)))))]
 
 [reverse (-poly (a) (-> (-lst a) (-lst a)))]
@@ -681,7 +682,7 @@
           (cl->* (Univ (-lst a) . -> . (-opt (-ne-lst a)))
                  (b (-lst a) (-> b a Univ)
                        . -> . (-opt (-ne-lst a)))))]
-[findf (-poly (a) ((a . -> . B) (-lst a) . -> . (-opt a)))]
+[findf (-poly (a) ((a . -> . B :T+ #f) (-lst a) . -> . (-opt a) :T+ #f))]
 
 [assq  (-poly (a b) (Univ (-lst (-pair a b)) . -> . (-opt (-pair a b))))]
 [assv  (-poly (a b) (Univ (-lst (-pair a b)) . -> . (-opt (-pair a b))))]
@@ -710,13 +711,13 @@
                        . -> .
                        (-lst -Index)))]
 
-[list? (make-pred-ty (-lst Univ))]
+[list? (make-pred-ty (-lst Univ) #t)]
 [list (-poly (a) (->* '() a (-lst a)))]
 [map (-polydots (c a b)
                 (cl->*
-                 (-> (-> a c) (-pair a (-lst a)) (-pair c (-lst c)))
+                 (-> (-> a c :T+ #f) (-pair a (-lst a)) (-pair c (-lst c)))
                  ((list
-                   ((list a) (b b) . ->... . c)
+                   ((list a) (b b) . ->... . c :T+ #f)
                    (-lst a))
                   ((-lst b) b) . ->... . (-lst c))))]
 [for-each (-polydots (a b) ((list ((list a) (b b) . ->... . Univ) (-lst a))
@@ -727,15 +728,15 @@
                                 ((-lst b) b) . ->... . c))]
 [foldl
  (-poly (a b c d)
-        (cl-> [((a b . -> . b) b (-lst a)) b]
-              [((a b c . -> . c) c (-lst a) (-lst b)) c]
-              [((a b c d . -> . d) d (-lst a) (-lst b) (-lst c)) d]))]
+        (cl-> [((a b . -> . b :T+ #f) b (-lst a)) b :T+ #f]
+              [((a b c . -> . c :T+ #f) c (-lst a) (-lst b)) c :T+ #f]
+              [((a b c d . -> . d :T+ #f) d (-lst a) (-lst b) (-lst c)) d :T+ #f]))]
 [foldr  (-poly (a b c d)
-               (cl-> [((a b . -> . b) b (-lst a)) b]
-                     [((a b c . -> . c) c (-lst a) (-lst b)) c]
-                     [((a b c d . -> . d) d (-lst a) (-lst b) (-lst c)) d]))]
+               (cl-> [((a b . -> . b :T+ #f) b (-lst a)) b :T+ #f]
+                     [((a b c . -> . c :T+ #f) c (-lst a) (-lst b)) c :T+ #f]
+                     [((a b c d . -> . d :T+ #f) d (-lst a) (-lst b) (-lst c)) d :T+ #f]))]
 [filter (-poly (a b) (cl->*
-                      ((asym-pred a Univ (-PS (-is-type 0 b) -tt))
+                      ((asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
                        (-lst a)
                        . -> .
                        (-lst b))
@@ -763,7 +764,7 @@
 ;; Section 4.10.7 (racket/list)
 [filter-map (-polydots (c a b)
                        ((list
-                         ((list a) (b b) . ->... . (-opt c))
+                         ((list a) (b b) . ->... . (-opt c) :T+ #f)
                          (-lst a))
                         ((-lst b) b) . ->... . (-lst c)))]
 [count (-polydots (a b)
@@ -775,10 +776,10 @@
                    -Index))]
 [partition
  (-poly (a b) (cl->*
-               (-> (asym-pred b Univ (-PS (-is-type 0 a) -tt)) (-lst b) (-values (list (-lst a) (-lst b))))
+               (-> (asym-pred b Univ (-PS (-is-type 0 a) -tt) #t) (-lst b) (-values (list (-lst a) (-lst b))))
                (-> (-> a Univ) (-lst a) (-values (list (-lst a) (-lst a))))))]
 
-[last   (-poly (a) ((-lst a) . -> . a))]
+[last   (-poly (a) ((-lst a) . -> . a :T+ #f))]
 [add-between (-poly (a b) ((-lst a) b
                            #:splice? -Boolean #f
                            #:before-first (-lst b) #f
@@ -793,7 +794,7 @@
  (-poly (a b)
    (cl->*
     (-> (-lst a)
-        (asym-pred a Univ (-PS (-is-type 0 b) -tt))
+        (asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
         (-lst b))
     (-> (-lst a) (-> a Univ) (-lst a))))]
 [dropf (-poly (a) (-> (-lst a) (-> a Univ) (-lst a)))]
@@ -801,14 +802,14 @@
  (-poly (a b)
    (cl->*
     (-> (-lst a)
-        (asym-pred a Univ (-PS (-is-type 0 b) -tt))
+        (asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
         (-values (list (-lst b) (-lst a))))
     (-> (-lst a) (-> a Univ) (-values (list (-lst a) (-lst a))))))]
 [takef-right
  (-poly (a b)
    (cl->*
     (-> (-lst a)
-        (asym-pred a Univ (-PS (-is-type 0 b) -tt))
+        (asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
         (-lst b))
     (-> (-lst a) (-> a Univ) (-lst a))))]
 [dropf-right (-poly (a) (-> (-lst a) (-> a Univ) (-lst a)))]
@@ -816,7 +817,7 @@
  (-poly (a b)
    (cl->*
     (-> (-lst a)
-        (asym-pred a Univ (-PS (-is-type 0 b) -tt))
+        (asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
         (-values (list (-lst a) (-lst b))))
     (-> (-lst a) (-> a Univ) (-values (list (-lst a) (-lst a))))))]
 
@@ -844,9 +845,9 @@
                              (-> (-lst a) -Nat (-seq (-lst a)))))]
 [permutations (-poly (a) (-> (-lst a) (-lst (-lst a))))]
 [in-permutations (-poly (a) (-> (-lst a) (-seq (-lst a))))]
-[argmin (-poly (a) ((a . -> . -Real) (-lst a) . -> . a))]
-[argmax (-poly (a) ((a . -> . -Real) (-lst a) . -> . a))]
-[group-by (-poly (a b) (->opt (-> a b) (-lst a) [(-> b b Univ)] (-lst (-lst a))))]
+[argmin (-poly (a) ((a . -> . -Real) (-lst a) . -> . a :T+ #f))]
+[argmax (-poly (a) ((a . -> . -Real) (-lst a) . -> . a :T+ #f))]
+[group-by (-poly (a b) (->opt (-> a b :T+ #f) (-lst a) [(-> b b Univ)] (-lst (-lst a))))]
 [cartesian-product (-polydots (a) (->... '() ((-lst a) a) (-lst (make-ListDots a 'a))))]
 [remf (-poly (a) (-> (-> a Univ) (-lst a) (-lst a)))]
 [remf* (-poly (a) (-> (-> a Univ) (-lst a) (-lst a)))]
@@ -857,11 +858,11 @@
 ;; Section 4.11 (Mutable Pairs)
 [mcons (-poly (a b) (-> a b (-mpair a b)))]
 [mcar (-poly (a b)
-             (cl->* (-> (-mpair a b) a)
-                    (-> (-mlst a) a)
+             (cl->* (-> (-mpair a b) a :T+ #f)
+                    (-> (-mlst a) a :T+ #f)
                     (-> -MPairTop Univ)))]
 [mcdr (-poly (a b)
-             (cl->* (-> (-mpair a b) b)
+             (cl->* (-> (-mpair a b) b :T+ #f)
                     (-> (-mlst a) (-mlst a))
                     (-> -MPairTop Univ)))]
 [set-mcar! (-poly (a b)
@@ -871,12 +872,12 @@
                   (cl->* (-> (-mpair a b) b -Void)
                          (-> (-mlst a) (-mlst a) -Void)))]
 [unsafe-mcar (-poly (a b)
-                    (cl->* (-> (-mpair a b) a)
-                           (-> (-mlst a) a)
+                    (cl->* (-> (-mpair a b) a :T+ #f)
+                           (-> (-mlst a) a :T+ #f)
                            (-> -MPairTop Univ)))]
 [unsafe-mcdr (-poly (a b)
-                    (cl->* (-> (-mpair a b) b)
-                           (-> (-mlst a) (-mlst a))
+                    (cl->* (-> (-mpair a b) b :T+ #f)
+                           (-> (-mlst a) (-mlst a) :T+ #f)
                            (-> -MPairTop Univ)))]
 [unsafe-set-mcar! (-poly (a b)
                          (cl->* (-> (-mpair a b) a -Void)
@@ -884,7 +885,7 @@
 [unsafe-set-mcdr! (-poly (a b)
                          (cl->* (-> (-mpair a b) b -Void)
                                 (-> (-mlst a) (-mlst a) -Void)))]
-[mpair? (make-pred-ty -MPairTop)]
+[mpair? (make-pred-ty -MPairTop #t)]
 ;; mlist is a macro that under the hood uses -mlist, which is annotated in
 ;; base-special-env.rkt
 
@@ -893,21 +894,21 @@
 [mappend (-poly (a) (->* (list) (-mlst a) (-mlst a)))]
 
 ;; Section 4.12 (Vectors)
-[vector? (make-pred-ty -VectorTop)]
+[vector? (make-pred-ty -VectorTop #t)]
 [vector->list (-poly (a) (cl->* (-> (-vec a) (-lst a))
                                 (-> -VectorTop (-lst Univ))))]
 [list->vector (-poly (a) (-> (-lst a) (-mvec a)))]
 [vector-length (->acc (list -VectorTop)
                       -Index
-                      (list -vec-len))]
+                      (list -vec-len) #:T+ #t)]
 [vector (-poly (a) (->* (list) a (-mvec a)))]
 [vector-immutable (-poly (a) (->* (list) a (-ivec a)))]
 [vector->immutable-vector (-poly (a)
                                  (cl-> [((-vec a)) (-ivec a)]
                                        [(-VectorTop) (-ivec Univ)]))]
 [vector-fill! (-poly (a) (-> (-vec a) a -Void))]
-[vector-argmax (-poly (a) (-> (-> a -Real) (-vec a) a))]
-[vector-argmin (-poly (a) (-> (-> a -Real) (-vec a) a))]
+[vector-argmax (-poly (a) (-> (-> a -Real) (-vec a) a :T+ #f))]
+[vector-argmin (-poly (a) (-> (-> a -Real) (-vec a) a :T+ #f))]
 [vector-memq (-poly (a) (-> Univ (-vec a) (-opt -Index)))]
 [vector-memv (-poly (a) (-> Univ (-vec a) (-opt -Index)))]
 [vector-member (-poly (a) (Univ (-vec a) . -> . (-opt -Index)))]
@@ -922,7 +923,7 @@
                           . ->... .
                           -Index))]
 [vector-filter (-poly (a b) (cl->*
-                              ((asym-pred a Univ (-PS (-is-type 0 b) -tt))
+                              ((asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
                                (-vec a)
                                . -> .
                                (-mvec b))
@@ -935,9 +936,9 @@
         (cl->* ((-vec a) . -> . (-mvec a))
                ((-vec a) -Integer . -> . (-mvec a))
                ((-vec a) -Integer -Integer . -> . (-mvec a))))]
-[vector-map (-polydots (c a b) ((list ((list a) (b b) . ->... . c) (-vec a))
+[vector-map (-polydots (c a b) ((list ((list a) (b b) . ->... . c :T+ #f) (-vec a))
                                 ((-vec b) b) . ->... . (-mvec c)))]
-[vector-map! (-polydots (a b) ((list ((list a) (b b) . ->... . a) (-vec a))
+[vector-map! (-polydots (a b) ((list ((list a) (b b) . ->... . a :T+ #f) (-vec a))
                                ((-vec b) b) . ->... . (-mvec a)))]
 [vector-append (-poly (a) (->* (list) (-vec a) (-mvec a)))]
 [vector-take   (-poly (a) ((-vec a) -Integer . -> . (-mvec a)))]
@@ -953,27 +954,27 @@
 [box (-poly (a) (a . -> . (-box a)))]
 [box-immutable (-poly (a) (a . -> . (-box a)))]
 [unbox (-poly (a) (cl->*
-                   ((-box a) . -> . a)
+                   ((-box a) . -> . a :T+ #f)
                    (-BoxTop . -> . Univ)))]
 [set-box! (-poly (a) ((-box a) a . -> . -Void))]
 [box-cas! (-poly (a) ((-box a) a a . -> . -Boolean))]
 [unsafe-unbox (-poly (a) (cl->*
-                          ((-box a) . -> . a)
+                          ((-box a) . -> . a :T+ #f)
                           (-BoxTop . -> . Univ)))]
 [unsafe-set-box! (-poly (a) ((-box a) a . -> . -Void))]
 [unsafe-unbox* (-poly (a) (cl->*
-                           ((-box a) . -> . a)
+                           ((-box a) . -> . a :T+ #f)
                            (-BoxTop . -> . Univ)))]
 [unsafe-set-box*! (-poly (a) ((-box a) a . -> . -Void))]
 [unsafe-box*-cas! (-poly (a) ((-box a) a a . -> . -Boolean))]
-[box? (make-pred-ty -BoxTop)]
+[box? (make-pred-ty -BoxTop #t)]
 
 ;; Section 4.14 (Hash Tables)
-[hash? (make-pred-ty -HashTableTop)]
+[hash? (make-pred-ty -HashTableTop #t)]
 [hash-eq? (-> -HashTableTop B)]
 [hash-eqv? (-> -HashTableTop B)]
 [hash-equal? (-> -HashTableTop B)]
-[hash-weak? (asym-pred -HashTableTop B (-PS (-is-type 0 -Weak-HashTableTop) (-not-type 0 -Weak-HashTableTop)))]
+[hash-weak? (asym-pred -HashTableTop B (-PS (-is-type 0 -Weak-HashTableTop) (-not-type 0 -Weak-HashTableTop)) #t)]
 [hash (-poly (a b) (->* (list) (make-Rest (list a b)) (-Immutable-HT a b)))]
 [hasheqv (-poly (a b) (->* (list) (make-Rest (list a b)) (-Immutable-HT a b)))]
 [hasheq (-poly (a b) (->* (list) (make-Rest (list a b)) (-Immutable-HT a b)))]
@@ -992,20 +993,20 @@
 [hash-set! (-poly (a b) ((-HT a b) a b . -> . -Void))]
 [hash-set*! (-poly (a b) (->* (list (-HT a b)) (make-Rest (list a b)) -Void))]
 [hash-ref (-poly (a b c)
-                 (cl-> [((-HT a b) a) b]
-                       [((-HT a b) a (-val #f)) (-opt b)]
-                       [((-HT a b) a (-> c)) (Un b c)]
-                       [(-HashTableTop a) Univ]
-                       [(-HashTableTop a (-val #f)) Univ]
-                       [(-HashTableTop a (-> c)) Univ]))]
-[hash-ref! (-poly (a b) (-> (-HT a b) a (-> b) b))]
+                 (cl-> [((-HT a b) a) b :T+ #f]
+                       [((-HT a b) a (-val #f)) (-opt b) :T+ #f]
+                       [((-HT a b) a (-> c :T+ #f)) (Un b c) :T+ #f]
+                       [(-HashTableTop a) Univ :T+ #t]
+                       [(-HashTableTop a (-val #f)) Univ :T+ #t]
+                       [(-HashTableTop a (-> c :T+ #f)) Univ :T+ #t]))]
+[hash-ref! (-poly (a b) (-> (-HT a b) a (-> b :T+ #f) b :T+ #f))]
 [hash-has-key? (-HashTableTop Univ . -> . B)]
 [hash-update! (-poly (a b)
-                     (cl-> [((-HT a b) a (-> b b)) -Void]
-                           [((-HT a b) a (-> b b) (-> b)) -Void]))]
+                     (cl-> [((-HT a b) a (-> b b :T+ #f)) -Void]
+                           [((-HT a b) a (-> b b :T+ #f) (-> b :T+ #f)) -Void]))]
 [hash-update (-poly (a b)
-                    (cl-> [((-HT a b) a (-> b b)) (-Immutable-HT a b)]
-                          [((-HT a b) a (-> b b) (-> b)) (-Immutable-HT a b)]))]
+                    (cl-> [((-HT a b) a (-> b b :T+ #f)) (-Immutable-HT a b)]
+                          [((-HT a b) a (-> b b :T+ #f) (-> b :T+ #f)) (-Immutable-HT a b)]))]
 [hash-remove (-poly (a b) (cl-> [((-HT a b) Univ) (-Immutable-HT a b)]
                                 [(-HashTableTop Univ) (-Immutable-HT Univ Univ)]))]
 [hash-remove! (-poly (a b) (cl-> [((-HT a b) a) -Void]
@@ -1030,17 +1031,17 @@
                (->key -HashTableTop #:kind (Un (-val #f) (-val 'immutable) (-val 'mutable) (-val 'ephemeron) (-val 'weak)) #f
                       -HashTableTop)))]
 
-[hash-map (-poly (a b c) (cl-> [((-HT a b) (a b . -> . c)) (-lst c)]
-                               [((-HT a b) (a b . -> . c) Univ) (-lst c)]
-                               [(-HashTableTop (Univ Univ . -> . c)) (-lst c)]
-                               [(-HashTableTop (Univ Univ . -> . c) Univ) (-lst c)]))]
-[hash-map/copy (-poly (a b c d) (->key (-HT a b) (a b . -> . (-values (list c d)))
+[hash-map (-poly (a b c) (cl-> [((-HT a b) (a b . -> . c :T+ #f)) (-lst c)]
+                               [((-HT a b) (a b . -> . c :T+ #f) Univ) (-lst c)]
+                               [(-HashTableTop (Univ Univ . -> . c :T+ #f)) (-lst c)]
+                               [(-HashTableTop (Univ Univ . -> . c :T+ #f) Univ) (-lst c)]))]
+[hash-map/copy (-poly (a b c d) (->key (-HT a b) (a b . -> . (-values (list c d)) :T+ #f)
                                        #:kind (Un (-val #f) (-val 'immutable) (-val 'mutable) (-val 'ephemeron) (-val 'weak)) #f
                                        (-HT c d)))]
-[hash-for-each (-poly (a b c) (cl-> [((-HT a b) (-> a b c)) -Void]
-                                    [((-HT a b) (-> a b c) Univ) -Void]
-                                    [(-HashTableTop (-> Univ Univ c)) -Void]
-                                    [(-HashTableTop (-> Univ Univ c) Univ) -Void]))]
+[hash-for-each (-poly (a b c) (cl-> [((-HT a b) (-> a b c :T+ #f)) -Void]
+                                    [((-HT a b) (-> a b c :T+ #f) Univ) -Void]
+                                    [(-HashTableTop (-> Univ Univ c :T+ #f)) -Void]
+                                    [(-HashTableTop (-> Univ Univ c :T+ #f) Univ) -Void]))]
 [hash-count (-> -HashTableTop -Index)]
 [hash-empty? (-> -HashTableTop -Boolean)]
 [hash-keys (-poly (a b) (cl-> [((-HT a b)) (-lst a)]
@@ -1069,10 +1070,10 @@
                             ((-HT a b) -Integer . -> . (Un (-val #f) -Integer))
                             (-> -HashTableTop -Integer (Un (-val #f) -Integer))))]
 [hash-iterate-key (-poly (a b)
-                           (cl->* ((-HT a b) -Integer . -> . a)
+                           (cl->* ((-HT a b) -Integer . -> . a :T+ #f)
                                   (-> -HashTableTop -Integer Univ)))]
 [hash-iterate-value (-poly (a b)
-                           (cl->* ((-HT a b) -Integer . -> . b)
+                           (cl->* ((-HT a b) -Integer . -> . b :T+ #f)
                                   (-> -HashTableTop -Integer Univ)))]
 [hash-iterate-pair (-poly (a b)
                            (cl->* ((-HT a b) -Integer . -> . (-pair a b))
@@ -1086,9 +1087,9 @@
 [unsafe-immutable-hash-iterate-next
   (-poly (a b) ((-Immutable-HT a b) -Integer . -> . (Un (-val #f) -Integer)))]
 [unsafe-immutable-hash-iterate-key
-  (-poly (a b) ((-Immutable-HT a b) -Integer . -> . a))]
+  (-poly (a b) ((-Immutable-HT a b) -Integer . -> . a :T+ #f))]
 [unsafe-immutable-hash-iterate-value
-  (-poly (a b) ((-Immutable-HT a b) -Integer . -> . b))]
+  (-poly (a b) ((-Immutable-HT a b) -Integer . -> . b :T+ #f))]
 [unsafe-immutable-hash-iterate-pair
   (-poly (a b) ((-Immutable-HT a b) -Integer . -> . (-pair a b)))]
 [unsafe-immutable-hash-iterate-key+value
@@ -1099,9 +1100,9 @@
 [unsafe-mutable-hash-iterate-next
   (-poly (a b) ((-Mutable-HT a b) -Integer . -> . (Un (-val #f) -Integer)))]
 [unsafe-mutable-hash-iterate-key
-  (-poly (a b) ((-Mutable-HT a b) -Integer . -> . a))]
+  (-poly (a b) ((-Mutable-HT a b) -Integer . -> . a :T+ #f))]
 [unsafe-mutable-hash-iterate-value
-  (-poly (a b) ((-Mutable-HT a b) -Integer . -> . b))]
+  (-poly (a b) ((-Mutable-HT a b) -Integer . -> . b :T+ #f))]
 [unsafe-mutable-hash-iterate-pair
   (-poly (a b) ((-Mutable-HT a b) -Integer . -> . (-pair a b)))]
 [unsafe-mutable-hash-iterate-key+value
@@ -1112,9 +1113,9 @@
 [unsafe-weak-hash-iterate-next
   (-poly (a b) ((-Weak-HT a b) -Integer . -> . (Un (-val #f) -Integer)))]
 [unsafe-weak-hash-iterate-key
-  (-poly (a b) ((-Weak-HT a b) -Integer . -> . a))]
+  (-poly (a b) ((-Weak-HT a b) -Integer . -> . a :T+ #f))]
 [unsafe-weak-hash-iterate-value
-  (-poly (a b) ((-Weak-HT a b) -Integer . -> . b))]
+  (-poly (a b) ((-Weak-HT a b) -Integer . -> . b :T+ #f))]
 [unsafe-weak-hash-iterate-pair
   (-poly (a b) ((-Weak-HT a b) -Integer . -> . (-pair a b)))]
 [unsafe-weak-hash-iterate-key+value
@@ -1130,7 +1131,7 @@
 [hash-union! (-poly (a b) (->* (list (-Mutable-HT a b))  (-HT a b) -Void))]
 
 ;; Section 4.15 (Sequences and Streams)
-[sequence? (make-pred-ty -SequenceTop)]
+[sequence? (make-pred-ty -SequenceTop #t)]
 [in-sequences
  (-polydots (a) (->* '() (-seq-dots '() a 'a) (-seq-dots '() a 'a)))]
 [in-cycle
@@ -1147,37 +1148,37 @@
 [stop-after (-poly (a) ((-seq a) (a . -> . Univ) . -> . (-seq a)))]
 [make-do-sequence
  (-polydots (a b)
-   ((-> (-values (list (a . -> . (make-ValuesDots '() b 'b))
-                       (a . -> . a)
+   ((-> (-values (list (a . -> . (make-ValuesDots '() b 'b) :T+ #f)
+                       (a . -> . a :T+ #f)
                        a
                        (Un (a . -> . Univ) (-val #f))
                        (Un (->... '() (b b) Univ) (-val #f))
                        (Un (->... (list a) (b b) Univ) (-val #f)))))
     . -> . (-seq-dots '() b 'b)))]
 [sequence-generate
- (-polydots (a) ((-seq-dots '() a 'a) . -> . (-values (list (-> -Boolean) (-> (make-ValuesDots '() a 'a))))))]
+ (-polydots (a) ((-seq-dots '() a 'a) . -> . (-values (list (-> -Boolean) (-> (make-ValuesDots '() a 'a) :T+ #f)))))]
 ;; Doesn't work (mu types are single-valued only):
 ;[sequence-generate*  (-poly (a) ((-seq a) . -> . (-mu t (-values (list (Un (-lst a) (-val #f)) t)))))]
 ;; Doesn't render nicely (but seems to work fine):
 [empty-sequence (-polydots (a) (-seq-dots '() a 'a))]
 [sequence->list (-poly (a) ((-seq a) . -> . (-lst a)))]
 [sequence-length (-SequenceTop . -> . -Nat)]
-[sequence-ref (-polydots (a) ((-seq-dots '() a 'a) -Integer . -> . (make-ValuesDots '() a 'a)))]
+[sequence-ref (-polydots (a) ((-seq-dots '() a 'a) -Integer . -> . (make-ValuesDots '() a 'a) :T+ #f))]
 [sequence-tail (-polydots (a) ((-seq-dots '() a 'a) -Integer . -> . (-seq-dots '() a 'a)))]
 [sequence-append (-polydots (a) (->* '() (-seq-dots '() a 'a) (-seq-dots '() a 'a)))]
 ; We can't express the full type without multiple dotted type variables:
 [sequence-map (-polydots (a b)
                 (cl->*
-                  ((->... '() (b b) a) (-seq-dots '() b 'b) . -> . (-seq a))
-                  ((-> a (make-ValuesDots '() b 'b)) (-seq a) . -> . (-seq-dots '() b 'b))))]
-[sequence-andmap (-polydots (b a) ((->... '() (a a) b) (-seq-dots '() a 'a) . -> . (Un b (-val #t))))]
-[sequence-ormap (-polydots (b a) ((->... '() (a a) b) (-seq-dots '() a 'a) . -> . (Un b (-val #f))))]
+                  ((->... '() (b b) a :T+ #f) (-seq-dots '() b 'b) . -> . (-seq a))
+                  ((-> a (make-ValuesDots '() b 'b) :T+ #f) (-seq a) . -> . (-seq-dots '() b 'b))))]
+[sequence-andmap (-polydots (b a) ((->... '() (a a) b :T+ #f) (-seq-dots '() a 'a) . -> . (Un b (-val #t))))]
+[sequence-ormap (-polydots (b a) ((->... '() (a a) b :T+ #f) (-seq-dots '() a 'a) . -> . (Un b (-val #f))))]
 [sequence-for-each (-polydots (a) ((->... '() (a a) Univ) (-seq-dots '() a 'a) . -> . -Void))]
-[sequence-fold (-polydots (b a) ((->... (list b) (a a) b) b (-seq-dots '() a 'a) . -> . b))]
+[sequence-fold (-polydots (b a) ((->... (list b) (a a) b :T+ #f) b (-seq-dots '() a 'a) . -> . b :T+ #f))]
 [sequence-count (-polydots (a) ((->... '() (a a) Univ) (-seq-dots '() a 'a) . -> . -Nat))]
 [sequence-filter (-polydots (a b c)
                    (cl->*
-                    ((asym-pred a Univ (-PS (-is-type 0 b) -tt))
+                    ((asym-pred a Univ (-PS (-is-type 0 b) -tt) #t)
                      (-seq a)
                      . -> .
                      (-seq b))
@@ -1192,7 +1193,7 @@
 [set-empty? (-poly (e) (-> (-list-or-set e) B))]
 [set-count (-poly (e) (-> (-list-or-set e) -Index))]
 [set-member? (-poly (e) (-> (-list-or-set e) e B))]
-[set-first (-poly (e) (-> (-list-or-set e) e))]
+[set-first (-poly (e) (-> (-list-or-set e) e :T+ #f))]
 [set-rest (-poly (e) (set-abs -set (-> (-set e) (-set e))))]
 [set-add (-poly (e) (set-abs -set (-> (-set e) e (-set e))))]
 [set-remove (-poly (e) (set-abs -set (-> (-set e) Univ (-set e))))]
@@ -1208,8 +1209,8 @@
 [proper-subset? (-poly (e) (set-abs -set (-> (-set e) (-set e) B)))]
 [set-map (-poly (e b) (-> (-list-or-set e) (-> e b) (-lst b)))]
 [set-for-each (-poly (e b) (-> (-list-or-set e) (-> e b) -Void))]
-[generic-set? (asym-pred Univ B (-PS -tt (-not-type 0 (-list-or-set Univ))))]
-[set? (make-pred-ty (-set Univ))]
+[generic-set? (asym-pred Univ B (-PS -tt (-not-type 0 (-list-or-set Univ))) #t)]
+[set? (make-pred-ty (-set Univ) #t)]
 [set-equal? (-poly (e) (-> (-set e) B))]
 [set-eqv? (-poly (e) (-> (-set e) B))]
 [set-eq? (-poly (e) (-> (-set e) B))]
@@ -1220,31 +1221,31 @@
 [set->list (-poly (e) (-> (-set e) (-lst e)))]
 
 ;; Section 4.18 (Procedures)
-[procedure? (make-pred-ty top-func)]
-[compose (-poly (a b c) (-> (-> b c) (-> a b) (-> a c)))]
-[compose1 (-poly (a b c) (-> (-> b c) (-> a b) (-> a c)))]
+[procedure? (make-pred-ty top-func #t)]
+[compose (-poly (a b c) (-> (-> b c :T+ #f) (-> a b :T+ #f) (-> a c :T+ #f)))]
+[compose1 (-poly (a b c) (-> (-> b c :T+ #f) (-> a b :T+ #f) (-> a c :T+ #f)))]
 [procedure-rename (-poly (a) (-> (-Inter top-func a) -Symbol a))]
 [procedure->method (-poly (a)(-> (-Inter top-func a) a))]
 [procedure-closure-contents-eq? (-> top-func top-func -Boolean)]
 ;; keyword-apply - hard to give a type
 [procedure-arity (-> top-func (Un -Nat -Arity-At-Least (-lst (Un -Nat -Arity-At-Least))))]
-[procedure-arity? (make-pred-ty (Un -Nat -Arity-At-Least (-lst (Un -Nat -Arity-At-Least))))]
+[procedure-arity? (make-pred-ty (Un -Nat -Arity-At-Least (-lst (Un -Nat -Arity-At-Least))) #t)]
 [procedure-arity-includes? (->opt top-func -Nat [Univ] B)]
 [procedure-reduce-arity (-> top-func (Un -Nat -Arity-At-Least (-lst (Un -Nat -Arity-At-Least))) top-func)]
 [procedure-keywords (-> top-func (-values (list (-lst -Keyword) (-opt (-lst -Keyword)))))]
 
-[apply        (-poly (a b) (((list) a . ->* . b) (-lst a) . -> . b))]
-[new-apply-proc (-poly (a b) (((list) a . ->* . b) (-lst a) . -> . b))]
-[kernel:apply (-poly (a b) (((list) a . ->* . b) (-lst a) . -> . b))]
+[apply        (-poly (a b) (((list) a . ->* . b :T+ #f) (-lst a) . -> . b :T+ #f))]
+[new-apply-proc (-poly (a b) (((list) a . ->* . b :T+ #f) (-lst a) . -> . b :T+ #f))]
+[kernel:apply (-poly (a b) (((list) a . ->* . b :T+ #f) (-lst a) . -> . b :T+ #f))]
 [time-apply
  (-polydots (b a) (cl->*
-                   (-> (-> b) -Null (-values (list (-lst* b) -Nat -Nat -Nat)))
-                   (-> (->... '() (a a) b)
+                   (-> (-> b :T+ #f) -Null (-values (list (-lst* b) -Nat -Nat -Nat)))
+                   (-> (->... '() (a a) b :T+ #f)
                        (make-ListDots a 'a)
                        (-values (list (-lst* b) -Nat -Nat -Nat)))))]
 
 ;; Section 4.18.3 (racket/function)
-[identity (-poly (a) (->acc (list a) a null))]
+[identity (-poly (a) (->acc (list a) a null #:T+ #t))]
 [const (-poly (a) (-> a (->* '() Univ a)))]
 [negate (-polydots (a b c d)
           (cl->* (-> (-> c Univ : (-PS (-is-type 0 a) (-not-type 0 b)))
@@ -1263,14 +1264,14 @@
 ;; doesn't cover cases where we pass multiple of the function's arguments to curry,
 ;; also doesn't express that the returned function is itself curried
 [curry (-polydots (a c b)
-                  (cl->* ((->... (list a) (b b) c) a . -> . (->... '() (b b) c))
-                         ((->... (list a) (b b) c) . -> . (a . -> . (->... '() (b b) c)))))]
+                  (cl->* ((->... (list a) (b b) c :T+ #f) a . -> . (->... '() (b b) c :T+ #f))
+                         ((->... (list a) (b b) c :T+ #f) . -> . (a . -> . (->... '() (b b) c :T+ #f) :T+ #f))))]
 (primitive? (-> Univ B))
 (primitive-closure? (-> Univ B))
 
 ;; Sections 4.19 & 4.20 (Void and Undefined)
 [void (->* '() Univ -Void)]
-[void? (make-pred-ty -Void)]
+[void? (make-pred-ty -Void #t)]
 
 [unsafe-undefined -Unsafe-Undefined]
 
@@ -1298,21 +1299,21 @@
         Univ]
        (-values (list (-poly (a) (-struct-property a #f)) (-> Univ B) (-> Univ Univ))))]
 
-[struct-type-property? (make-pred-ty (-struct-property -Bottom #f))]
+[struct-type-property? (make-pred-ty (-struct-property -Bottom #f) #t)]
 [struct-type-property-accessor-procedure? (-> Univ B)]
 [struct-type-property-predicate-procedure? (->opt Univ [(-opt (-struct-property -Bottom #f))] B)]
 
 ;; Section 5.6 (Structure Utilities)
 [struct->vector (Univ . -> . (-vec Univ))]
 [struct? (-> Univ -Boolean)]
-[struct-type? (make-pred-ty -StructTypeTop)]
+[struct-type? (make-pred-ty -StructTypeTop #t)]
 
 ;; Section 6.2 (Classes)
 [object% (-class)]
 
 ;; Section 6.11 (Object, Class, and Interface Utilities)
-[object? (make-pred-ty (-object))]
-[class? (make-pred-ty -ClassTop)]
+[object? (make-pred-ty (-object) #t)]
+[class? (make-pred-ty -ClassTop #t)]
 ;; TODO: interface?
 ;;       generic?
 [object=? (-> (-object) (-object) -Boolean)]
@@ -1331,7 +1332,7 @@
 ;; TODO: class-info (is this sound to allow?)
 
 ;; Section 7.8 (Unit Utilities)
-[unit? (make-pred-ty -UnitTop)]
+[unit? (make-pred-ty -UnitTop #t)]
 
 ;; Section 9.1
 [exn:misc:match? (-> Univ B)]
@@ -1339,20 +1340,20 @@
 [match:error ((list) Univ . ->* . (Un))]
 ;[match:error (Univ . -> . (Un))]
 [match-equality-test (-Param (Univ Univ . -> . Univ) (Univ Univ . -> . Univ))]
-[matchable? (make-pred-ty (Un -String -Bytes))]
+[matchable? (make-pred-ty (Un -String -Bytes) #t)]
 [syntax-srclocs (Univ . -> . Univ)]
 
 ;; Section 10.1
 [values (-polydots (a b) (cl->*
                            (-> (-values null))
-                           (->acc (list a) a null)
+                           (->acc (list a) a null #:T+ #t)
                            ((list a) (b b) . ->... . (make-ValuesDots (list (-result a)) b 'b))
                            (->* (list) Univ ManyUniv)))]
 [call-with-values
   (-polydots (b a)
     (cl->*
-     ((-> (make-ValuesDots null a 'a)) (null (a a) . ->... . b) . -> .  b)
-     ((-> ManyUniv) ((list) Univ . ->* . b) . -> . b)))]
+     ((-> (make-ValuesDots null a 'a) :T+ #f) (null (a a) . ->... . b :T+ #f) . -> .  b :T+ #f)
+     ((-> ManyUniv) ((list) Univ . ->* . b :T+ #f) . -> . b :T+ #f)))]
 
 ;; Section 10.2
 [raise (cl->* ((Un -Flat -Exn) . -> . (Un))
@@ -1370,11 +1371,11 @@
 [raise-syntax-error (->optkey (-opt Sym) -String [Univ Univ (-lst (-Syntax Univ)) -String] #:exn (-> (-lst (-Syntax Univ)) -String -Cont-Mark-Set -Exn) #f (Un))]
 ;raise-argument-error, raise-type-error, etc. (in index)
 
-[unquoted-printing-string? (make-pred-ty -Unquoted-Printing-String)]
+[unquoted-printing-string? (make-pred-ty -Unquoted-Printing-String #t)]
 [unquoted-printing-string (-> -String -Unquoted-Printing-String)]
 [unquoted-printing-string-value (-> -Unquoted-Printing-String -String)]
 
-[call-with-exception-handler (-poly (a) (-> (-> Univ a) (-> a) a))]
+[call-with-exception-handler (-poly (a) (-> (-> Univ a :T+ #f) (-> a :T+ #f) a :T+ #f))]
 [uncaught-exception-handler (-Param (-> Univ ManyUniv) (-> Univ ManyUniv))]
 
 [error-escape-handler (-Param (-> ManyUniv) (-> ManyUniv))]
@@ -1386,14 +1387,14 @@
 
 ;; Section 10.2.5
 [prop:exn:srclocs (-struct-property (-> -Self (-lst -Srcloc)) #'exn:srclocs?)]
-[exn:srclocs? (make-pred-ty (-has-struct-property #'prop:exn:srclocs))]
+[exn:srclocs? (make-pred-ty (-has-struct-property #'prop:exn:srclocs) #t)]
 [exn:srclocs-accessor (-> Univ (-lst Univ))] ;TODO
 
 [srcloc->string (-> -Srcloc -String)]
 
 ;; Section 10.3 (Delayed Evaluation)
-[promise? (make-pred-ty (-Promise Univ))]
-[force (-poly (a) (->acc (list (-Promise a)) a (list -force)))]
+[promise? (make-pred-ty (-Promise Univ) #t)]
+[force (-poly (a) (->acc (list (-Promise a)) a (list -force) #:T+ #f))]
 [promise-forced? (-poly (a) (-> (-Promise a) B))]
 [promise-running? (-poly (a) (-> (-Promise a) B))]
 
@@ -1401,59 +1402,59 @@
 [call-with-continuation-prompt
  (-polydots (a b d c)
    (cl->*
-    (-> (-> b) (-Prompt-Tagof b (-> (-> d) d)) (Un b d))
-    (-> (-> b) (-Prompt-Tagof b (->... '() (c c) d)) (->... '() (c c) d)
-        (Un b d))
-    (-> (-> b) Univ)))]
+    (-> (-> b :T+ #f) (-Prompt-Tagof b (-> (-> d :T+ #f) d)) (Un b d) :T+ #f)
+    (-> (-> b :T+ #f) (-Prompt-Tagof b (->... '() (c c) d :T+ #f)) (->... '() (c c) d :T+ #f)
+        (Un b d) :T+ #f)
+    (-> (-> b :T+ #f) Univ)))]
 [abort-current-continuation
  (-polydots (a b d e c)
    (cl->*
-    (->... (list (-Prompt-Tagof b (->... '() (c c) d))) (c c) e)
-    (->... (list (-Prompt-Tagof b (->... '() (c c) ManyUniv))) (c c) e)))]
+    (->... (list (-Prompt-Tagof b (->... '() (c c) d :T+ #f))) (c c) e :T+ #f)
+    (->... (list (-Prompt-Tagof b (->... '() (c c) ManyUniv))) (c c) e :T+ #f)))]
 [make-continuation-prompt-tag
  (-poly (a b) (->opt [Sym] (-Prompt-Tagof a b)))]
 ;; default-continuation-prompt-tag is defined in "base-contracted.rkt"
 [call-with-current-continuation
  (-polydots (a b c)
-   (cl->* (->opt (-> (-> (Un)) (-values null)) (-Prompt-TagTop) (-values null))
+   (cl->* (->opt (-> (-> (Un)) (-values null)) (-Prompt-TagTop) (-values null) :T+ #f)
           (->opt (-> (->... (list a) (c c) (Un))
-                     (make-ValuesDots (list (-result b)) c 'c))
+                     (make-ValuesDots (list (-result b)) c 'c) :T+ #f)
                  (-Prompt-TagTop)
-                 (make-ValuesDots (list (-result (Un a b))) c 'c))))]
+                 (make-ValuesDots (list (-result (Un a b))) c 'c) :T+ #f)))]
 [call/cc
  (-polydots (a b c)
-   (cl->* (->opt (-> (-> (Un)) (-values null)) (-Prompt-TagTop) (-values null))
+   (cl->* (->opt (-> (-> (Un)) (-values null)) (-Prompt-TagTop) (-values null) :T+ #f)
           (->opt (-> (->... (list a) (c c) (Un))
-                     (make-ValuesDots (list (-result b)) c 'c))
+                     (make-ValuesDots (list (-result b)) c 'c) :T+ #f)
                  (-Prompt-TagTop)
-                 (make-ValuesDots (list (-result (Un a b))) c 'c))))]
+                 (make-ValuesDots (list (-result (Un a b))) c 'c) :T+ #f)))]
 [call-with-composable-continuation
  (-polydots (b c a)
    (-> ;; takes a continuation and should return the same
        ;; type as the continuation's input type
-       (-> (->... '() (a a) b) (make-ValuesDots '() a 'a))
+       (-> (->... '() (a a) b :T+ #f) (make-ValuesDots '() a 'a) :T+ #f)
        (-Prompt-Tagof b c)
        ;; the continuation's input is the same as the
        ;; return type here
-       (make-ValuesDots '() a 'a)))]
+       (make-ValuesDots '() a 'a) :T+ #f))]
 [call-with-escape-continuation
  (-polydots (a b c)
-   (cl->* (-> (-> (-> (Un)) (-values null)) (-values null))
+   (cl->* (-> (-> (-> (Un)) (-values null)) (-values null) :T+ #f)
           (-> (-> (->... (list a) (c c) (Un))
-                  (make-ValuesDots (list (-result b)) c 'c))
-              (make-ValuesDots (list (-result (Un a b))) c 'c))))]
+                  (make-ValuesDots (list (-result b)) c 'c) :T+ #f)
+              (make-ValuesDots (list (-result (Un a b))) c 'c) :T+ #f)))]
 [call/ec
  (-polydots (a b c)
-   (cl->* (-> (-> (-> (Un)) (-values null)) (-values null))
+   (cl->* (-> (-> (-> (Un)) (-values null)) (-values null) :T+ #f)
           (-> (-> (->... (list a) (c c) (Un))
-                  (make-ValuesDots (list (-result b)) c 'c))
-              (make-ValuesDots (list (-result (Un a b))) c 'c))))]
-[call-with-continuation-barrier (-poly (a) (-> (-> a) a))]
+                  (make-ValuesDots (list (-result b)) c 'c) :T+ #f)
+              (make-ValuesDots (list (-result (Un a b))) c 'c) :T+ #f)))]
+[call-with-continuation-barrier (-poly (a) (-> (-> a :T+ #f) a :T+ #f))]
 [continuation-prompt-available? (-> -Prompt-TagTop B)]
 [continuation?
- (asym-pred Univ B (-PS (-is-type 0 top-func) -tt))]
-[continuation-prompt-tag? (make-pred-ty -Prompt-TagTop)]
-[dynamic-wind (-poly (a) (-> (-> ManyUniv) (-> a) (-> ManyUniv) a))]
+ (asym-pred Univ B (-PS (-is-type 0 top-func) -tt) #t)]
+[continuation-prompt-tag? (make-pred-ty -Prompt-TagTop #t)]
+[dynamic-wind (-poly (a) (-> (-> ManyUniv) (-> a :T+ #f) (-> ManyUniv) a :T+ #f))]
 
 ;; Section 10.5 (Continuation Marks)
 ;; continuation-marks needs type for continuations as other
@@ -1482,15 +1483,15 @@
  (-poly (a b)
         (cl->*
          (-> (-opt -Cont-Mark-Set) (-Continuation-Mark-Keyof a)
-             (-opt a))
+             (-opt a) :T+ #f)
          (->opt (-opt -Cont-Mark-Set) (-Continuation-Mark-Keyof a)
                 [b -Prompt-TagTop]
-                (Un a b))
+                (Un a b) :T+ #f)
          (->opt (-opt -Cont-Mark-Set) Univ [Univ -Prompt-TagTop] Univ)))]
 [call-with-immediate-continuation-mark
- (-poly (a) (->opt Univ (-> Univ a) [Univ] a))]
-[continuation-mark-key? (make-pred-ty -Continuation-Mark-KeyTop)]
-[continuation-mark-set? (make-pred-ty -Cont-Mark-Set)]
+ (-poly (a) (->opt Univ (-> Univ a :T+ #f) [Univ] a :T+ #f))]
+[continuation-mark-key? (make-pred-ty -Continuation-Mark-KeyTop #t)]
+[continuation-mark-set? (make-pred-ty -Cont-Mark-Set #t)]
 [make-continuation-mark-key
  (-poly (a) (->opt [-Symbol] (-Continuation-Mark-Keyof a)))]
 [continuation-mark-set->context
@@ -1508,10 +1509,10 @@
 
 ;; Section 11.1.1
 [thread (-> (-> Univ) -Thread)]
-[thread? (make-pred-ty -Thread)]
+[thread? (make-pred-ty -Thread #t)]
 [current-thread (-> -Thread)]
 [thread/suspend-to-kill (-> (-> Univ) -Thread)]
-[call-in-nested-thread (-poly (a) (->opt (-> a) [-Custodian] a))]
+[call-in-nested-thread (-poly (a) (->opt (-> a :T+ #f) [-Custodian] a :T+ #f))]
 
 ;; Section 11.1.2
 [thread-suspend (-Thread . -> . -Void)]
@@ -1532,31 +1533,31 @@
 [thread-send
  (-poly (a) (cl->* (-> -Thread Univ -Void)
                    (-> -Thread Univ (-val #f) (-opt -Void))
-                   (-> -Thread Univ (-> a) (Un -Void a))))]
+                   (-> -Thread Univ (-> a :T+ #f) (Un -Void a) :T+ #f)))]
 [thread-receive (-> Univ)]
 [thread-try-receive (-> Univ)]
 [thread-receive-evt (-> (-mu x (-evt x)))]
 [thread-rewind-receive (-> (-lst Univ) -Void)]
 
 ;; Section 11.2.1
-[evt? (make-pred-ty (-evt Univ))]
-[sync (-poly (a) (->* '() (-evt a) a))]
+[evt? (make-pred-ty (-evt Univ) #t)]
+[sync (-poly (a) (->* '() (-evt a) a :T+ #f))]
 [sync/timeout
  (-poly (a b)
    (cl->*
-    (->* (list (-val #f)) (-evt a) a)
-    (->* (list -NonNegReal) (-evt a) (-opt a))
-    (->* (list (-> b)) (-evt a) (Un a b))))]
-[sync/enable-break (-poly (a) (->* '() (-evt a) a))]
+    (->* (list (-val #f)) (-evt a) a :T+ #f)
+    (->* (list -NonNegReal) (-evt a) (-opt a) :T+ #f)
+    (->* (list (-> b)) (-evt a) (Un a b) :T+ #f)))]
+[sync/enable-break (-poly (a) (->* '() (-evt a) a :T+ #f))]
 [sync/timeout/enable-break
  (-poly (a b)
    (cl->*
-    (->* (list (-val #f)) (-evt a) a)
-    (->* (list -NonNegReal) (-evt a) (-opt a))
-    (->* (list (-> b)) (-evt a) (Un a b))))]
+    (->* (list (-val #f)) (-evt a) a :T+ #f)
+    (->* (list -NonNegReal) (-evt a) (-opt a) :T+ #f)
+    (->* (list (-> b :T+ #f)) (-evt a) (Un a b) :T+ #f)))]
 [choice-evt (-poly (a) (->* '() (-evt a) (-evt a)))]
-[wrap-evt (-poly (a b) (-> (-evt a) (-> a b) (-evt b)))]
-[handle-evt (-poly (a b) (-> (-evt a) (-> a b) (-evt b)))]
+[wrap-evt (-poly (a b) (-> (-evt a) (-> a b :T+ #f) (-evt b)))]
+[handle-evt (-poly (a b) (-> (-evt a) (-> a b :T+ #f) (-evt b)))]
 [guard-evt (-poly (a) (-> (-> (-evt a)) (-evt a)))]
 [nack-guard-evt
  (-poly (a)
@@ -1568,50 +1569,50 @@
 [replace-evt (-poly (a b)
                (cl->*
                  (-> (-evt a) (-> a (-evt b)) (-evt b))
-                 (-> (-evt a) (-> a b) (-mu x (-evt x)))))]
+                 (-> (-evt a) (-> a b :T+ #f) (-mu x (-evt x)))))]
 [never-evt (-evt (Un))]
 [system-idle-evt (-> (-evt -Void))]
 [alarm-evt (-> -Real (-mu x (-evt x)))]
-[handle-evt? (asym-pred Univ B (-PS (-is-type 0 (-evt Univ)) -tt))]
+[handle-evt? (asym-pred Univ B (-PS (-is-type 0 (-evt Univ)) -tt) #t)]
 [prop:evt (-struct-property (Un (-evt Univ) (-> -Self ManyUniv) -Nat) #'evt?)]
 [current-evt-pseudo-random-generator
  (-Param -Pseudo-Random-Generator -Pseudo-Random-Generator)]
 
 ;; Section 11.2.2
 [make-channel (-poly (a) (-> (-channel a)))]
-[channel? (make-pred-ty -ChannelTop)]
-[channel-get (-poly (a) ((-channel a) . -> . a))]
-[channel-try-get (-poly (a) ((-channel a) . -> . (Un a (-val #f))))]
+[channel? (make-pred-ty -ChannelTop #t)]
+[channel-get (-poly (a) ((-channel a) . -> . a :T+ #f))]
+[channel-try-get (-poly (a) ((-channel a) . -> . (Un a (-val #f)) :T+ #f))]
 [channel-put (-poly (a) ((-channel a) a . -> . -Void))]
 [channel-put-evt (-poly (a) (-> (-channel a) a (-mu x (-evt x))))]
-[channel-put-evt? (asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt))]
+[channel-put-evt? (asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt) #t)]
 
 ;; Section 11.2.3 (Semaphores)
-[semaphore? (make-pred-ty -Semaphore)]
+[semaphore? (make-pred-ty -Semaphore #t)]
 [make-semaphore (->opt [-Nat] -Semaphore)]
 [semaphore-post (-> -Semaphore -Void)]
 [semaphore-wait (-> -Semaphore -Void)]
 [semaphore-try-wait? (-> -Semaphore B)]
 [semaphore-wait/enable-break (-> -Semaphore -Void)]
 [semaphore-peek-evt (-> -Semaphore (-mu x (-evt x)))]
-[semaphore-peek-evt? (asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt))]
+[semaphore-peek-evt? (asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt) #t)]
 [call-with-semaphore
  (-polydots (b a)
-   (cl->* (->... (list -Semaphore (->... '() [a a] b))
-                 [a a] b)
-          (->... (list -Semaphore (->... '() [a a] b) (-opt (-> b)))
-                 [a a] b)))]
+   (cl->* (->... (list -Semaphore (->... '() [a a] b :T+ #f))
+                 [a a] b :T+ #f)
+          (->... (list -Semaphore (->... '() [a a] b :T+ #f) (-opt (-> b)))
+                 [a a] b :T+ #f)))]
 [call-with-semaphore/enable-break
  (-polydots (b a)
-   (cl->* (->... (list -Semaphore (->... '() [a a] b))
-                 [a a] b)
-          (->... (list -Semaphore (->... '() [a a] b) (-opt (-> b)))
-                 [a a] b)))]
+   (cl->* (->... (list -Semaphore (->... '() [a a] b :T+ #f))
+                 [a a] b :T+ #f)
+          (->... (list -Semaphore (->... '() [a a] b :T+ #f) (-opt (-> b)))
+                 [a a] b :T+ #f)))]
 
 ;; Section 11.3.1 (Thread Cells)
-[thread-cell? (make-pred-ty -ThreadCellTop)]
+[thread-cell? (make-pred-ty -ThreadCellTop #t)]
 [make-thread-cell (-poly (a) (->opt a [Univ] (-thread-cell a)))]
-[thread-cell-ref (-poly (a) (-> (-thread-cell a) a))]
+[thread-cell-ref (-poly (a) (-> (-thread-cell a) a :T+ #f))]
 [thread-cell-set! (-poly (a) (-> (-thread-cell a) a -Void))]
 [current-preserved-thread-cell-values
  (cl->* (-> Univ) (-> Univ -Void))]
@@ -1623,27 +1624,27 @@
 [extend-parameterization (-poly (a b) (-> Univ (-Param a b) a Univ))]
 
 [make-parameter (-poly (a b) (cl-> [(a) (-Param a a)]
-                                   [(b (a . -> . b)) (-Param a b)]))]
-[make-derived-parameter (-poly (a b c d) (-> (-Param a b) (-> c a) (-> b d) (-Param c d)))]
-[parameter? (make-pred-ty (-Param -Bottom Univ))]
+                                   [(b (a . -> . b :T+ #f)) (-Param a b)]))]
+[make-derived-parameter (-poly (a b c d) (-> (-Param a b) (-> c a :T+ #f) (-> b d :T+ #f) (-Param c d)))]
+[parameter? (make-pred-ty (-Param -Bottom Univ) #t)]
 [parameter-procedure=? (-poly (a b c d) (-> (-Param a b) (-Param c d) B))]
 
 [current-parameterization (-> -Parameterization)]
-[call-with-parameterization (-poly (a) (-> -Parameterization (-> a) a))]
-[parameterization? (make-pred-ty -Parameterization)]
+[call-with-parameterization (-poly (a) (-> -Parameterization (-> a :T+ #f) a :T+ #f))]
+[parameterization? (make-pred-ty -Parameterization #t)]
 
 ;; Section 11.4 (Futures)
-[future (-poly (A) ((-> A) . -> . (-future A)))]
-[touch (-poly (A) ((-future A) . -> . A))]
+[future (-poly (A) ((-> A :T+ #f) . -> . (-future A)))]
+[touch (-poly (A) ((-future A) . -> . A :T+ #f))]
 [futures-enabled? (-> -Boolean)]
 [current-future (-> (-opt (-future Univ)))]
-[future? (make-pred-ty (-future Univ))]
-[would-be-future (-poly (A) ((-> A) . -> . (-future A)))]
+[future? (make-pred-ty (-future Univ) #t)]
+[would-be-future (-poly (A) ((-> A :T+ #f) . -> . (-future A)))]
 [processor-count (-> -PosInt)]
 
 ;; Section 11.4.2 (Future Semaphores)
 [make-fsemaphore (-> -Nat -FSemaphore)]
-[fsemaphore? (make-pred-ty -FSemaphore)]
+[fsemaphore? (make-pred-ty -FSemaphore #t)]
 [fsemaphore-post (-> -FSemaphore -Void)]
 [fsemaphore-wait (-> -FSemaphore -Void)]
 [fsemaphore-try-wait? (-> -FSemaphore B)]
@@ -1651,8 +1652,8 @@
 
 ;; Section 11.5 (Places)
 [place-enabled? (-> -Boolean)]
-[place? (make-pred-ty -Place)]
-[place-channel? (make-pred-ty -Place-Channel)]
+[place? (make-pred-ty -Place #t)]
+[place-channel? (make-pred-ty -Place-Channel #t)]
 ;; FIXME: the `#:at` keyword is for remote places, not supported yet
 [dynamic-place (->key (Un -Module-Path -Path) Sym
                       #:at (-val #f) #f
@@ -1679,7 +1680,7 @@
 ;; Section 12 (Macros)
 
 ;; Section 12.2
-[syntax? (make-pred-ty (-Syntax Univ))]
+[syntax? (make-pred-ty (-Syntax Univ) #t)]
 
 [syntax-source (-> (-Syntax Univ) Univ)]
 [syntax-line (-> (-Syntax Univ) (-opt -PosInt))]
@@ -1689,7 +1690,7 @@
 
 [syntax-original? (-poly (a) (-> (-Syntax a) B))]
 [syntax-source-module (->opt (-Syntax Univ) [Univ] (Un (-val #f) -Path Sym -Module-Path-Index))]
-[syntax-e (-poly (a) (->acc (list (-Syntax a)) a (list -syntax-e)))]
+[syntax-e (-poly (a) (->acc (list (-Syntax a)) a (list -syntax-e) #:T+ #f))]
 [syntax->list (-poly (a)
                 (cl->* (-> (-Syntax (-lst a)) (-lst a))
                        (-> (-Syntax Univ)
@@ -1722,7 +1723,7 @@
     (->opt ctxt Pre  [srcloc prop cert] A)
     (->opt ctxt Univ [srcloc prop cert] S)))]
 
-[identifier? (make-pred-ty (-Syntax Sym))]
+[identifier? (make-pred-ty (-Syntax Sym) #t)]
 
 [generate-temporaries (-> (Un (-Syntax (-lst Univ)) (-lst Univ)) (-lst (-Syntax Sym)))]
 [identifier-prune-lexical-context (->opt (-Syntax Sym) [(-lst Sym)] (-Syntax Sym))]
@@ -1782,7 +1783,7 @@
  (Ident . ->opt . [(Un -Int (-val #f))] -Symbol)]
 
 ;; Section 12.4
-[set!-transformer? (make-pred-ty (-has-struct-property #'prop:set!-transformer))]
+[set!-transformer? (make-pred-ty (-has-struct-property #'prop:set!-transformer) #t)]
 [make-set!-transformer (-> (-> (-Syntax Univ) (-Syntax Univ)) Univ)]
 [set!-transformer-procedure (-> Univ (-> (-Syntax Univ) (-Syntax Univ)))]
 [prop:set!-transformer (-struct-property (Un -Nat
@@ -1790,7 +1791,7 @@
                                                    [(-Self (-Syntax Univ)) (-Syntax Univ)]))
                                          #'set!-transformer?)]
 
-[rename-transformer? (make-pred-ty (-has-struct-property #'prop:rename-transformer))]
+[rename-transformer? (make-pred-ty (-has-struct-property #'prop:rename-transformer) #t)]
 [make-rename-transformer (->opt (-Syntax Sym) [(-> (-Syntax Sym) (-Syntax Sym))] Univ)]
 [rename-transformer-target (-> Univ (-Syntax Sym))]
 [prop:rename-transformer (-struct-property (Un -Nat (-Syntax Sym) (-> -Self (-Syntax Sym)))
@@ -1844,7 +1845,7 @@
          Univ]
         (-Syntax Univ))]
 
-[internal-definition-context? (make-pred-ty -Internal-Definition-Context)]
+[internal-definition-context? (make-pred-ty -Internal-Definition-Context #t)]
 [syntax-local-make-definition-context (->opt [(-opt -Internal-Definition-Context)] -Internal-Definition-Context)]
 [syntax-local-bind-syntaxes (-> (-lst (-Syntax Sym)) (-opt (-Syntax Univ)) -Internal-Definition-Context -Void)]
 [internal-definition-context-introduce
@@ -1917,9 +1918,9 @@
 [current-locale (-Param -String -String)]
 
 ;; Section 13.1.2
-[input-port? (make-pred-ty -Input-Port)]
-[output-port? (make-pred-ty -Output-Port)]
-[port? (make-pred-ty -Port)]
+[input-port? (make-pred-ty -Input-Port #t)]
+[output-port? (make-pred-ty -Output-Port #t)]
+[port? (make-pred-ty -Port #t)]
 
 [close-input-port (-> -Input-Port -Void)]
 [close-output-port (-> -Output-Port -Void)]
@@ -1931,11 +1932,11 @@
 [current-output-port (-Param -Output-Port -Output-Port)]
 [current-error-port (-Param -Output-Port -Output-Port)]
 
-[file-stream-port? (asym-pred Univ B (-PS (-is-type 0 -Port) -tt))]
-[terminal-port? (asym-pred Univ B (-PS (-is-type 0 -Port) -tt))]
+[file-stream-port? (asym-pred Univ B (-PS (-is-type 0 -Port) -tt) #t)]
+[terminal-port? (asym-pred Univ B (-PS (-is-type 0 -Port) -tt) #t)]
 
 [eof (-val eof)]
-[eof-object? (make-pred-ty (-val eof))]
+[eof-object? (make-pred-ty (-val eof) #t)]
 
 ;; Section 13.1.3
 [flush-output (->opt [-Output-Port] -Void)]
@@ -1975,28 +1976,28 @@
         (-values (list -Input-Port -Output-Port)))]
 
 
-[call-with-input-file (-poly (a) (-Pathlike (-Input-Port . -> . a) #:mode (Un (-val 'binary) (-val 'text)) #f . ->key .  a))]
-[call-with-output-file (-poly (a) (-Pathlike (-Output-Port . -> . a)
+[call-with-input-file (-poly (a) (-Pathlike (-Input-Port . -> . a :T+ #f) #:mode (Un (-val 'binary) (-val 'text)) #f . ->key .  a :T+ #f))]
+[call-with-output-file (-poly (a) (-Pathlike (-Output-Port . -> . a :T+ #f)
                                    #:exists (one-of/c 'error 'append 'update 'replace 'truncate 'truncate/replace) #f
                                    #:mode (one-of/c 'binary 'text) #f
-                                   . ->key .  a))]
+                                   . ->key .  a :T+ #f))]
 
-[call-with-input-file* (-poly (a) (-Pathlike (-Input-Port . -> . a) #:mode (Un (-val 'binary) (-val 'text)) #f . ->key .  a))]
-[call-with-output-file* (-poly (a) (-Pathlike (-Output-Port . -> . a)
+[call-with-input-file* (-poly (a) (-Pathlike (-Input-Port . -> . a :T+ #f) #:mode (Un (-val 'binary) (-val 'text)) #f . ->key .  a :T+ #f))]
+[call-with-output-file* (-poly (a) (-Pathlike (-Output-Port . -> . a :T+ #f)
                                    #:exists (one-of/c 'error 'append 'update 'replace 'truncate 'truncate/replace) #f
                                    #:mode (one-of/c 'binary 'text) #f
-                                   . ->key .  a))]
+                                   . ->key .  a :T+ #f))]
 
 [with-input-from-file
- (-poly (a) (->key -Pathlike (-> a) #:mode (one-of/c 'binary 'text) #f a))]
+ (-poly (a) (->key -Pathlike (-> a :T+ #f) #:mode (one-of/c 'binary 'text) #f a :T+ #f))]
 [with-output-to-file
- (-poly (a) (->key -Pathlike (-> a)
+ (-poly (a) (->key -Pathlike (-> a :T+ #f)
                    #:exists (one-of/c 'error 'append 'update 'can-update
                            'replace 'truncate
                            'must-truncate 'truncate/replace)
                    #f
                    #:mode (one-of/c 'binary 'text) #f
-                   a))]
+                   a :T+ #f))]
 |#
 
 [port-try-file-lock? (-> (Un -Input-Port -Output-Port) (one-of/c 'shared 'exclusive) B)]
@@ -2093,7 +2094,7 @@
 [port->list
  (-poly (a) (cl->*
              (-> (-lst Univ))
-             (->opt (-> -Input-Port a) [-Input-Port] (-lst a))))]
+             (->opt (-> -Input-Port a :T+ #f) [-Input-Port] (-lst a))))]
 [port->string (->optkey [-Input-Port] #:close? Univ #f -String)]
 [port->bytes  (->optkey [-Input-Port] #:close? Univ #f -Bytes)]
 
@@ -2108,15 +2109,15 @@
 
 [call-with-input-string
  (-polydots (a)
-   (-> -String (-> -Input-Port (make-ValuesDots '() a 'a))
-       (make-ValuesDots '() a 'a)))]
+   (-> -String (-> -Input-Port (make-ValuesDots '() a 'a) :T+ #f)
+       (make-ValuesDots '() a 'a) :T+ #f))]
 [call-with-input-bytes
  (-polydots (a)
-   (-> -Bytes (-> -Input-Port (make-ValuesDots '() a 'a))
-       (make-ValuesDots '() a 'a)))]
+   (-> -Bytes (-> -Input-Port (make-ValuesDots '() a 'a) :T+ #f)
+       (make-ValuesDots '() a 'a) :T+ #f))]
 
-[with-input-from-string (-poly (a) (-> -String (-> a) a))]
-[with-input-from-bytes (-poly (a) (-> -Bytes (-> a) a))]
+[with-input-from-string (-poly (a) (-> -String (-> a :T+ #f) a :T+ #f))]
+[with-input-from-bytes (-poly (a) (-> -Bytes (-> a :T+ #f) a :T+ #f))]
 
 ;; Section 13.1.10.2
 [input-port-append  (->* (list Univ) -Input-Port -Input-Port)]
@@ -2350,7 +2351,7 @@
 [pretty-print-show-inexactness (-Param Univ B)]
 [pretty-print-abbreviate-read-macros (-Param Univ B)]
 
-[pretty-print-style-table? (make-pred-ty -Pretty-Print-Style-Table)]
+[pretty-print-style-table? (make-pred-ty -Pretty-Print-Style-Table #t)]
 [pretty-print-current-style-table (-Param -Pretty-Print-Style-Table -Pretty-Print-Style-Table)]
 [pretty-print-extend-style-table (-> (-opt -Pretty-Print-Style-Table) (-lst Sym) (-lst Sym) -Pretty-Print-Style-Table)]
 [pretty-print-remap-stylable (-Param (-> Univ (-opt Sym)) (-> Univ (-opt Sym)))]
@@ -2372,7 +2373,7 @@
 ;; Section 13.7
 
 ;; Section 13.7.1
-[readtable? (make-pred-ty -Read-Table)]
+[readtable? (make-pred-ty -Read-Table #t)]
 [make-readtable
  (->* (list (-opt -Read-Table))
       (make-Rest
@@ -2405,14 +2406,14 @@
 ;; Nothing defined here
 
 ;; Section 13.7.3
-[special-comment? (make-pred-ty -Special-Comment)]
+[special-comment? (make-pred-ty -Special-Comment #t)]
 [make-special-comment (-> Univ -Special-Comment)]
 [special-comment-value (-> -Special-Comment Univ)]
 
 ;; Section 13.8
 [prop:custom-write (-struct-property (-> -Self -Output-Port (Un B (-val 1) (-val 0)) ManyUniv)
                                      #'custom-write?)]
-[custom-write? (make-pred-ty (-has-struct-property #'prop:custom-write))]
+[custom-write? (make-pred-ty (-has-struct-property #'prop:custom-write) #t)]
 [custom-write-accessor (-> (-has-struct-property #'prop:custom-write)
                            (-some-res (me) (-> me -Output-Port (Un B (-val 1) (-val 0)) ManyUniv) : #:+ me))]
 
@@ -2421,7 +2422,7 @@
                                                   (-val 'maybe)
                                                   (-val 'always))
                                               #'custom-print-quotable?)]
-[custom-print-quotable? (make-pred-ty (-has-struct-property #'prop:custom-print-quotable))]
+[custom-print-quotable? (make-pred-ty (-has-struct-property #'prop:custom-print-quotable) #t)]
 [custom-print-quotable-accessor (-> (-has-struct-property #'prop:custom-print-quotable)
                                     (Un (-val 'self)
                                         (-val 'never)
@@ -2438,13 +2439,13 @@
 [sha256-bytes (->opt (Un -Bytes -Input-Port) [-Nat (Un -Nat (-val #f))] -Bytes)]
 
 ;; Section 14.1 (Namespaces)
-[namespace? (make-pred-ty -Namespace)]
+[namespace? (make-pred-ty -Namespace #t)]
 [make-namespace (->opt [(one-of/c  'empty 'initial)] -Namespace)]
 [make-empty-namespace (-> -Namespace)]
 [make-base-empty-namespace (-> -Namespace)]
 [make-base-namespace (-> -Namespace)]
 
-[namespace-anchor? (make-pred-ty -Namespace-Anchor)]
+[namespace-anchor? (make-pred-ty -Namespace-Anchor #t)]
 [namespace-anchor->empty-namespace (-> -Namespace-Anchor -Namespace)]
 [namespace-anchor->namespace (-> -Namespace-Anchor -Namespace)]
 
@@ -2467,7 +2468,7 @@
 [namespace-syntax-introduce (-poly (a) (-> (-Syntax a) (-Syntax a)))]
 [module-provide-protected? (-> -Module-Path-Index Sym B)]
 
-[variable-reference? (make-pred-ty -Variable-Reference)]
+[variable-reference? (make-pred-ty -Variable-Reference #t)]
 [variable-reference->empty-namespace (-> -Variable-Reference -Namespace)]
 [variable-reference->namespace (-> -Variable-Reference -Namespace)]
 [variable-reference->resolved-module-path (-> -Variable-Reference (-opt -Resolved-Module-Path))]
@@ -2506,7 +2507,7 @@
 [current-compile (-Param (-> Univ B -Compiled-Expression) (-> Univ B -Compiled-Expression))]
 [compile (-> Univ -Compiled-Expression)]
 [compile-syntax (-> (-Syntax Univ) -Compiled-Expression)]
-[compiled-expression? (make-pred-ty -Compiled-Expression)]
+[compiled-expression? (make-pred-ty -Compiled-Expression #t)]
 
 [compile-enforce-module-constants (-Param B B)]
 [compile-allow-set!-undefined (-Param B B)]
@@ -2515,10 +2516,10 @@
 [load-on-demand-enabled (-Param B B)]
 
 ;; Section 14.4 (Module Names and Loading)
-[resolved-module-path? (make-pred-ty -Resolved-Module-Path)]
+[resolved-module-path? (make-pred-ty -Resolved-Module-Path #t)]
 [make-resolved-module-path (-> (Un -Symbol -Path) -Resolved-Module-Path)]
 [resolved-module-path-name (-> -Resolved-Module-Path (Un -Path -Symbol))]
-[module-path? (asym-pred Univ B (-PS (-is-type 0 -Module-Path) -tt))]
+[module-path? (asym-pred Univ B (-PS (-is-type 0 -Module-Path) -tt) #t)]
 
 [current-module-name-resolver (-Param (cl->* (-Resolved-Module-Path Univ . -> . Univ)
                                              ((Un -Module-Path -Path)
@@ -2536,7 +2537,7 @@
                                      (-opt -Resolved-Module-Path))]
 [current-module-declare-source (-Param (-opt (Un -Symbol -Path))
                                        (-opt (Un -Symbol -Path)))]
-[module-path-index? (make-pred-ty -Module-Path-Index)]
+[module-path-index? (make-pred-ty -Module-Path-Index #t)]
 [module-path-index-resolve (-> -Module-Path-Index -Resolved-Module-Path)]
 [module-path-index-split (-> -Module-Path-Index
                              (-values
@@ -2546,7 +2547,7 @@
 [module-path-index-join (-> (-opt -Module-Path)
                             (-opt (Un -Module-Path-Index -Resolved-Module-Path))
                             -Module-Path-Index)]
-[compiled-module-expression? (make-pred-ty -Compiled-Module-Expression)]
+[compiled-module-expression? (make-pred-ty -Compiled-Module-Expression #t)]
 [module-compiled-name (-> -Compiled-Module-Expression -Symbol)]
 [module-compiled-imports (-> -Compiled-Module-Expression
                              (-lst (-pair (-opt -Integer)
@@ -2583,14 +2584,14 @@
  (let ((mod (Un -Module-Path -Resolved-Module-Path -Module-Path-Index)))
   (-poly (a)
    (cl->* (-> mod (Un (one-of/c #f 0) -Void) -Void)
-          (-> mod (Un (one-of/c #f 0) -Void) (-> a) (Un -Void a))
+          (-> mod (Un (one-of/c #f 0) -Void) (-> a :T+ #f) (Un -Void a))
           (->opt mod Sym [(-> Univ)] Univ))))]
 
 [dynamic-require-for-syntax
  (let ((mod (Un -Module-Path -Resolved-Module-Path -Module-Path-Index)))
   (-poly (a)
    (cl->* (-> mod (-val #f) -Void)
-          (-> mod (-val #f) (-> a) (Un -Void a))
+          (-> mod (-val #f) (-> a :T+ #f) (Un -Void a))
           (->opt mod Sym [(-> Univ)] Univ))))]
 
 [module-declared?
@@ -2638,12 +2639,12 @@
 [chaperone-of? (Univ Univ . -> . B)]
 
 [make-impersonator-property (-> Sym (-values (list -Impersonator-Property (-> Univ B) (-> Univ Univ))))]
-[impersonator-property? (make-pred-ty -Impersonator-Property)]
+[impersonator-property? (make-pred-ty -Impersonator-Property #t)]
 [impersonator-property-accessor-procedure? (-> Univ B)]
 [impersonator-prop:application-mark -Impersonator-Property]
 
 ;; Section 14.6 (Security Guards)
-[security-guard? (make-pred-ty -Security-Guard)]
+[security-guard? (make-pred-ty -Security-Guard #t)]
 [make-security-guard
  (->opt -Security-Guard
         (-> Sym (-opt -Path) (-lst Sym) ManyUniv)
@@ -2653,7 +2654,7 @@
 [current-security-guard (-Param -Security-Guard -Security-Guard)]
 
 ;; Section 14.7 (Custodians)
-[custodian? (make-pred-ty -Custodian)]
+[custodian? (make-pred-ty -Custodian #t)]
 [make-custodian (->opt [-Custodian] -Custodian)]
 [custodian-shutdown-all (-> -Custodian -Void)]
 [current-custodian (-Param -Custodian -Custodian)]
@@ -2663,16 +2664,16 @@
 [custodian-limit-memory (->opt -Custodian -Nat [-Custodian] -Void)]
 
 [make-custodian-box (-poly (a) (-> -Custodian a (-CustodianBox a)))]
-[custodian-box? (make-pred-ty (-poly (a) (-CustodianBox a)))]
-[custodian-box-value (-poly (a) (-> (-CustodianBox a) a))]
+[custodian-box? (make-pred-ty (-poly (a) (-CustodianBox a)) #t)]
+[custodian-box-value (-poly (a) (-> (-CustodianBox a) a :T+ #f))]
 
 ;; Section 14.8 (Thread Groups)
 [make-thread-group (->opt [-Thread-Group] -Thread-Group)]
-[thread-group? (make-pred-ty -Thread-Group)]
+[thread-group? (make-pred-ty -Thread-Group #t)]
 [current-thread-group (-Param -Thread-Group -Thread-Group)]
 
 ;; Section 14.9 (Structure Inspectors)
-[inspector? (make-pred-ty -Inspector)]
+[inspector? (make-pred-ty -Inspector #t)]
 [make-inspector (->opt [-Inspector] -Inspector)]
 [make-sibling-inspector (->opt [-Inspector] -Inspector)]
 [current-inspector (-Param -Inspector -Inspector)]
@@ -2692,7 +2693,7 @@
 [struct-type-make-predicate
  (-poly (a)
    (cl->*
-    (-> (make-StructType a) (make-pred-ty a))
+    (-> (make-StructType a) (make-pred-ty a #t))
     (-> -StructTypeTop (-> Univ B))))]
 [object-name (-> Univ Univ)]
 
@@ -2700,11 +2701,11 @@
 [current-code-inspector (-Param -Inspector -Inspector)]
 
 ;; Section 15.1 (Path Manipulation)
-[path? (make-pred-ty -Path)]
+[path? (make-pred-ty -Path #t)]
 [path-string? (asym-pred Univ B
                          (-PS (-is-type 0 (Un -Path -String))
-                              (-not-type 0 -Path)))]
-[path-for-some-system? (make-pred-ty -SomeSystemPath)]
+                              (-not-type 0 -Path)) #t)]
+[path-for-some-system? (make-pred-ty -SomeSystemPath #t)]
 
 [string->path (-> -String -Path)]
 [bytes->path (cl->* (-> -Bytes -Path) (-> -Bytes -PathConventionType -SomeSystemPath))]
@@ -2821,8 +2822,8 @@
    (cl->* (-Pathlike . -> . -NonNegFixnum)
           (-Pathlike (-val #f) . -> . -NonNegFixnum)
           (-Pathlike -Nat . -> . -Void)
-          (-Pathlike (-val #f) (-> a) . -> . (Un a -NonNegFixnum))
-          (-Pathlike -Nat (-> a) . -> . (Un a -Void))))]
+          (-Pathlike (-val #f) (-> a :T+ #f) . -> . (Un a -NonNegFixnum) :T+ #f)
+          (-Pathlike -Nat (-> a :T+ #f) . -> . (Un a -Void) :T+ #f)))]
 
 
 [file-or-directory-permissions
@@ -2849,10 +2850,10 @@
 [filesystem-root-list (-> (-lst -Path))]
 
 ;; Section 15.2.4
-[filesystem-change-evt? (asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt))]
+[filesystem-change-evt? (asym-pred Univ B (-PS (-is-type 0 (-mu x (-evt x))) -tt) #t)]
 [filesystem-change-evt-cancel (-> (-mu x (-evt x)) -Void)]
 [filesystem-change-evt (-poly (a) (cl->* (-> -Pathlike (-mu x (-evt x)))
-                                         (-> -Pathlike (-> a) (Un (-mu x (-evt x)) a))))]
+                                         (-> -Pathlike (-> a :T+ #f) (Un (-mu x (-evt x)) a))))]
 
 ;; Section 15.2.5 (racket/file)
 [copy-directory/files (->key -Pathlike -Pathlike
@@ -2873,9 +2874,9 @@
 [fold-files
  (-poly
   (a)
-  (let ([funarg* (-Path (one-of/c 'file 'dir 'link) a . -> . (-values (list a Univ)))]
-        [funarg (-Path (one-of/c 'file 'dir 'link) a . -> . a)])
-     ((Un funarg funarg*) a [(-opt -Pathlike) Univ]. ->opt . a)))]
+  (let ([funarg* (-Path (one-of/c 'file 'dir 'link) a . -> . (-values (list a Univ)) :T+ #f)]
+        [funarg (-Path (one-of/c 'file 'dir 'link) a . -> . a :T+ #f)])
+     ((Un funarg funarg*) a [(-opt -Pathlike) Univ]. ->opt . a :T+ #f)))]
 
 [make-directory* (-> -Pathlike -Void)]
 [make-parent-directory* (-> -Pathlike -Void)]
@@ -2905,7 +2906,7 @@
 
 [tcp-accept-ready? (-TCP-Listener . -> . B)]
 [tcp-close (-TCP-Listener . -> . -Void)]
-[tcp-listener? (make-pred-ty -TCP-Listener)]
+[tcp-listener? (make-pred-ty -TCP-Listener #t)]
 
 [tcp-accept-evt
  (-> -TCP-Listener
@@ -2916,7 +2917,7 @@
                 ((Un -TCP-Listener -Port) [(-val #f)] . ->opt . (-values (list -String -String)))
                 ((Un -TCP-Listener -Port) (-val #t) . -> . (-values (list -String -Index -String -Index))))]
 
-[tcp-port? (asym-pred Univ B (-PS (-is-type 0 (Un -Input-Port -Output-Port)) -tt))]
+[tcp-port? (asym-pred Univ B (-PS (-is-type 0 (Un -Input-Port -Output-Port)) -tt) #t)]
 [port-number? (Univ . -> . B)]
 [listen-port-number? (Univ . -> . B)]
 
@@ -2937,7 +2938,7 @@
 [udp-receive!/enable-break (->opt -UDP-Socket -Bytes [-Int -Int] (-values (list -Nat -String -Nat)))]
 
 [udp-close (-> -UDP-Socket -Void)]
-[udp? (make-pred-ty -UDP-Socket)]
+[udp? (make-pred-ty -UDP-Socket #t)]
 [udp-bound? (-> -UDP-Socket B)]
 [udp-connected? (-> -UDP-Socket B)]
 
@@ -3006,7 +3007,7 @@
 [subprocess-status (-> -Subprocess (Un (-val 'running) -Nat))]
 [subprocess-kill (-> -Subprocess Univ -Void)]
 [subprocess-pid (-> -Subprocess -Nat)]
-[subprocess? (make-pred-ty -Subprocess)]
+[subprocess? (make-pred-ty -Subprocess #t)]
 [current-subprocess-custodian-mode (-Param (one-of/c #f 'kill 'interrupt)
                                            (one-of/c #f 'kill 'interrupt))]
 [subprocess-group-enabled (-Param Univ B)]
@@ -3140,7 +3141,7 @@
 	      (-lst* (-opt -Input-Port) (-opt -Output-Port) -Nat (-opt -Input-Port) fun-type))))))]
 
 ;; Section 15.5 (Logging)
-[logger? (make-pred-ty -Logger)]
+[logger? (make-pred-ty -Logger #t)]
 [make-logger (->opt [(-opt Sym) (-opt -Logger)] -Logger)]
 [logger-name (-> -Logger (-opt Sym))]
 [current-logger (-Param -Logger -Logger)]
@@ -3149,23 +3150,23 @@
                     (->opt -Logger -Log-Level (Un (-val #f) -Symbol) -String Univ [Univ] -Void))]
 [log-level? (->opt -Logger -Log-Level [(-opt -Symbol)] B)]
 
-[log-receiver? (make-pred-ty -Log-Receiver)]
+[log-receiver? (make-pred-ty -Log-Receiver #t)]
 [make-log-receiver (opt-fn (list -Logger -Log-Level) (list (-opt -Symbol)) -Log-Receiver #:rest (make-Rest (list -Log-Level (-opt -Symbol))))]
 
 ;; Section 15.5.4 (Additional Logging Functions, racket/logging)
-[log-level/c (make-pred-ty (one-of/c 'none 'fatal 'error 'warning 'info 'debug))]
+[log-level/c (make-pred-ty (one-of/c 'none 'fatal 'error 'warning 'info 'debug) #t)]
 [with-intercepted-logging
  (-polydots (a)
    (->* (list (-> (-vec* -Symbol -String Univ (-opt -Symbol)) Univ)
-              (-> (make-ValuesDots null a 'a)))
+              (-> (make-ValuesDots null a 'a) :T+ #f))
         (-opt (one-of/c 'none 'fatal 'error 'warning 'info 'debug))
-        (make-ValuesDots null a 'a)))]
+        (make-ValuesDots null a 'a) :T+ #f))]
 [with-logging-to-port
  (-polydots (a)
-   (->* (list -Output-Port (-> (make-ValuesDots null a 'a))
+   (->* (list -Output-Port (-> (make-ValuesDots null a 'a) :T+ #f)
               (one-of/c 'none 'fatal 'error 'warning 'info 'debug))
         (-opt -Symbol)
-        (make-ValuesDots null a 'a)))]
+        (make-ValuesDots null a 'a) :T+ #f))]
 
 ;; Section 15.6 (Time)
 [seconds->date (cl->* (-Real . -> . -Date)
@@ -3178,15 +3179,15 @@
  (->opt [(Un (-val #f) (-val 'subprocesses) -Thread)] -Fixnum)]
 
 ;; Section 15.7
-[environment-variables? (make-pred-ty -Environment-Variables)]
+[environment-variables? (make-pred-ty -Environment-Variables #t)]
 [current-environment-variables (-Param -Environment-Variables)]
-[bytes-environment-variable-name? (asym-pred Univ B (-PS (-is-type 0 -Bytes) -tt))]
+[bytes-environment-variable-name? (asym-pred Univ B (-PS (-is-type 0 -Bytes) -tt) #t)]
 [make-environment-variables (->* null -Bytes -Environment-Variables)]
 [environment-variables-ref (-> -Environment-Variables -Bytes (-opt -Bytes))]
 [environment-variables-set! (->opt -Environment-Variables -Bytes (-opt -Bytes) [(-> Univ)] Univ)]
 [environment-variables-names (-> -Environment-Variables  (-lst -Bytes))]
 [environment-variables-copy (-> -Environment-Variables -Environment-Variables)]
-[string-environment-variable-name? (asym-pred Univ B (-PS (-is-type 0 -String) -tt))]
+[string-environment-variable-name? (asym-pred Univ B (-PS (-is-type 0 -String) -tt) #t)]
 [getenv (-> -String (Un -String (-val #f)))]
 [putenv (-> -String -String B)]
 
@@ -3228,30 +3229,30 @@
                                    (-lst Univ))
                             (-pair label-sym
                                    (-lst -String))))
-                  (->... (list (-lst Univ)) [-String a] b)
+                  (->... (list (-lst Univ)) [-String a] b :T+ #f)
                   (-lst -String)
                   [(-> -String Univ)
                    ;; Still permits unknown-proc args that accept rest arguments
                    (-> -String Univ)]
-                  b))))]
+                  b :T+ #f))))]
 
 ;; Section 16.1 (Weak Boxes)
 [make-weak-box (-poly (a) (-> a (-weak-box a)))]
 [weak-box-value
  (-poly (a b)
-   (cl->* (-> (-weak-box a) (-opt a))
-          (-> (-weak-box a) b (Un b a))
+   (cl->* (-> (-weak-box a) (-opt a) :T+ #f)
+          (-> (-weak-box a) b (Un b a) :T+ #f)
           (->opt -Weak-BoxTop [Univ] Univ)))]
-[weak-box? (make-pred-ty -Weak-BoxTop)]
+[weak-box? (make-pred-ty -Weak-BoxTop #t)]
 
 ;; Section 16.2 (Ephemerons)
 [make-ephemeron (-poly (k v) (-> k v (-Ephemeron v)))]
-[ephemeron? (make-pred-ty (-Ephemeron Univ))]
-[ephemeron-value (-poly (v) (-> (-Ephemeron v) (Un (-val #f) v)))]
+[ephemeron? (make-pred-ty (-Ephemeron Univ) #t)]
+[ephemeron-value (-poly (v) (-> (-Ephemeron v) (Un (-val #f) v) :T+ #f))]
 
 ;; Section 16.3 (Wills and Executors)
 [make-will-executor (-> -Will-Executor)]
-[will-executor? (make-pred-ty -Will-Executor)]
+[will-executor? (make-pred-ty -Will-Executor #t)]
 [will-register (-poly (a) (-> -Will-Executor a (-> a ManyUniv) -Void))]
 [will-execute (-> -Will-Executor ManyUniv)]
 [will-try-execute (-> -Will-Executor ManyUniv)]
@@ -3273,12 +3274,12 @@
 ;; Section 17.2 (Unsafe Data Extraction)
 [unsafe-car (-poly (a b)
                    (cl->*
-                    (->acc (list (-pair a b)) a (list -car))
-                    (->* (list (-lst a)) a)))]
+                    (->acc (list (-pair a b)) a (list -car) #:T+ #f)
+                    (->* (list (-lst a)) a :T+ #f)))]
 [unsafe-cdr (-poly (a b)
                    (cl->*
-                    (->acc (list (-pair a b)) b (list -cdr))
-                    (->* (list (-lst a)) (-lst a))))]
+                    (->acc (list (-pair a b)) b (list -cdr) #:T+ #f)
+                    (->* (list (-lst a)) (-lst a) :T+ #f)))]
 [unsafe-vector-length (-VectorTop . -> . -Index)]
 [unsafe-vector*-length (-VectorTop . -> . -Index)]
 [unsafe-struct-ref top-func]
@@ -3289,8 +3290,8 @@
 [unsafe-fxvector-ref (-FxVector -Fixnum . -> . -Fixnum)]
 
 ;; Section 17.4 (Unsafe Undefined)
-[check-not-unsafe-undefined (-poly (a) (-> a -Symbol a))]
-[check-not-unsafe-undefined/assign (-poly (a) (-> a -Symbol a))]
+[check-not-unsafe-undefined (-poly (a) (-> a -Symbol a :T+ #f))]
+[check-not-unsafe-undefined/assign (-poly (a) (-> a -Symbol a :T+ #f))]
 
 ;; Section 18.2 (Libraries and Collections)
 [find-library-collection-paths (->opt [(-lst -Pathlike) (-lst -Pathlike)] (-lst -Path))]
@@ -3299,7 +3300,7 @@
  (-poly (a)
         (cl->*
          (->optkey -Pathlike -Pathlike [] #:rest -Pathlike #:check-compiled? Univ #f -Path)
-         (->optkey -Pathlike -Pathlike [] #:rest -Pathlike #:fail (-String . -> . a) #f #:check-compiled? Univ #f (Un a -Path))))]
+         (->optkey -Pathlike -Pathlike [] #:rest -Pathlike #:fail (-String . -> . a :T+ #f) #f #:check-compiled? Univ #f (Un a -Path) :T+ #f)))]
 [collection-path (->* (list) -Pathlike -Path)]
 [current-library-collection-paths (-Param (-lst -Path) (-lst -Path))]
 [current-library-collection-links
@@ -3311,8 +3312,8 @@
 ;; Typed Racket Reference
 ;; Section 4
 [assert (-poly (a b) (cl->*
-                      (Univ (make-pred-ty (list a) Univ b) . -> . b)
-                      (-> (Un a (-val #f)) a)))]
+                      (Univ (make-pred-ty (list a) Univ b #t) . -> . b :T+ #f)
+                      (-> (Un a (-val #f)) a :T+ #f)))]
 [defined? (->* (list Univ) -Boolean : (-PS (-not-type 0 -Undefined) (-is-type 0 -Undefined)))]
 
 ;; Syntax Manual
@@ -3386,9 +3387,9 @@
  (-poly (a)
   (cl->*
    (->optkey -Pathlike [(-> -Input-Port (Un))] #:mode (one-of/c 'binary 'text) #f (-lst Univ))
-   (->optkey -Pathlike [(-> -Input-Port a)] #:mode (one-of/c 'binary 'text) #f (-lst a)))))
+   (->optkey -Pathlike [(-> -Input-Port a :T+ #f)] #:mode (one-of/c 'binary 'text) #f (-lst a)))))
 [call-with-atomic-output-file
- (-poly (a) (->opt -Pathlike (-> -Output-Port -Path a) [(-opt -Security-Guard)] a))]
+ (-poly (a) (->opt -Pathlike (-> -Output-Port -Path a :T+ #f) [(-opt -Security-Guard)] a :T+ #f))]
 (get-preference
  (let ((use-lock-type Univ)
        (timeout-lock-there-type (-opt (-> -Path Univ)))
@@ -3460,8 +3461,8 @@
   (->key
    (-opt -Pathlike)
    (one-of/c 'shared 'exclusive)
-   (-> a)
-   (-> a)
+   (-> a :T+ #f)
+   (-> a :T+ #f)
    #:lock-file
    (-opt -Pathlike)
    #f
@@ -3471,49 +3472,49 @@
    #:max-delay
    -Real
    #f
-   a)))
+   a :T+ #f)))
 (sort
  (-poly
   (a b)
   (cl->*
-   (->key (-lst a) (-> a a -Boolean) #:key (-opt (-> a a)) #f #:cache-keys? -Boolean #f (-lst a))
-   (->key (-lst a) (-> b b -Boolean) #:key (-> a b) #t #:cache-keys? -Boolean #f (-lst a)))))
+   (->key (-lst a) (-> a a -Boolean) #:key (-opt (-> a a :T+ #f)) #f #:cache-keys? -Boolean #f (-lst a))
+   (->key (-lst a) (-> b b -Boolean) #:key (-> a b :T+ #f) #t #:cache-keys? -Boolean #f (-lst a)))))
 (vector-sort
  (-poly
   (a b)
   (cl->*
-   (->optkey (-vec a) (-> a a -Boolean) [-Integer (-opt -Integer)] #:key (-opt (-> a a)) #f #:cache-keys? -Boolean #f (-vec a))
-   (->optkey (-vec a) (-> b b -Boolean) [-Integer (-opt -Integer)] #:key (-> a b) #t #:cache-keys? -Boolean #f (-vec a)))))
+   (->optkey (-vec a) (-> a a -Boolean) [-Integer (-opt -Integer)] #:key (-opt (-> a a :T+ #f)) #f #:cache-keys? -Boolean #f (-vec a))
+   (->optkey (-vec a) (-> b b -Boolean) [-Integer (-opt -Integer)] #:key (-> a b :T+ #f) #t #:cache-keys? -Boolean #f (-vec a)))))
 (vector-sort!
  (-poly
   (a b)
   (cl->*
-   (->optkey (-vec a) (-> a a -Boolean) [-Integer (-opt -Integer)] #:key (-opt (-> a a)) #f #:cache-keys? -Boolean #f -Void)
-   (->optkey (-vec a) (-> b b -Boolean) [-Integer (-opt -Integer)] #:key (-> a b) #t #:cache-keys? -Boolean #f -Void))))
+   (->optkey (-vec a) (-> a a -Boolean) [-Integer (-opt -Integer)] #:key (-opt (-> a a :T+ #f)) #f #:cache-keys? -Boolean #f -Void)
+   (->optkey (-vec a) (-> b b -Boolean) [-Integer (-opt -Integer)] #:key (-> a b :T+ #f) #t #:cache-keys? -Boolean #f -Void))))
 (check-duplicates
  (-poly
   (a b c)
   (cl->*
    (->optkey (-lst a) ((-> a a Univ))
-             #:key (-> a a) #f
-             (-opt a))
+             #:key (-> a a :T+ #f) #f
+             (-opt a) :T+ #f)
    (->optkey (-lst a) ((-> b b Univ))
-             #:key (-> a b) #f
-             (-opt a))
+             #:key (-> a b :T+ #f) #f
+             (-opt a) :T+ #f)
    (->optkey (-lst a) ((-> a a Univ))
-             #:key (-> a a) #f
-             #:default (-> c) #f
-             (Un a c))
+             #:key (-> a a :T+ #f) #f
+             #:default (-> c :T+ #f) #f
+             (Un a c) :T+ #f)
    (->optkey (-lst a) ((-> b b Univ))
-             #:key (-> a b) #f
-             #:default (-> c) #f
-             (Un a c)))))
+             #:key (-> a b :T+ #f) #f
+             #:default (-> c :T+ #f) #f
+             (Un a c) :T+ #f))))
 (remove-duplicates
  (-poly
   (a b)
   (cl->*
-   (->optkey (-lst a) ((-> a a Univ)) #:key (-opt (-> a a)) #f (-lst a))
-   (->optkey (-lst a) ((-> b b Univ)) #:key (-opt (-> a b)) #f (-lst a)))))
+   (->optkey (-lst a) ((-> a a Univ)) #:key (-opt (-> a a :T+ #f)) #f (-lst a))
+   (->optkey (-lst a) ((-> b b Univ)) #:key (-opt (-> a b :T+ #f)) #f (-lst a)))))
 (open-input-file (->key -Pathlike
                         #:mode (one-of/c 'binary 'text) #f
                         #:for-module? Univ #f
@@ -3541,12 +3542,12 @@
   #f
   (-values (list -Input-Port -Output-Port))))
 (call-with-input-file
-    (-poly (a) (->key -Pathlike (-> -Input-Port a) #:mode (Un (-val 'binary) (-val 'text)) #f a)))
+    (-poly (a) (->key -Pathlike (-> -Input-Port a :T+ #f) #:mode (Un (-val 'binary) (-val 'text)) #f a :T+ #f)))
 (call-with-output-file
     (-poly (a)
      (->key
       -Pathlike
-      (-> -Output-Port a)
+      (-> -Output-Port a :T+ #f)
       #:exists
       (one-of/c 'error 'append 'update 'replace 'truncate 'truncate/replace 'can-update 'must-truncate)
       #f
@@ -3556,14 +3557,14 @@
       #:permissions
       -Nat
       #f
-      a)))
-(call-with-input-file* (-poly (a) (->key -Pathlike (-> -Input-Port a) #:mode (Un (-val 'binary) (-val 'text)) #f a)))
+      a :T+ #f)))
+(call-with-input-file* (-poly (a) (->key -Pathlike (-> -Input-Port a :T+ #f) #:mode (Un (-val 'binary) (-val 'text)) #f a :T+ #f)))
 (call-with-output-file*
  (-poly
   (a)
   (->key
    -Pathlike
-   (-> -Output-Port a)
+   (-> -Output-Port a :T+ #f)
    #:exists
    (one-of/c 'error 'append 'update 'replace 'truncate 'truncate/replace 'can-update 'must-truncate)
    #f
@@ -3573,14 +3574,14 @@
    #:permissions
    -Nat
    #f
-   a)))
-(with-input-from-file (-poly (a) (->key -Pathlike (-> a) #:mode (Un (-val 'binary) (-val 'text)) #f a)))
+   a :T+ #f)))
+(with-input-from-file (-poly (a) (->key -Pathlike (-> a :T+ #f) #:mode (Un (-val 'binary) (-val 'text)) #f a :T+ #f)))
 (with-output-to-file
     (-poly
      (a)
      (->key
       -Pathlike
-      (-> a)
+      (-> a :T+ #f)
       #:exists
       (one-of/c 'error 'append 'update 'can-update 'replace 'truncate 'must-truncate 'truncate/replace)
       #f
@@ -3590,7 +3591,7 @@
       #:permissions
       -Nat
       #f
-   a)))
+   a :T+ #f)))
 (port->lines
  (->optkey [-Input-Port]
            #:line-mode (one-of/c 'linefeed 'return 'return-linefeed 'any 'any-one) #f

--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -28,7 +28,7 @@
   (syntax-binding-set->syntax s what))
 
 
-(define-initial-env initialize-special
+(define-initial-env initialize-special #:default-T+ #true
   ;; make-promise
   [(make-template-identifier 'lazy 'racket/private/promise)
    (-poly (a)
@@ -91,7 +91,7 @@
           (let ([seq-vals
                  (lambda (a b)
                    (-values (list
-                             (-> Univ (-values-dots (list a) b 'b))
+                             (-> Univ (-values-dots (list a) b 'b) :T+ #true)
                              (Un (-> Univ Univ) (-val #f))
                              (-> Univ Univ)
                              Univ
@@ -386,5 +386,5 @@
        (-opt -Input-Port) (-opt -Output-Port) (-opt -Output-Port) -Place)]
   [(make-template-identifier 'start-place 'racket/place)
    (-> -Symbol -Module-Path -Symbol (-opt -Input-Port) (-opt -Output-Port) (-opt -Output-Port) -Place)]
-  [(make-template-identifier '-mlist 'compatibility/mlist)
-   (-poly (a) (->* (list) a (-mlst a)))])
+   [(make-template-identifier '-mlist 'compatibility/mlist)
+    (-poly (a) (->* (list) a (-mlst a)))])

--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -665,16 +665,10 @@
                                                        (id-drop orig-sels orig-muts num-fields)))
                                            (struct-info-list new-sels new-muts)))))))
 
-                         #,(ignore
-                             ;; bg: provide the static struct info directly, unlike other define-syntax forms
-                             ;; this is similar to the struct quad code in `typecheck/provide-handling.rkt`
-                             ;; TODO need this? sound? leave it to #1078 close #926 ?
-                             #'(begin
-                                 (define-syntax nm
-                                   (if id-is-ctor?
-                                     (make-struct-info-wrapper* #'internal-maker si #'type)
-                                     si))
-                                 (provide nm)))
+                         (define-syntax nm
+                              (if id-is-ctor?
+                                  (make-struct-info-wrapper* #'internal-maker si #'type)
+                                  si))
 
                          (dtsi* (tvar ...) spec type (body ...) #:maker maker-name)
                          #,(ignore

--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -391,7 +391,7 @@
                [else (quasisyntax/loc (car types) (U #,@types))])))
      `#s(contract-def ,type-stx ,flat? ,maker? typed ,te-mode))))
 
-(define-values [define-predicate]
+(define define-predicate
   (let ()
     (define (dp-maker te-mode)
       (define/with-syntax m-p (case te-mode ((shallow) #'make-predicate-shallow) ((optional) #'make-predicate-optional) (else #'make-predicate)))
@@ -412,7 +412,7 @@
             #;(dp-maker shallow)
             #;(dp-maker optional))))
 
-(define-values [make-predicate]
+(define make-predicate
   (let ()
     (define (mp-maker te-mode)
       (syntax-parser

--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -17,9 +17,16 @@
 ;;   implementations of the forms
 
 
-(provide require/opaque-type require-typed-struct-legacy require-typed-struct
-         require/typed-legacy require/typed require/typed/provide
-         require-typed-struct/provide core-cast make-predicate define-predicate
+(provide require/opaque-type require/opaque-type-shallow require/opaque-type-optional
+         require-typed-struct-legacy require-typed-struct-legacy-shallow require-typed-struct-legacy-optional
+         require-typed-struct require-typed-struct-shallow require-typed-struct-optional
+         require/typed-legacy require/typed-legacy-shallow require/typed-legacy-optional
+         require/typed require/typed-shallow require/typed-optional
+         require/typed/provide require/typed/provide-shallow require/typed/provide-optional
+         require-typed-struct/provide require-typed-struct/provide-shallow require-typed-struct/provide-optional
+         core-cast core-cast-shallow core-cast-optional
+         make-predicate
+         define-predicate
          require-typed-signature)
 
 (module forms racket/base
@@ -54,6 +61,71 @@
       [(_ e ty) (quasisyntax/loc stx (#%expression #,(syntax/loc stx (-core-cast e ty))))]))
   (provide cast))
 
+;; copied from `forms`
+(module forms-shallow racket/base
+  (require (for-syntax racket/lazy-require racket/base))
+  (begin-for-syntax
+    (lazy-require [(submod "..")
+                   (require/opaque-type-shallow
+                    (require-typed-signature require-typed-signature-shallow)
+                    require-typed-struct-legacy-shallow
+                    require-typed-struct-shallow
+                    require/typed-legacy-shallow
+                    require/typed-shallow
+                    require/typed/provide-shallow
+                    require-typed-struct/provide-shallow
+                    core-cast-shallow)]))
+  (define-syntax (def stx)
+    (syntax-case stx ()
+      [(_ id ...)
+       (with-syntax ([(names ...) (generate-temporaries #'(id ...))])
+         #'(begin (provide (rename-out [names id] ...))
+                  (define-syntax (names stx) (id stx)) ...))]))
+  (def require/opaque-type-shallow
+       require-typed-signature-shallow
+       require-typed-struct-legacy-shallow
+       require-typed-struct-shallow
+       require/typed-legacy-shallow require/typed-shallow require/typed/provide-shallow
+       require-typed-struct/provide-shallow)
+  (define-syntax (-core-cast-shallow stx) (core-cast-shallow stx))
+  (define-syntax (cast-shallow stx)
+    (syntax-case stx ()
+      [(_ e ty) (quasisyntax/loc stx (#%expression #,(syntax/loc stx (-core-cast-shallow e ty))))]))
+  (provide cast-shallow))
+
+;; copied from `forms`
+(module forms-optional racket/base
+  (require (for-syntax racket/lazy-require racket/base))
+  (begin-for-syntax
+    (lazy-require [(submod "..")
+                   (require/opaque-type-optional
+                    (require-typed-signature require-typed-signature-optional)
+                    require-typed-struct-legacy-optional
+                    require-typed-struct-optional
+                    require/typed-legacy-optional
+                    require/typed-optional
+                    require/typed/provide-optional
+                    require-typed-struct/provide-optional
+                    core-cast-optional)]))
+  (define-syntax (def stx)
+    (syntax-case stx ()
+      [(_ id ...)
+       (with-syntax ([(names ...) (generate-temporaries #'(id ...))])
+         #'(begin (provide (rename-out [names id] ...))
+                  (define-syntax (names stx) (id stx)) ...))]))
+  (def require/opaque-type-optional
+       require-typed-signature-optional
+       require-typed-struct-legacy-optional
+       require-typed-struct-optional
+       require/typed-legacy-optional require/typed-optional require/typed/provide-optional
+       require-typed-struct/provide-optional)
+  (define-syntax (-core-cast-optional stx) (core-cast-optional stx))
+  (define-syntax (cast-optional stx)
+    (syntax-case stx ()
+      [(_ e ty) (quasisyntax/loc stx (#%expression #,(syntax/loc stx (-core-cast-optional e ty))))]))
+  (provide cast-optional))
+
+
 ;; unsafe operations go in this submodule
 (module* unsafe #f
   ;; turned into a macro on the requiring side
@@ -63,7 +135,10 @@
 ;; *do not export*
 (define-syntax unsafe-kw (syntax-rules ()))
 
-(require (for-template (submod "." forms) "../utils/require-contract.rkt"
+(require (for-template (submod "." forms)
+                       (submod "." forms-shallow)
+                       (submod "." forms-optional)
+                       "../utils/require-contract.rkt"
                        (submod "../typecheck/internal-forms.rkt" forms)
                        "colon.rkt"
                        "top-interaction.rkt"
@@ -82,8 +157,9 @@
          racket/struct-info
          syntax/struct
          syntax/location
+         (only-in syntax/srcloc build-source-location-list)
          "../utils/require-contract.rkt"
-         (for-template "../utils/any-wrap.rkt")
+         (for-template "../utils/any-wrap.rkt" "../utils/shallow-contract.rkt")
          "../utils/tc-utils.rkt"
          "../private/syntax-properties.rkt"
          "../private/cast-table.rkt"
@@ -120,7 +196,15 @@
   #:datum-literals (:)
   (pattern [field:id : type]))
 
-(define-values (require/typed-legacy require/typed unsafe-require/typed)
+(define (require/contract-maker te-mode)
+  (case te-mode
+    ((shallow) #'require/contract-shallow)
+    ((optional) #'require/contract-optional)
+    (else #'require/contract)))
+
+(define-values (require/typed-legacy require/typed-legacy-shallow require/typed-legacy-optional
+                require/typed require/typed-shallow require/typed-optional
+                unsafe-require/typed)
  (let ()
   (define-syntax-class opt-rename
     #:attributes (nm orig-nm spec)
@@ -170,28 +254,34 @@
     (pattern [(~or (~datum opaque) #:opaque) opaque ty:id pred:id #:name-exists]
              #:with opt #'(#:name-exists)))
 
-  (define-syntax-class (clause legacy unsafe? lib)
+  (define-syntax-class (clause legacy unsafe? te-mode lib)
    #:attributes (spec)
-   (pattern oc:opaque-clause #:attr spec
-     #`(require/opaque-type oc.ty oc.pred #,lib #,@(if unsafe? #'(unsafe-kw) #'()) . oc.opt))
-   (pattern (~var strc (struct-clause legacy)) #:attr spec
-     #`(require-typed-struct strc.nm (strc.tvar ...)
-                             (strc.body ...) strc.constructor-parts ...
-                             #:type-name strc.type
-                             #,@(if unsafe? #'(unsafe-kw) #'())
-                             #,lib))
+   (pattern oc:opaque-clause
+     #:with r/ot/te-mode (case te-mode ((shallow) #'require/opaque-type-shallow) ((optional) #'require/opaque-type-optional) (else #'require/opaque-type))
+     #:attr spec
+     #`(r/ot/te-mode oc.ty oc.pred #,lib #,@(if unsafe? #'(unsafe-kw) #'()) . oc.opt))
+   (pattern (~var strc (struct-clause legacy))
+     #:with rts/te-mode (case te-mode ((shallow) #'require-typed-struct-shallow) ((optional) #'require-typed-struct-optional) (else #'require-typed-struct))
+     #:attr spec
+     #`(rts/te-mode strc.nm (strc.tvar ...)
+                    (strc.body ...) strc.constructor-parts ...
+                    #:type-name strc.type
+                    #,@(if unsafe? #'(unsafe-kw) #'())
+                    #,lib))
    (pattern sig:signature-clause #:attr spec
      (quasisyntax/loc #'sig (require-typed-signature sig.sig-name (sig.var ...) (sig.type ...) #,lib)))
-   (pattern sc:simple-clause #:attr spec
-     #`(require/typed #:internal sc.nm sc.ty #,lib
-                      #,@(if unsafe? #'(unsafe-kw) #'()))))
+   (pattern sc:simple-clause
+     #:with r/t/te-mode (case te-mode ((shallow) #'require/typed-shallow) ((optional) #'require/typed-optional) (else #'require/typed))
+     #:attr spec
+     #`(r/t/te-mode #:internal sc.nm sc.ty #,lib
+                    #,@(if unsafe? #'(unsafe-kw) #'()))))
 
 
-  (define ((r/t-maker legacy unsafe?) stx)
+  (define ((r/t-maker legacy unsafe? te-mode) stx)
     (unless (or (unbox typed-context?) (eq? (syntax-local-context) 'module-begin))
       (raise-syntax-error #f "only allowed in a typed module" stx))
     (syntax-parse stx
-      [(_ lib:expr (~var c (clause legacy unsafe? #'lib)) ...)
+      [(_ lib:expr (~var c (clause legacy unsafe? te-mode #'lib)) ...)
        (when (zero? (syntax-length #'(c ...)))
          (raise-syntax-error #f "at least one specification is required" stx))
        #`(begin c.spec ...)]
@@ -204,11 +294,12 @@
        (define/with-syntax sm (if (attribute parent)
                                   #'(#:struct-maker parent)
                                   #'()))
+       (define/with-syntax r/c/te-mode (require/contract-maker te-mode))
        (cond [(not (attribute unsafe?))
               ;; define `cnt*` to be fixed up later by the module type-checking
               (define cnt*
                 (syntax-local-lift-expression
-                 (make-contract-def-rhs #'ty #f (attribute parent))))
+                 (make-contract-def-rhs #'ty #f (attribute parent) te-mode)))
               (quasisyntax/loc stx
                 (begin
                   ;; register the identifier so that it has a binding (for top-level)
@@ -216,7 +307,7 @@
                          (list #'(define-syntaxes (hidden) (values)))
                          null)
                   #,(internal #'(require/typed-internal hidden ty . sm))
-                  #,(ignore #`(require/contract nm.spec hidden #,cnt* lib))))]
+                  #,(ignore #`(r/c/te-mode nm.spec hidden #,cnt* lib #,(format "~a" (syntax->datum #'ty))))))]
              [else
               (define/with-syntax hidden2 (generate-temporary #'nm.nm))
               (quasisyntax/loc stx
@@ -227,42 +318,51 @@
                   #,(ignore #'(define hidden2 hidden))
                   (rename-without-provide nm.nm hidden2 hidden)
                   #,(internal #'(require/typed-internal hidden2 ty . sm))))])]))
-  (values (r/t-maker #t #f) (r/t-maker #f #f) (r/t-maker #f #t))))
+  (values (r/t-maker #t #f deep) (r/t-maker #t #f shallow) (r/t-maker #t #f optional)
+          (r/t-maker #f #f deep) (r/t-maker #f #f shallow) (r/t-maker #f #f optional)
+          (r/t-maker #f #t deep))))
 
+(define-values [require/typed/provide require/typed/provide-shallow require/typed/provide-optional]
+  (let ()
+    (define ((rtp-maker te-mode) stx)
+      (unless (memq (syntax-local-context) '(module module-begin))
+        (raise-syntax-error 'require/typed/provide
+                            "can only be used at module top-level"))
+      (define/with-syntax r/t/p (case te-mode ((shallow) #'require/typed/provide-shallow) ((optional) #'require/typed/provide-optional) (else #'require/typed/provide)))
+      (define/with-syntax r/t (case te-mode ((shallow) #'require/typed-shallow) ((optional) #'require/typed-optional) (else #'require/typed)))
+      (syntax-parse stx
+        [(_ lib) #'(begin)]
+        [(_ lib [r:id t] other-clause ...)
+         #'(begin (r/t lib [r t])
+                  (provide r)
+                  (r/t/p lib other-clause ...))]
+        [(_ lib (~and clause [#:struct nm:opt-parent
+                                       (body:typed-field ...)
+                                       option ...])
+            other-clause ...)
+         #'(begin (r/t lib clause)
+                  (provide (struct-out nm.nm))
+                  (r/t/p lib other-clause ...))]
+        [(_ lib (~and clause [#:opaque t:id pred:id])
+            other-clause ...)
+         #'(begin (r/t lib clause)
+                  (provide t pred)
+                  (r/t/p lib other-clause ...))]))
 
-(define (require/typed/provide stx)
-  (unless (memq (syntax-local-context) '(module module-begin))
-    (raise-syntax-error 'require/typed/provide
-                        "can only be used at module top-level"))
-  (syntax-parse stx
-    [(_ lib) #'(begin)]
-    [(_ lib [r:id t] other-clause ...)
-     #'(begin (require/typed lib [r t])
-              (provide r)
-              (require/typed/provide lib other-clause ...))]
-    [(_ lib (~and clause [#:struct nm:opt-parent
-                                   (body:typed-field ...)
-                                   option ...])
-        other-clause ...)
-     #'(begin (require/typed lib clause)
-              (provide (struct-out nm.nm))
-              (require/typed/provide lib other-clause ...))]
-    [(_ lib (~and clause [#:opaque t:id pred:id])
-        other-clause ...)
-     #'(begin (require/typed lib clause)
-              (provide t pred)
-              (require/typed/provide lib other-clause ...))]))
+    (values (rtp-maker deep) (rtp-maker shallow) (rtp-maker optional))))
 
-
-
-(define require-typed-struct/provide
-  (syntax-rules ()
-    [(_ (nm par) . rest)
-     (begin (require-typed-struct (nm par) . rest)
-            (provide (struct-out nm)))]
-    [(_ nm . rest)
-     (begin (require-typed-struct nm . rest)
-            (provide (struct-out nm)))]))
+(define-values [require-typed-struct/provide require-typed-struct/provide-shallow require-typed-struct/provide-optional]
+  (let ()
+    (define (rtsp-maker te-mode)
+      (define/with-syntax r/t/s (case te-mode ((shallow) #'require-typed-struct-shallow) ((optional) #'require-typed-struct-optional) (else #'require-typed-struct)))
+      (syntax-rules ()
+        [(_ (nm par) . rest)
+         (begin (r/t/s (nm par) . rest)
+                (provide (struct-out nm)))]
+        [(_ nm . rest)
+         (begin (r/t/s nm . rest)
+                (provide (struct-out nm)))]))
+    (values (rtsp-maker 'guarder) (rtsp-maker 'shallow) (rtsp-maker 'optional))))
 
 ;; Conversion of types to contracts
 ;;  define-predicate
@@ -271,12 +371,12 @@
 
 ;; Helpers to construct syntax for contract definitions
 ;; make-contract-def-rhs : Type-Stx Boolean Boolean -> Syntax
-(define (make-contract-def-rhs type flat? maker?)
-  (define contract-def `#s(contract-def ,type ,flat? ,maker? untyped))
+(define (make-contract-def-rhs type flat? maker? te-mode)
+  (define contract-def `#s(contract-def ,type ,flat? ,maker? untyped ,te-mode))
   (contract-def-property #'#f (λ () contract-def)))
 
 ;; make-contract-def-rhs/from-typed : Id Boolean Boolean -> Syntax
-(define (make-contract-def-rhs/from-typed id flat? maker?)
+(define (make-contract-def-rhs/from-typed id flat? maker? te-mode)
   (contract-def-property
    #'#f
    ;; This function should only be called after the type-checking pass has finished.
@@ -289,68 +389,65 @@
          (cond [(not types) #f]
                [(null? (cdr types)) (car types)]
                [else (quasisyntax/loc (car types) (U #,@types))])))
-     `#s(contract-def ,type-stx ,flat? ,maker? typed))))
+     `#s(contract-def ,type-stx ,flat? ,maker? typed ,te-mode))))
 
+(define-values [define-predicate]
+  (let ()
+    (define (dp-maker te-mode)
+      (define/with-syntax m-p (case te-mode ((shallow) #'make-predicate-shallow) ((optional) #'make-predicate-optional) (else #'make-predicate)))
+      (lambda (stx)
+        (syntax-parse stx
+          [(_ name:id ty:expr)
+           #`(begin
+               ;; We want the value bound to name to have a nice object name. Using the built in mechanism
+               ;; of define has better performance than procedure-rename.
+               #,(ignore
+                  (syntax/loc stx
+                    (define name
+                      (let ([pred (m-p ty)])
+                        (lambda (x) (pred x))))))
+               ;; not a require, this is just the unchecked declaration syntax
+               #,(internal (syntax/loc stx (require/typed-internal name (Any -> Boolean : ty)))))])))
+    (values (dp-maker deep)
+            #;(dp-maker shallow)
+            #;(dp-maker optional))))
 
-(define (define-predicate stx)
-  (syntax-parse stx
-    [(_ name:id ty:expr)
-     #`(begin
-         ;; We want the value bound to name to have a nice object name. Using the built in mechanism
-         ;; of define has better performance than procedure-rename.
-         #,(ignore
-            (syntax/loc stx
-              (define name
-                (let ([pred (make-predicate ty)])
-                  (lambda (x) (pred x))))))
-         ;; not a require, this is just the unchecked declaration syntax
-         #,(internal (syntax/loc stx (require/typed-internal name (Any -> Boolean : ty)))))]))
+(define-values [make-predicate]
+  (let ()
+    (define (mp-maker te-mode)
+      (syntax-parser
+        [(_ ty:expr)
+         (define name (syntax-local-lift-expression
+                       (make-contract-def-rhs #'ty #t #f te-mode)))
+         (define (check-valid-type _)
+           (define type (parse-type #'ty))
+           (define vars (fv type))
+           ;; If there was an error don't create another one
+           (unless (or (Error? type) (null? vars))
+             (tc-error/delayed
+              "Type ~a could not be converted to a predicate because it contains free variables."
+              type)))
+         #`(#,(external-check-property #'#%expression check-valid-type)
+            #,(ignore-some/expr #`(flat-contract-predicate #,name) #'(Any -> Boolean : ty)))]))
+    (values (mp-maker deep)
+            #;(mp-maker shallow) 
+            #;(mp-maker optional))))
 
-
-(define (make-predicate stx)
-  (syntax-parse stx
-    [(_ ty:expr)
-     (define name (syntax-local-lift-expression
-                   (make-contract-def-rhs #'ty #t #f)))
-     (define (check-valid-type _)
-       (define type (parse-type #'ty))
-       (define vars (fv type))
-       ;; If there was an error don't create another one
-       (unless (or (Error? type) (null? vars))
-         (tc-error/delayed
-          "Type ~a could not be converted to a predicate because it contains free variables."
-          type)))
-     #`(#,(external-check-property #'#%expression check-valid-type)
-        #,(ignore-some/expr #`(flat-contract-predicate #,name) #'(Any -> Boolean : ty)))]))
-
-;; wrapped above in the `forms` submodule
-(define (core-cast stx)
-  (syntax-parse stx
-    [(_ v:expr ty:expr)
-     (define (apply-contract v ctc-expr pos neg)
-       #`(#%expression
-          #,(ignore-some/expr
-             #`(let-values (((val) #,(with-type* v #'Any)))
-                 #,(syntax-property
-                    (quasisyntax/loc stx
-                      (contract
-                       #,ctc-expr
-                       val
-                       '#,pos
-                       '#,neg
-                       #f
-                       (quote-srcloc #,stx)))
-                    'feature-profile:TR-dynamic-check #t))
-             #'ty)))
-
-     (cond [(not (unbox typed-context?)) ; no-check, don't check
+(define-values [core-cast core-cast-shallow core-cast-optional]
+  (let ()
+    (define ((cc-maker te-mode) stx)
+      (syntax-parse stx
+        [(_ v:expr ty:expr)
+         (cond
+           [(not (unbox typed-context?)) ; no-check, don't check
             #'v]
            [else
             (define new-ty-ctc (syntax-local-lift-expression
-                                (make-contract-def-rhs #'ty #f #f)))
+                                (make-contract-def-rhs #'ty #f #f te-mode)))
             (define existing-ty-id new-ty-ctc)
-            (define existing-ty-ctc (syntax-local-lift-expression
-                                     (make-contract-def-rhs/from-typed existing-ty-id #f #f)))
+            (define existing-ty-ctc
+              (syntax-local-lift-expression
+                (make-contract-def-rhs/from-typed existing-ty-id #f #f te-mode)))
             (define (store-existing-type existing-type)
               (check-no-free-vars existing-type #'v)
               (cast-table-add! existing-ty-id (datum->syntax #f existing-type #'v)))
@@ -365,48 +462,95 @@
                  #:stx stx
                  "Type ~a could not be converted to a contract because it contains free variables."
                  type)))
-            #`(#,(external-check-property #'#%expression check-valid-type)
-               #,(apply-contract
-                  (apply-contract
-                   #`(#,(casted-expr-property #'#%expression store-existing-type)
-                      v)
-                   existing-ty-ctc 'typed-world 'cast)
-                  new-ty-ctc 'cast 'typed-world))])]))
+            (define/with-syntax check-ty-expr (external-check-property #'#%expression check-valid-type))
+            (define/with-syntax store-ty-expr (casted-expr-property #'#%expression store-existing-type))
+            (case te-mode
+              [(shallow)
+               (define/with-syntax ty-str (format "~a" (syntax->datum #'ty))) ;;bg better to parse-type ?
+               ;; (printf "damn ~a ~s ~a~n" (syntax-line stx) stx (build-source-location-list stx))
+               (define/with-syntax ctx (build-source-location-list stx))
+               #`(check-ty-expr
+                  #,(ignore-some/expr
+                      #`(#%plain-app shallow-shape-check
+                                     (store-ty-expr v)
+                                     #,new-ty-ctc 'ty-str 'ctx)
+                      #'ty))]
+              [(optional)
+               #`(check-ty-expr
+                  #,(ignore-some/expr
+                      #`(store-ty-expr v)
+                      #'ty))]
+              [else
+               (define (apply-contract v ctc-expr pos neg)
+                 #`(#%expression
+                    #,(ignore-some/expr
+                       #`(let-values (((val) #,(with-type* v #'Any)))
+                           #,(syntax-property
+                              (quasisyntax/loc stx
+                                (contract
+                                 #,ctc-expr
+                                 val
+                                 '#,pos
+                                 '#,neg
+                                 #f
+                                 (quote-srcloc #,stx)))
+                              'feature-profile:TR-dynamic-check #t))
+                       #'ty)))
+               #`(check-ty-expr
+                  #,(apply-contract
+                     (apply-contract
+                      #`(store-ty-expr
+                         v)
+                      existing-ty-ctc 'typed-world 'cast)
+                     new-ty-ctc 'cast 'typed-world))])])]))
+    (values (cc-maker deep) (cc-maker shallow) (cc-maker optional))))
 
+(define-values [require/opaque-type require/opaque-type-shallow require/opaque-type-optional]
+  (let ()
+    (define-syntax-class unsafe-id
+      (pattern (~literal unsafe-kw)))
+    (define-syntax-class name-exists-kw
+      (pattern #:name-exists))
+    (define ((ro-maker te-mode) stx)
+      (syntax-parse stx
+        [_ #:when (eq? 'module-begin (syntax-local-context))
+           ;; it would be inconvenient to find the correct #%module-begin here, so we rely on splicing
+           #`(begin #,stx (begin))]
+        [(_ ty:id pred:id lib (~optional unsafe:unsafe-id) (~optional ne:name-exists-kw) ...)
+         (with-syntax ([hidden (generate-temporary #'pred)]
+                       [require/contract (require/contract-maker te-mode)]
+                       [default-ctc
+                         (case te-mode
+                           ((shallow)
+                            #'(procedure-arity-includes/c 1))
+                           ((optional)
+                            #'any/c)
+                           (else
+                            #'(or/c struct-predicate-procedure?/c
+                                    ((make-any-wrap-warning/c) . c-> . boolean?))))])
+           ;; this is needed because this expands to the contract directly without
+           ;; going through the normal `make-contract-def-rhs` function.
+           (set-box! include-extra-requires? #t)
+           (quasisyntax/loc stx
+             (begin
+               ;; register the identifier for the top-level (see require/typed)
+               #,@(if (eq? (syntax-local-context) 'top-level)
+                      (list #'(define-syntaxes (hidden) (values)))
+                      null)
+               #,(internal #'(require/typed-internal hidden (Any -> Boolean : (Opaque pred))))
+               #,(if (attribute ne)
+                     (internal (syntax/loc stx (define-type-alias-internal ty (Opaque pred))))
+                     (syntax/loc stx (define-type-alias ty (Opaque pred))))
+               #,(ignore
+                   (with-syntax ((ctc (if (attribute unsafe) ; unsafe- shouldn't generate contracts
+                                        #'any/c
+                                        #'default-ctc)))
+                     #'(define pred-cnt ctc)))
+               #,(ignore #`(require/contract pred hidden pred-cnt lib "(-> Any Boolean)")))))]))
+    (values (ro-maker deep) (ro-maker shallow) (ro-maker optional))))
 
-(define (require/opaque-type stx)
-  (define-syntax-class unsafe-id
-    (pattern (~literal unsafe-kw)))
-  (define-syntax-class name-exists-kw
-    (pattern #:name-exists))
-  (syntax-parse stx
-    [_ #:when (eq? 'module-begin (syntax-local-context))
-       ;; it would be inconvenient to find the correct #%module-begin here, so we rely on splicing
-       #`(begin #,stx (begin))]
-    [(_ ty:id pred:id lib (~optional unsafe:unsafe-id) (~optional ne:name-exists-kw) ...)
-     (with-syntax ([hidden (generate-temporary #'pred)])
-       ;; this is needed because this expands to the contract directly without
-       ;; going through the normal `make-contract-def-rhs` function.
-       (set-box! include-extra-requires? #t)
-       (quasisyntax/loc stx
-         (begin
-           ;; register the identifier for the top-level (see require/typed)
-           #,@(if (eq? (syntax-local-context) 'top-level)
-                  (list #'(define-syntaxes (hidden) (values)))
-                  null)
-           #,(internal #'(require/typed-internal hidden (Any -> Boolean : (Opaque pred))))
-           #,(if (attribute ne)
-                 (internal (syntax/loc stx (define-type-alias-internal ty (Opaque pred))))
-                 (syntax/loc stx (define-type-alias ty (Opaque pred))))
-           #,(if (attribute unsafe)
-                 (ignore #'(define pred-cnt any/c)) ; unsafe- shouldn't generate contracts
-                 (ignore #'(define pred-cnt
-                             (or/c struct-predicate-procedure?/c
-                                   (any-wrap-warning/c . c-> . boolean?)))))
-           #,(ignore #'(require/contract pred hidden pred-cnt lib)))))]))
-
-
-(define-values (require-typed-struct-legacy require-typed-struct)
+(define-values (require-typed-struct-legacy require-typed-struct-legacy-shallow require-typed-struct-legacy-optional
+                require-typed-struct require-typed-struct-shallow require-typed-struct-optional)
  (let ()
   (define-splicing-syntax-class (constructor-term legacy struct-name)
    (pattern (~seq) #:fail-when legacy #f #:attr name struct-name #:attr extra #f)
@@ -419,7 +563,7 @@
    (pattern (~seq) #:attr unsafe? #f)
    (pattern (~seq (~literal unsafe-kw)) #:attr unsafe? #t))
 
-  (define ((rts legacy) stx)
+  (define ((rts legacy te-mode) stx)
     (syntax-parse stx #:literals (:)
       [(_ name:opt-parent
           (~optional (~seq (tvar:id ...)) #:defaults ([(tvar 1) '()]))
@@ -458,7 +602,9 @@
                       ;; the struct type to use for the constructor/selectors
                       [self-type (if (null? (syntax->list #'(tvar ...)))
                                      #'type
-                                     #'poly-type)])
+                                     #'poly-type)]
+                      [r/t/te-mode (case te-mode ((shallow) #'require/typed-shallow) ((optional) #'require/typed-optional) (else #'require/typed))]
+                      [r/c/te-mode (require/contract-maker te-mode)])
                      (when (and (not (attribute unsafe.unsafe?))
                                 (pair? (syntax->list #'(tvar ...))))
                        (tc-error/stx stx "polymorphic structs are not supported"))
@@ -519,34 +665,51 @@
                                                        (id-drop orig-sels orig-muts num-fields)))
                                            (struct-info-list new-sels new-muts)))))))
 
-                         (define-syntax nm
-                              (if id-is-ctor?
-                                  (make-struct-info-wrapper* #'internal-maker si #'type)
-                                  si))
+                         #,(ignore
+                             ;; bg: provide the static struct info directly, unlike other define-syntax forms
+                             ;; this is similar to the struct quad code in `typecheck/provide-handling.rkt`
+                             ;; TODO need this? sound? leave it to #1078 close #926 ?
+                             #'(begin
+                                 (define-syntax nm
+                                   (if id-is-ctor?
+                                     (make-struct-info-wrapper* #'internal-maker si #'type)
+                                     si))
+                                 (provide nm)))
 
                          (dtsi* (tvar ...) spec type (body ...) #:maker maker-name)
-                         #,(ignore #'(require/contract pred hidden (or/c struct-predicate-procedure?/c (c-> any-wrap/c boolean?)) lib))
+                         #,(ignore
+                             (with-syntax ((pred-ctc
+                                            (case te-mode
+                                              ((deep)
+                                               #'(or/c struct-predicate-procedure?/c (c-> any-wrap/c boolean?)))
+                                              ((shallow)
+                                               ;; 2021-12-06 shallow could skip the result checks on a pred if it's a struct-predicate-procedure
+                                               #'(procedure-arity-includes/c 1))
+                                              (else
+                                               #'any/c))))
+                               #'(r/c/te-mode pred hidden pred-ctc lib "(-> Any Boolean)")))
                          #,(internal #`(require/typed-internal hidden (Any -> Boolean :
                                                                            #,(if (stx-null? #'(tvar ...))
                                                                                  #'type
                                                                                  #`(type #,@(stx-map (const (syntax Any)) #'(tvar ...)))))))
-                         (require/typed #:internal (maker-name real-maker) type lib
+                         (r/t/te-mode #:internal (maker-name real-maker) type lib
                                         #:struct-maker parent
                                         #,@(if (attribute unsafe.unsafe?) #'(unsafe-kw) #'()))
 
                          ;This needs to be a different identifier to meet the specifications
                          ;of struct (the id constructor shouldn't expand to it)
                          #,(if (syntax-e #'extra-maker)
-                               #`(require/typed #:internal (maker-name extra-maker) type lib
+                               #`(r/t/te-mode #:internal (maker-name extra-maker) type lib
                                                 #:struct-maker parent
                                                 #,@(if (attribute unsafe.unsafe?) #'(unsafe-kw) #'()))
                                #'(begin))
 
                          #,@(if (attribute unsafe.unsafe?)
-                                #'((require/typed #:internal sel (All (tvar ...) (self-type -> ty)) lib unsafe-kw) ...)
-                                #'((require/typed lib [sel (All (tvar ...) (self-type -> ty))]) ...)))))]))
+                                #'((r/t/te-mode #:internal sel (All (tvar ...) (self-type -> ty)) lib unsafe-kw) ...)
+                                #'((r/t/te-mode lib [sel (All (tvar ...) (self-type -> ty))]) ...)))))]))
 
-  (values (rts #t) (rts #f))))
+  (values (rts #t deep) (rts #t shallow) (rts #t optional)
+          (rts #f deep) (rts #f shallow) (rts #f optional))))
 
 (define (require-typed-signature stx)
   (syntax-parse stx

--- a/typed-racket-lib/typed-racket/core.rkt
+++ b/typed-racket-lib/typed-racket/core.rkt
@@ -21,11 +21,17 @@
          "standard-inits.rkt"
          "tc-setup.rkt")
 
-(provide mb-core ti-core wt-core)
+(provide mb-core ti-core wt-core wt-core-shallow wt-core-optional)
+
+(define-syntax-class type-enforcement-mode
+  (pattern #:deep)
+  (pattern #:shallow)
+  (pattern #:optional))
 
 (define (mb-core stx)
   (syntax-parse stx
-    [(mb (~or (~optional
+    [(mb (~or (~optional te-mode:type-enforcement-mode)
+              (~optional
                (~or (~and #:optimize    (~bind [opt? #'#t])); kept for backward compatibility
                     (~and #:no-optimize (~bind [opt? #'#f]))))
               (~optional
@@ -34,26 +40,43 @@
                (~and #:no-delay-errors no-delay-errors?)))
          ...
          forms ...)
-     (let ([pmb-form (syntax/loc stx (#%plain-module-begin forms ...))]
-           [delay-errors^? (or (not (attribute no-delay-errors?)) (delay-errors?))])
+     (let* ([pmb-form (syntax/loc stx (#%plain-module-begin forms ...))]
+            [te-attr (attribute te-mode)]
+            [te-mode (keyword->te-mode te-attr)]
+            [delay-errors^? (or (not (attribute no-delay-errors?)) (delay-errors?))])
        (parameterize ([optimize? (or (and (not (attribute opt?)) (optimize?))
                                      (and (attribute opt?) (syntax-e (attribute opt?))))]
-                      [with-refinements? (or (attribute refinement-reasoning?)
-                                             (with-refinements?))])
-         (tc-module/full stx pmb-form
+                      [with-refinements? (and (or (attribute refinement-reasoning?)
+                                                  (with-refinements?))
+                                              (when (not (eq? te-mode deep))
+                                                (raise-arguments-error
+                                                  (string->symbol (format "typed/racket/~a" (keyword->string (syntax-e te-attr))))
+                                                  "#:with-refinements unsupported")))])
+         (tc-module/full te-mode stx pmb-form
           (λ (new-mod pre-before-code pre-after-code)
+            (define ctc-cache (make-hash))
+            (define (change-contract-fixups/cache forms)
+              (change-contract-fixups forms ctc-cache))
+            (define (change-provide-fixups/cache forms)
+              (change-provide-fixups forms ctc-cache))
+            (define (shallow-rewrite/cache body-stx)
+              (define-values [extra-def* body+] (maybe-shallow-rewrite body-stx ctc-cache))
+              (when extra-def*
+                (set-box! include-extra-requires? #t))
+              (cons (or extra-def* '()) body+))
             (with-syntax*
              (;; pmb = #%plain-module-begin
               [(pmb . body2) new-mod]
               ;; perform the provide transformation from [Culpepper 07]
               [transformed-body (begin0 (remove-provides #'body2) (do-time "Removed provides"))]
+              [((before-rewritten-code ...) . rewritten-body) (shallow-rewrite/cache #'transformed-body)]
               ;; add the real definitions of contracts on requires
               [transformed-body
-               (begin0 (change-contract-fixups (syntax->list #'transformed-body))
+               (begin0 (change-contract-fixups/cache (syntax->list #'rewritten-body))
                        (do-time "Fixed contract ids"))]
               ;; add the real definitions of contracts on the before- and after-code
-              [(before-code ...) (change-provide-fixups (flatten-all-begins pre-before-code))]
-              [(after-code ...) (begin0 (change-provide-fixups (flatten-all-begins pre-after-code))
+              [(before-code ...) (change-provide-fixups/cache (flatten-all-begins pre-before-code))]
+              [(after-code ...) (begin0 (change-provide-fixups/cache (flatten-all-begins pre-after-code))
                                   (do-time "Generated contracts"))]
               ;; potentially optimize the code based on the type information
               [(optimized-body ...) (maybe-optimize #'transformed-body)] ;; has own call to do-time
@@ -65,22 +88,32 @@
                                   'disappeared-use (disappeared-use-todo))])
              ;; reconstruct the module with the extra code
              ;; use the regular %#module-begin from `racket/base' for top-level printing
-             (arm #`(#%module-begin 
+             (arm #`(#%module-begin
                      #,(if (unbox include-extra-requires?) extra-requires #'(begin))
-                     before-code ... optimized-body ... after-code ... check-syntax-help))))
+                     before-rewritten-code ... before-code ... optimized-body ... after-code ... check-syntax-help))))
           #:delay-errors? delay-errors^?)))]))
 
-(define (ti-core stx )
+(define (ti-core stx)
   (current-type-names (init-current-type-names))
   (syntax-parse stx
     #:literal-sets (kernel-literals)
     [(_ . (module . rest))
      #'(module . rest)]
-    [(_ . (~and form ((~var command (static interactive-command? #f)) . _)))
+    [(_ (~optional te:type-enforcement-mode) . (~and form ((~var command (static interactive-command? #f)) . _)))
      (do-standard-inits)
      ((interactive-command-procedure (attribute command.value)) #'form)]
-    [(_ . form)
+    [(_ (~optional te:type-enforcement-mode) . form)
+     (define te-mode (keyword->te-mode (attribute te)))
      ;; TODO(endobson): Remove the call to do-standard-inits when it is no longer necessary
      ;; Cast at the top-level still needs this for some reason
      (do-standard-inits)
-     (tc-toplevel/full stx #'form)]))
+     (tc-toplevel/full te-mode stx #'form)]))
+
+;; Decide how to enforce types at runtime
+(define (keyword->te-mode stx)
+  (case (syntax-e (or stx #'#:deep))
+    ((#:deep) deep)
+    ((#:shallow) shallow)
+    ((#:optional) optional)
+    (else (error (format "Internal Typed Racket Error: unknown type enforcement mode ~s~n" stx)))))
+

--- a/typed-racket-lib/typed-racket/env/global-env.rkt
+++ b/typed-racket-lib/typed-racket/env/global-env.rkt
@@ -51,7 +51,7 @@
            (define t* (if (box? t) (unbox t) t))
            (unless (equal? type t*)
              (tc-error/delayed #:stx id "Duplicate type annotation of ~a for ~a, previous was ~a" type (syntax-e id) t*)))]
-        [else (free-id-table-set! the-mapping id (box type))]))
+        [else (register-type id (box type))]))
 
 ;; add a bunch of types to the mapping
 ;; listof[id] listof[type] -> void
@@ -63,7 +63,7 @@
 ;; identifier -> type
 (define (lookup-type id [fail-handler (λ () (lookup-fail id))])
   (define v (free-id-table-ref the-mapping id fail-handler))
-  (cond [(box? v) (unbox v)] 
+  (cond [(box? v) (unbox v)]
         [(procedure? v) (define t (v)) (register-type id t) t]
         [else v]))
 

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -25,7 +25,7 @@
          "../types/struct-table.rkt"
          "../types/utils.rkt"
          data/queue
-         racket/private/dict racket/list racket/promise
+         racket/private/dict racket/list racket/promise racket/stxparam
          racket/match
          syntax/private/id-table
          syntax/id-set)
@@ -41,9 +41,11 @@
 
 (define-syntax (define-initial-env stx)
   (syntax-parse stx
-    [(_ initialize-env [id-expr ty] ...)
+    [(_ initialize-env #:default-T+ T+ [id-expr ty] ...)
      #`(begin
-         (define initial-env (make-env [id-expr (λ () ty)] ... ))
+         (define initial-env
+           (syntax-parameterize ([default-rng-shallow-safe? T+])
+             (make-env [id-expr (λ () ty)] ... )))
          (define (initialize-env) (initialize-type-env initial-env))
          (provide initialize-env))]))
 
@@ -51,7 +53,10 @@
   (for-each (lambda (nm/ty) (register-resolved-type-alias (car nm/ty) (cadr nm/ty))) initial-type-names))
 
 (define (initialize-type-env initial-env)
-  (for-each (lambda (nm/ty) (register-type-if-undefined (car nm/ty) (cadr nm/ty))) initial-env))
+  (define (init nm/ty/sh)
+    (define id (car nm/ty/sh))
+    (register-type-if-undefined id (cadr nm/ty/sh)))
+  (for-each init initial-env))
 
 ;; stores definition syntaxes for lifting out common expressions
 (define type-definitions (make-queue))
@@ -184,8 +189,8 @@
                            (Result: t
                                     (PropSet: (TrueProp:)
                                               (TrueProp:))
-                                    (Empty:)))))))
-     `(simple-> (list ,@(map type->sexp dom)) ,(type->sexp t))]
+                                    (Empty:)))) rng-T+)))
+     `(simple-> (list ,@(map type->sexp dom)) ,(type->sexp t) #:T+ ,rng-T+)]
     [(Fun: (list (Arrow: dom #f'()
                          (Values:
                           (list
@@ -193,11 +198,12 @@
                                     (PropSet:
                                      (TypeProp: pth ft)
                                      (NotTypeProp: pth ft))
-                                    (Empty:)))))))
+                                    (Empty:)))) rng-T+)))
      `(make-pred-ty (list ,@(map type->sexp dom))
                     ,(type->sexp t)
                     ,(type->sexp ft)
-                    ,(object->sexp pth))]
+                    ,(object->sexp pth)
+                    ,rng-T+)]
     [(Fun: (list (Arrow: dom #f '()
                          (Values:
                           (list
@@ -207,20 +213,22 @@
                                                    (== -False))
                                      (TypeProp: (Path: pth (cons 0 0))
                                                 (== -False)))
-                                    (Path: pth (cons 0 0))))))))
+                                    (Path: pth (cons 0 0))))) rng-T+)))
      `(->acc (list ,@(map type->sexp dom))
              ,(type->sexp t)
-             (list ,@(map path-elem->sexp pth)))]
+             (list ,@(map path-elem->sexp pth))
+             #:T+ ,rng-T+)]
     [(Fun: (? has-optional-args? arrs))
-     (match-define (Arrow: fdoms _ kws rng) (first arrs))
-     (match-define (Arrow: ldoms rst _ _) (last arrs))
+     (match-define (Arrow: fdoms _ kws rng _) (first arrs))
+     (match-define (Arrow: ldoms rst _ _ _) (last arrs))
      (define opts (drop ldoms (length fdoms)))
      `(opt-fn
        (list ,@(map type->sexp fdoms))
        (list ,@(map type->sexp opts))
        ,(type->sexp rng)
        ,@(if rst `(#:rest ,(type->sexp rst)) '())
-       ,@(if (null? kws) '() `(#:kws (list ,@(map type->sexp kws)))))]
+       ,@(if (null? kws) '() `(#:kws (list ,@(map type->sexp kws))))
+       #:T+ ,(andmap Arrow-rng-shallow-safe? arrs))]
     [(Fun: arrs) `(make-Fun (list ,@(map type->sexp arrs)))]
     [(DepFun: dom pre rng)
      `(make-DepFun (list ,@(map type->sexp dom))
@@ -338,18 +346,21 @@
     [(Arrow: dom #f '()
              (Values: (list (Result: t (PropSet: (TrueProp:)
                                                  (TrueProp:))
-                                     (Empty:)))))
+                                     (Empty:)))) rng-T+)
      `(-Arrow (list ,@(map type->sexp dom))
-              ,(type->sexp t))]
-    [(Arrow: dom #f '() rng)
+              ,(type->sexp t)
+              #:T+ ,rng-T+)]
+    [(Arrow: dom #f '() rng rng-T+)
      `(-Arrow (list ,@(map type->sexp dom))
-              ,(type->sexp rng))]
-    [(Arrow: dom rest kws rng)
+              ,(type->sexp rng)
+              #:T+ ,rng-T+)]
+    [(Arrow: dom rest kws rng rng-T+)
      `(make-Arrow
        (list ,@(map type->sexp dom))
        ,(and rest (type->sexp rest))
        (list ,@(map type->sexp kws))
-       ,(type->sexp rng))]
+       ,(type->sexp rng)
+       ,rng-T+)]
     [(Rest: tys )
      `(make-Rest (list ,@(map type->sexp tys)))]
     [(RestDots: ty db)
@@ -458,7 +469,13 @@
 (define (tname-env-init-code)
   (make-init-code
     type-name-env-map
-    (λ (id ty) #`(register-type-name #'#,id #,(quote-type ty)))))
+    make-register-type-name-code))
+
+(define (make-register-type-code id ty)
+  #`(register-type #'#,id #,(quote-type ty)))
+
+(define (make-register-type-name-code id ty)
+  #`(register-type-name #'#,id #,(quote-type ty)))
 
 
 (define (talias-env-init-code)
@@ -469,7 +486,7 @@
 (define (env-init-code)
   (make-init-code
     type-env-map
-    (λ (id ty) #`(register-type #'#,id #,(quote-type ty)))))
+    make-register-type-code))
 
 (define (struct-name-env-init)
   (make-init-code

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -219,8 +219,8 @@
              (list ,@(map path-elem->sexp pth))
              #:T+ ,rng-T+)]
     [(Fun: (? has-optional-args? arrs))
-     (match-define (Arrow: fdoms _ kws rng _) (first arrs))
-     (match-define (Arrow: ldoms rst _ _ _) (last arrs))
+     (match-define (Arrow: fdoms _ kws rng) (first arrs))
+     (match-define (Arrow: ldoms rst _ _) (last arrs))
      (define opts (drop ldoms (length fdoms)))
      `(opt-fn
        (list ,@(map type->sexp fdoms))

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -448,8 +448,8 @@
 (define/cond-contract (cgen/arrow context s-arr t-arr)
   (context? Arrow? Arrow? . -> . (or/c #f cset?))
   (match* (s-arr t-arr)
-    [((Arrow: ss s-rest s-kws s _)
-      (Arrow: ts t-rest t-kws t _))
+    [((Arrow: ss s-rest s-kws s)
+      (Arrow: ts t-rest t-kws t))
      (define (rest->end rest)
        (match rest
          [(Rest: rst-ts) (star-end rst-ts)]

--- a/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -448,8 +448,8 @@
 (define/cond-contract (cgen/arrow context s-arr t-arr)
   (context? Arrow? Arrow? . -> . (or/c #f cset?))
   (match* (s-arr t-arr)
-    [((Arrow: ss s-rest s-kws s)
-      (Arrow: ts t-rest t-kws t))
+    [((Arrow: ss s-rest s-kws s _)
+      (Arrow: ts t-rest t-kws t _))
      (define (rest->end rest)
        (match rest
          [(Rest: rst-ts) (star-end rst-ts)]

--- a/typed-racket-lib/typed-racket/infer/promote-demote.rkt
+++ b/typed-racket-lib/typed-racket/infer/promote-demote.rkt
@@ -40,7 +40,7 @@
   ;; Returns the changed arr or #f if there is no arr above it
   (define (arr-change arr)
     (match arr
-      [(Arrow: dom rst kws rng)
+      [(Arrow: dom rst kws rng rng-T+)
        (cond
          [(apply V-in? V (get-propsets rng))
           #f]
@@ -50,13 +50,15 @@
            (map contra dom)
            (contra (RestDots-ty rst))
            (map contra kws)
-           (co rng))]
+           (co rng)
+           rng-T+)]
          [else
           (make-Arrow
            (map contra dom)
            (and rst (contra rst))
            (map contra kws)
-           (co rng))])]))
+           (co rng)
+           rng-T+)])]))
   (define (change-elems ts)
     (for/list ([t (in-list ts)])
       (if (V-in? V t)

--- a/typed-racket-lib/typed-racket/language-info.rkt
+++ b/typed-racket-lib/typed-racket/language-info.rkt
@@ -4,14 +4,21 @@
 
 (define ((get-info arg) key default)
   (case key
-    [(configure-runtime) `(#(typed-racket/language-info configure ()))]
+    [(configure-runtime) `(#(typed-racket/language-info configure ',arg))]
     [else default]))
 
-;; options currently always empty
 (define (configure options)
   (namespace-require 'racket/base)
-  (eval '(begin
+  (define te-mode
+    (cond
+      [(memq 'deep options) 'deep]
+      [(memq 'shallow options) 'shallow]
+      [(memq 'optional options) 'optional]
+      [else 'deep]))
+  (eval `(begin
            (require (for-syntax typed-racket/utils/tc-utils racket/base))
-           (begin-for-syntax (set-box! typed-context? #t)))
+           (begin-for-syntax
+             (set-box! type-enforcement-mode ',te-mode)
+             (set-box! typed-context? '#t)))
         (current-namespace))
   (current-readtable (readtable)))

--- a/typed-racket-lib/typed-racket/minimal.rkt
+++ b/typed-racket-lib/typed-racket/minimal.rkt
@@ -8,8 +8,10 @@
 (define-for-syntax ts-mod 'typed-racket/typed-racket)
 
 (define-syntax (providing stx)
-  (syntax-case stx (libs from basics except)
-    [(form (libs (except lb ex ...) ...) (basics b ...) (from spec id ...) ...)
+  (syntax-case stx (libs from basics except ts-except)
+    [(form (libs (except lb ex ...) ...) (basics b ...)
+           (ts-except ts-ex ...)
+           (from spec id ...) ...)
      (datum->syntax
       stx
       (syntax->datum
@@ -24,5 +26,5 @@
              (require (only-in spec id ...) ...)
              (provide id ...) ...
              (provide (rename-out [b* b] ...))
-             (provide (except-out (all-from-out ts) b* ...))
+             (provide (except-out (all-from-out ts) b* ... (~? (~@ ts-ex ...))))
              (provide (all-from-out lb) ...))))))]))

--- a/typed-racket-lib/typed-racket/optimizer/dead-code.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/dead-code.rkt
@@ -4,6 +4,7 @@
          racket/syntax
          (for-template racket/base)
          "../utils/utils.rkt"
+         (only-in "../utils/tc-utils.rkt" current-type-enforcement-mode deep)
          "../types/type-table.rkt"
          "utils.rkt"
          "logging.rkt")
@@ -41,9 +42,11 @@
           (quasisyntax/loc/origin this-syntax #'kw
             (if tst-opt thn-opt els-opt))]))
   (pattern ((~and kw lambda) formals . bodies)
+    #:when (eq? deep (current-type-enforcement-mode))
     #:when (dead-lambda-branch? #'formals)
     #:with opt this-syntax)
   (pattern ((~and kw case-lambda) (formals . bodies) ...)
+    #:when (eq? deep (current-type-enforcement-mode))
     #:when (for/or ((formals (in-syntax #'(formals ...))))
              (dead-lambda-branch? formals))
     #:with opt

--- a/typed-racket-lib/typed-racket/optimizer/list.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/list.rkt
@@ -14,7 +14,7 @@
 (define-syntax-class known-length-list-expr
   #:attributes (opt len)
   (pattern (~and e :opt-expr)
-           #:attr tys (match (type-of #'e)
+           #:attr tys (match (maybe-type-of #'e)
                         [(tc-result1: (List: es)) es]
                         [_ #f])
            #:when (attribute tys)

--- a/typed-racket-lib/typed-racket/optimizer/pair.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/pair.rkt
@@ -4,14 +4,18 @@
          racket/match
          (for-template racket/base racket/unsafe/ops racket/list)
          (for-syntax racket/base syntax/parse racket/syntax)
+         (only-in "../utils/tc-utils.rkt" current-type-enforcement-mode)
          "../utils/utils.rkt"
          "../rep/type-rep.rkt"
          "../types/type-table.rkt"
          "../types/utils.rkt"
          "../types/base-abbrev.rkt"
+         (only-in "../types/match-expanders.rkt" Listof:)
          "../types/resolve.rkt"
          "../types/subtype.rkt"
          "../typecheck/typechecker.rkt"
+         "../optimizer/utils.rkt"
+         "../optimizer/logging.rkt"
          "utils.rkt"
          "logging.rkt")
 
@@ -33,7 +37,7 @@
   (subtypeof? e (-pair Univ Univ)))
 ;; can't do the above for mpairs, as they are invariant
 (define (has-mpair-type? e)
-  (match (type-of e) ; type of the operand
+  (match (maybe-type-of e) ; type of the operand
     [(tc-result1: (MPair: _ _)) #t]
     [_ #f]))
 
@@ -139,7 +143,7 @@
     (let-values
         ([(t res)
           (for/fold ([t   (match (type-of #'e.arg)
-                            [(tc-result1: t) t])]
+                            [(tc-result1: t) (static-type->dynamic-type t)])]
                      [res #'e.arg])
               ([accessor (in-list (reverse (syntax->list #'e.alt)))])
             (cond
@@ -161,3 +165,26 @@
               (values t ; stays unsafe from now on
                       #`(#,accessor #,res))]))])
       res)))
+
+(define (static-type->dynamic-type type)
+  ;; simple: forget all type structure except list spines
+  (define te-mode (current-type-enforcement-mode))
+  (case te-mode
+    ((deep)
+     type)
+    ((shallow)
+     (match type
+      [(Listof: _)
+       (-lst Univ)]
+      [(Pair: _ t-cdr)
+       (let cdr-loop ((t t-cdr))
+         (match t
+          [(Pair: _ t-cdr)
+           (-pair Univ (cdr-loop t-cdr))]
+          [tail
+           (-pair Univ (if (eq? tail -Null) -Null Univ))]))]
+      [(app resolve (Pair: _ _))
+       (-pair Univ Univ)]
+      [_
+        Univ]))
+    (else (raise-optimizer-context-error te-mode))))

--- a/typed-racket-lib/typed-racket/optimizer/unboxed-let.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/unboxed-let.rkt
@@ -142,7 +142,7 @@
               [(tc-result1: (Fun: (list (Arrow: doms
                                                 #f  ;; rest arg
                                                 '() ;; kw args
-                                                _ _))))
+                                                _))))
                doms]
               [_ #f]))]
     #:when doms

--- a/typed-racket-lib/typed-racket/optimizer/unboxed-let.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/unboxed-let.rkt
@@ -16,7 +16,7 @@
          "float-complex.rkt"
          "unboxed-tables.rkt")
 
-(provide unboxed-let-opt-expr)
+(provide unboxed-let-opt-expr escapes?)
 
 ;; possibly replace bindings of complex numbers by bindings of their 2
 ;; components useful for intermediate results used more than once and for
@@ -138,11 +138,11 @@
   #:literal-sets (kernel-literals)
   (pattern ((fun-name:constant-var) (~and fun (#%plain-lambda params body ...)))
     #:do [(define doms
-            (match (type-of #'fun)
+            (match (maybe-type-of #'fun)
               [(tc-result1: (Fun: (list (Arrow: doms
                                                 #f  ;; rest arg
                                                 '() ;; kw args
-                                                _))))
+                                                _ _))))
                doms]
               [_ #f]))]
     #:when doms
@@ -250,8 +250,12 @@
       [(#%plain-app rator:expr rands:expr ...)
        (or (direct-child-of? v #'(rands ...)) ; used as an argument, escapes
            (ormap rec (syntax->list #'(rator rands ...))))]
+      [_:ignore-table^
+       #t]
       [e:kernel-expression
-       (look-at #'(e.sub-exprs ...))]))
+       (look-at #'(e.sub-exprs ...))]
+      [_
+       (raise-argument-error 'escapes? "kernel-expression" exp)]))
 
 
   ;; if the given var is the _only_ element of the body and we're in a

--- a/typed-racket-lib/typed-racket/optimizer/utils.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/utils.rkt
@@ -26,7 +26,8 @@
          define-unsafe-syntax-class
          define-literal-syntax-class
          define-merged-syntax-class
-         syntax/loc/origin quasisyntax/loc/origin)
+         syntax/loc/origin quasisyntax/loc/origin
+         raise-optimizer-context-error)
 
 ;; for tracking both origin and source location information
 (define-syntax-rule (syntax/loc/origin loc op body)
@@ -39,11 +40,11 @@
 
 ;; is the syntax object s's type a subtype of t?
 (define (subtypeof? s t)
-  (match (type-of s)
+  (match (maybe-type-of s)
     [(tc-result1: (== t (lambda (x y) (subtype y x)))) #t] [_ #f]))
 ;; similar, but with type equality
 (define (isoftype? s t)
-  (match (type-of s)
+  (match (maybe-type-of s)
          [(tc-result1: (== t)) #t] [_ #f]))
 
 ;; generates a table matching safe to unsafe promitives
@@ -118,7 +119,7 @@
 (define-syntax-class (typed-expr predicate)
   #:attributes (opt)
   (pattern (~and e :opt-expr)
-           #:when (match (type-of #'e)
+           #:when (match (maybe-type-of #'e)
                     [(tc-result1: (? predicate)) #t]
                     [_ #f])))
 
@@ -132,11 +133,11 @@
     #:attr val (syntax-e #'v)
     #:with opt this-syntax)
   (pattern (~and e :opt-expr)
-    #:when (match (type-of #'e)
+    #:when (match (maybe-type-of #'e)
              [(tc-result1: (Val-able: _))
               #t]
              [_ #f])
-    #:attr val (match (type-of #'e)
+    #:attr val (match (maybe-type-of #'e)
                  [(tc-result1: (Val-able: v)) v]
                  [_ #f])))
 
@@ -159,3 +160,8 @@
     #:with (sub-exprs ...) #'(e)]
   [pattern (set! _ e:expr)
     #:with (sub-exprs ...) #'(e)])
+
+
+(define (raise-optimizer-context-error te-mode)
+  (raise-arguments-error 'optimize-top (format "cannot optimize in ~a context" te-mode)))
+

--- a/typed-racket-lib/typed-racket/optimizer/vector.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/vector.rkt
@@ -46,7 +46,7 @@
   #:commit
   #:attributes (len opt)
   (pattern (~and e :opt-expr)
-    #:attr tys (match (type-of #'e)
+    #:attr tys (match (maybe-type-of #'e)
                  [(tc-result1: (HeterogeneousVector: tys)) tys]
                  [_ #f])
     #:when (attribute tys)

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -761,7 +761,7 @@
          (parse-object-type stx do-parse)]
         [(:Refinement^ p?:id)
          (match (lookup-id-type/lexical #'p?)
-           [(and t (Fun: (list (Arrow: (list dom) #f '() _ _))))
+           [(and t (Fun: (list (Arrow: (list dom) #f '() _))))
             (make-Refinement dom #'p?)]
            [t (parse-error "expected a predicate for argument to Refinement"
                            "given" t)])]

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -1124,7 +1124,7 @@
          ;; use do-parse instead of parse-values-type because we need to add the props from the pred-ty
          (with-arity 1
            (make-pred-ty (list (do-parse #'dom)) (do-parse #'rng) (attribute latent.type)
-                         (-acc-path (attribute latent.path) (-arg-path 0)) #f))]
+                         (-acc-path (attribute latent.path) (-arg-path 0))))]
         [(~or (:->^ dom:non-keyword-ty ... (~var kws (keyword-tys do-parse)) ... rest:non-keyword-ty ddd:star rng)
               (dom:non-keyword-ty ... (~var kws (keyword-tys do-parse)) ... rest:non-keyword-ty ddd:star :->^ rng))
          (with-arity (length (syntax->list #'(dom ...)))

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -761,7 +761,7 @@
          (parse-object-type stx do-parse)]
         [(:Refinement^ p?:id)
          (match (lookup-id-type/lexical #'p?)
-           [(and t (Fun: (list (Arrow: (list dom) #f '() _))))
+           [(and t (Fun: (list (Arrow: (list dom) #f '() _ _))))
             (make-Refinement dom #'p?)]
            [t (parse-error "expected a predicate for argument to Refinement"
                            "given" t)])]
@@ -1124,7 +1124,7 @@
          ;; use do-parse instead of parse-values-type because we need to add the props from the pred-ty
          (with-arity 1
            (make-pred-ty (list (do-parse #'dom)) (do-parse #'rng) (attribute latent.type)
-                         (-acc-path (attribute latent.path) (-arg-path 0))))]
+                         (-acc-path (attribute latent.path) (-arg-path 0)) #f))]
         [(~or (:->^ dom:non-keyword-ty ... (~var kws (keyword-tys do-parse)) ... rest:non-keyword-ty ddd:star rng)
               (dom:non-keyword-ty ... (~var kws (keyword-tys do-parse)) ... rest:non-keyword-ty ddd:star :->^ rng))
          (with-arity (length (syntax->list #'(dom ...)))

--- a/typed-racket-lib/typed-racket/private/shallow-rewrite.rkt
+++ b/typed-racket-lib/typed-racket/private/shallow-rewrite.rkt
@@ -1,0 +1,744 @@
+#lang racket/base
+
+;; Rewrite typed code to defend itself with shape checks
+;; - typed functions check their inputs
+;; - elimination forms (e.g. car) check their results
+
+(provide shallow-rewrite-top)
+
+(require
+  racket/match
+  (only-in racket/format ~a)
+  (only-in racket/set set-union)
+  (only-in racket/list flatten)
+  (only-in racket/syntax generate-temporary with-syntax*)
+  (only-in syntax/srcloc build-source-location-list)
+  syntax/id-set
+  syntax/parse
+  typed-racket/env/index-env
+  typed-racket/env/scoped-tvar-env
+  typed-racket/env/tvar-env
+  typed-racket/rep/type-rep
+  typed-racket/rep/values-rep
+  typed-racket/types/abbrev
+  typed-racket/types/match-expanders
+  typed-racket/types/resolve
+  typed-racket/types/struct-table
+  typed-racket/types/substitute
+  typed-racket/types/type-table
+  typed-racket/types/union
+  typed-racket/types/utils
+  typed-racket/utils/class-utils
+  typed-racket/utils/plambda-utils
+  typed-racket/utils/shallow-utils
+  (only-in typed-racket/optimizer/unboxed-let escapes?)
+  (only-in typed-racket/private/type-annotation type-annotation get-type)
+  (only-in typed-racket/private/syntax-properties
+    type-ascription-property
+    type-inst-property
+    plambda-property
+    ignore^
+    ignore-some^
+    opt-lambda^
+    kw-lambda^
+    opt-lambda-property
+    kw-lambda-property
+    tr:class:def-property
+    tr:class:name-table-property)
+  (only-in (submod typed-racket/private/type-contract test-exports)
+    type->contract)
+  (for-syntax
+    racket/base)
+  (for-template
+    racket/base
+    (only-in racket/contract/base any/c) ;; for free-id test, to avoid rewrites
+    racket/unsafe/ops
+    (only-in racket/unsafe/undefined unsafe-undefined)
+    typed-racket/types/numeric-predicates
+    typed-racket/utils/shallow-contract
+    (only-in racket/private/class-internal find-method/who)
+    (only-in typed-racket/private/class-literals class-internal)))
+
+;; =============================================================================
+
+(define (shallow-rewrite-top stx ctc-cache)
+  (define rev-extra-def* (box '()))
+  (define (register-extra-defs! ex*)
+    (unless (null? ex*)
+      (define stx (with-syntax ((ex* ex*)) #'(begin . ex*)))
+      (set-box! rev-extra-def* (cons stx (unbox rev-extra-def*)))))
+  (define rewritten-stx
+    (let loop ([stx stx] [skip-dom? #f] [trusted-fn* (immutable-free-id-set)])
+      (syntax-parse stx
+        #:literals (#%plain-app #%plain-lambda begin case-lambda define-syntaxes define-values
+                    find-method/who let-values letrec-values quote values)
+
+        [(let-values ([(_) _meth])
+           (let-values ([(_) _rcvr])
+             (let-values (((_) (#%plain-app find-method/who _ _ _)))
+               (let-values ([(_) _args] ...) _))))
+         ;; send (for objects)
+         (define tc-res (maybe-type-of stx))
+         (define-values [extra* stx/check]
+           (protect-codomain tc-res stx (build-source-location-list stx) ctc-cache))
+         (void (register-extra-defs! extra*))
+         (if stx/check
+           (register-ignored (readd-props stx/check stx))
+           stx)]
+        [(#%plain-app
+           compose-class:id name:expr superclass:expr interface:expr internal:expr ...
+           (~and make-methods-lambda (#%plain-lambda (local-accessor:id local-mutator:id local-method-or-field:id ...) make-methods-body))
+           (quote b:boolean) (quote #f))
+         ;; class def, see typecheck/check-class-unit
+         (define parse-info
+           (let ((name-table (car (trawl-for-property #'make-methods-body tr:class:name-table-property))))
+             (parse-internal-class-data name-table)))
+         (define internal-external-mapping (make-internal-external-mapping parse-info))
+         (define public-method-name?
+           (let ([name* (hash-ref parse-info 'method-names)])
+             (lambda (name-stx)
+               (memq (hash-ref internal-external-mapping (syntax-e name-stx) #f) name*))))
+         (define private-method-name?
+           (let ([name* (hash-ref parse-info 'private-names)])
+             (lambda (name-stx)
+               (memq (syntax-e name-stx) name*))))
+         (register-ignored
+           (readd-props
+             (quasisyntax/loc stx
+               (#%plain-app compose-class name superclass interface internal ...
+                #,(readd-props
+                    #`(#%plain-lambda (local-accessor local-mutator local-method-or-field ...)
+                        #,(let shallow-rewrite-method-def ([val #'make-methods-body])
+                            (cond
+                              [(pair? val)
+                               (cons (shallow-rewrite-method-def (car val)) (shallow-rewrite-method-def (cdr val)))]
+                              [(not (syntax? val))
+                               val]
+                              [(let ((name (tr:class:def-property val)))
+                                 (and name
+                                      (or (public-method-name? name)
+                                          (private-method-name? name))
+                                      name))
+                               => (lambda (val-name)
+                                    (syntax-parse val
+                                     [((~literal #%plain-app)
+                                       (~literal chaperone-procedure)
+                                       ((~literal let-values) ((meth-id meth-fun)) let-body) . rest)
+                                      ;; TODO custom defense here, avoid checking 1st arg to method? ... for keywords, meth-fun is not an immediate lambda
+                                      (readd-props
+                                        (quasisyntax/loc val
+                                          (#%plain-app chaperone-procedure
+                                            (let-values ((meth-id #,(loop #'meth-fun (private-method-name? val-name) trusted-fn*))) let-body) . rest))
+                                        val)]
+                                     [_
+                                       (raise-argument-error 'shallow-rewrite-method-def "tr:class:def-property #t" val)]))]
+                              [else
+                               (define v (syntax-e val))
+                               (if (pair? v)
+                                 (readd-props
+                                   (datum->syntax val (cons (shallow-rewrite-method-def (car v)) (shallow-rewrite-method-def (cdr v))))
+                                   val)
+                                 val)])))
+                    #'make-methods-lambda)
+                 (quote b) (quote #f)))
+             stx))]
+        [((~or (~literal #%provide)
+               (~literal #%require)
+               (~literal begin-for-syntax)
+               (~literal define-syntaxes)
+               (~literal module*)
+               (~literal module)
+               (~literal quote)
+               (~literal quote-syntax)) . _)
+         stx]
+        [(~and (~or :opt-lambda^ :kw-lambda^)
+               (let-values (((f-name) (#%plain-lambda f-args f-body))) body))
+         ;; opt/kw function
+         (define num-args (length (syntax->list #'f-args)))
+         (with-extended-env (get-poly-tvarss stx)
+           (lambda ()
+             (readd-props
+               (quasisyntax/loc stx
+                 (let-values (((f-name)
+                               (#%plain-lambda f-args
+                                 #,(let dom-check-loop ([f-body #'f-body]
+                                                        [num-args num-args])
+                                     (if (zero? num-args)
+                                       (readd-props (loop f-body #f trusted-fn*) f-body)
+                                       (syntax-parse f-body
+                                        #:literals (let-values if)
+                                        [(let-values (((arg-id) (~and if-expr (if test default-expr arg)))) f-rest)
+                                         ;; optional, default expression may need defense
+                                         (define arg-ty (tc-results->type1 (type-of #'if-expr)))
+                                         (define-values [ex* arg+]
+                                           (if skip-dom?
+                                             (values '() #f)
+                                             (protect-domain arg-ty #'arg (build-source-location-list f-body) ctc-cache)))
+                                         (void (register-extra-defs! ex*))
+                                         (quasisyntax/loc f-body
+                                           (let-values (((arg-id)
+                                                         (if test
+                                                           #,(syntax-parse #'test
+                                                              [((~literal #%expression) ((~literal quote) #f))
+                                                               #'default-expr]
+                                                              [_
+                                                               (readd-props (loop #'default-expr #f trusted-fn*) #'default-expr)])
+                                                           #,(if arg+ (readd-props arg+ #'arg) #'arg))))
+                                             #,(dom-check-loop #'f-rest (- num-args 1))))]
+                                        [(let-values (((arg-id) arg-val)) f-rest)
+                                         ;; normal arg
+                                         (define arg-ty (tc-results->type1 (type-of #'arg-val)))
+                                         (define-values [ex* arg-val+]
+                                           (if skip-dom?
+                                             (values '() #f)
+                                             (protect-domain arg-ty #'arg-val (build-source-location-list f-body) ctc-cache)))
+                                         (void (register-extra-defs! ex*))
+                                         (quasisyntax/loc f-body
+                                           (let-values (((arg-id)
+                                                         #,(if arg-val+ (readd-props arg-val+ #'arg-val) #'arg-val)))
+                                             #,(dom-check-loop #'f-rest (- num-args 1))))]
+                                        [_
+                                         (raise-syntax-error 'shallow-rewrite-top "strange kw/opt function body"
+                                                             stx f-body)]))))))
+                   #,(register-ignored #'body)))
+                 stx)))]
+        [((~and lam-id (~or #%plain-lambda case-lambda)) formals . body)
+         #:when (not (maybe-type-of stx))
+         (define body+ (readd-props (loop #'body #f trusted-fn*) #'body))
+         (readd-props
+           (quasisyntax/loc stx
+             (lam-id formals . #,body+))
+           stx)]
+        [(#%plain-lambda formals . body)
+         (with-extended-env (get-poly-tvarss stx)
+          (lambda ()
+           (readd-props
+             (quasisyntax/loc stx
+               (#%plain-lambda formals .
+                 #,(let* ([body+
+                            (readd-props (loop #'body #f trusted-fn*) #'body)]
+                          [dom* (map Arrow-dom (syntax->arrows stx))]
+                          [check-formal*
+                            (let protect-loop ([args #'formals]
+                                               [dom* dom*])
+                              (if (or (identifier? args)
+                                      (null? args)
+                                      (and (syntax? args) (null? (syntax-e args))))
+                                '()
+                                (let*-values ([(fst rst)
+                                               (cond
+                                                 [(pair? args)
+                                                  (values (car args) (cdr args))]
+                                                 [(syntax? args)
+                                                  (let ((e (syntax-e args)))
+                                                    (values (car e) (cdr e)))]
+                                                 [else
+                                                   (raise-syntax-error 'shallow-rewrite-top "#%plain-lambda formals" #'formals args)])]
+                                              [(check*)
+                                               (let ((dom+
+                                                     (for/fold ((acc '()))
+                                                               ((dom (in-list dom*)))
+                                                       (if (pair? dom) (cons (cdr dom) acc) acc))))
+                                                 (protect-loop rst dom+))]
+                                              [(fst-ty)
+                                               (let ((ann-ty (and (type-annotation fst #:infer #f) (get-type fst #:infer #t #:default Univ))))
+                                                 (if (and ann-ty (not (Error? ann-ty)))
+                                                   ann-ty
+                                                   (apply Un (for/list ((dom (in-list dom*)) #:when (pair? dom)) (car dom)))))]
+                                              [(ex* fst+)
+                                               (if skip-dom?
+                                                 (values '() #f)
+                                                 (protect-domain fst-ty fst (build-source-location-list fst) ctc-cache))])
+                                  (void (register-extra-defs! ex*))
+                                  (if fst+ (cons fst+ check*) check*))))])
+                     (if (null? check-formal*)
+                       body+
+                       (cons
+                         (quasisyntax/loc #'body (#%plain-app void . #,check-formal*))
+                         body+)))))
+             stx)))]
+        [(case-lambda [formals* . body*] ...)
+         (define all-dom* (map Arrow-dom (syntax->arrows stx)))
+         (with-extended-env (get-poly-tvarss stx)
+           (lambda ()
+             (readd-props
+               (quasisyntax/loc stx
+                 (case-lambda .
+                     #,(for/list ([formals (in-list (syntax-e #'(formals* ...)))]
+                                  [body (in-list (syntax-e #'(body* ...)))])
+                         (cond
+                           [(dead-lambda-branch? formals)
+                            ;; no type
+                            (quasisyntax/loc formals [#,formals . #,body])]
+                           [else
+                             (define matching-dom*
+                               (let ([len (formals-length formals)])
+                                 (for/list ((dom (in-list all-dom*))
+                                            #:when (= len (length dom)))
+                                   dom)))
+                             (quasisyntax/loc stx
+                               [#,formals .
+                                #,(let* ([body+
+                                          (readd-props (loop body #f trusted-fn*) body)]
+                                         [check-formal*
+                                           (let protect-loop ([args formals]
+                                                              [dom* matching-dom*])
+                                             (if (or (identifier? args)
+                                                     (null? args)
+                                                     (and (syntax? args) (null? (syntax-e args))))
+                                               '()
+                                               (let*-values ([(fst rst)
+                                                              (cond
+                                                                [(pair? args)
+                                                                 (values (car args) (cdr args))]
+                                                                [(syntax? args)
+                                                                 (let ((e (syntax-e args)))
+                                                                   (values (car e) (cdr e)))]
+                                                                [else
+                                                                  (raise-syntax-error 'shallow-rewrite-top "#%plain-lambda formals" formals args)])]
+                                                             [(check*)
+                                                              (let ((dom+
+                                                                    (for/fold ((acc '()))
+                                                                              ((dom (in-list dom*)))
+                                                                      (if (pair? dom) (cons (cdr dom) acc) acc))))
+                                                                (protect-loop rst dom+))]
+                                                             [(fst-ty)
+                                                              (if (type-annotation fst #:infer #f)
+                                                                (get-type fst #:infer #t #:default Univ)
+                                                                (apply Un
+                                                                       (for/fold ((acc '()))
+                                                                                 ((dom (in-list dom*)))
+                                                                         (if (pair? dom) (cons (car dom) acc) acc))))]
+                                                             [(ex* fst+)
+                                                              (if skip-dom?
+                                                                (values '() #f)
+                                                                (protect-domain fst-ty fst (build-source-location-list fst) ctc-cache))])
+                                                 (void (register-extra-defs! ex*))
+                                                 (if fst+ (cons fst+ check*) check*))))])
+                                   (if (null? check-formal*)
+                                     body+
+                                     (cons
+                                       (quasisyntax/loc body (#%plain-app void . #,check-formal*))
+                                       body+)))])]))))
+               stx)))]
+        [(#%plain-app (letrec-values (((a:id) e0)) b:id) e1* ...)
+         #:when (free-identifier=? #'a #'b)
+         ;; (for ....) combinators expand to a recursive function that does not escape,
+         ;;  no need to check the domain --- use (loop e #true trusted-fn*) to skip
+         (define skip? (not (escapes? #'a #'e0 #false)))
+         (with-syntax ((e0+ (readd-props (loop #'e0 skip? (free-id-set-add trusted-fn* #'a)) #'e0))
+                      ((e1*+ ...) (for/list ((e1 (in-list (syntax-e #'(e1* ...)))))
+                                    (readd-props (loop e1 #f trusted-fn*) e1))))
+           (syntax/loc stx
+             (#%plain-app (letrec-values (((a) e0+)) b) e1*+ ...))) ]
+        [(x* ...)
+         #:when (is-application? stx)
+         (define stx+
+           (readd-props
+             (syntax*->syntax stx
+               (for/list ([x (in-list (syntax-e #'(x* ...)))])
+                 (readd-props (loop x skip-dom? trusted-fn*) x)))
+             stx))
+         (define-values [pre* f post*] (split-application stx+))
+         (cond
+           [(or (is-ignored? f)
+                (parameter-set-app? f post*)
+                (trusted-codomain? f)
+                (and (identifier? f)
+                     (or (free-id-set-member? trusted-fn* f)
+                         (cdr-list? f post*))))
+            stx+]
+           [else
+            (define cod-tc-res (type-of stx))
+            (define-values [extra* stx/cod]
+              (protect-codomain cod-tc-res stx+ (build-source-location-list stx) ctc-cache))
+            (void (register-extra-defs! extra*))
+            (if stx/cod
+              (readd-props stx/cod stx)
+              stx+)])]
+        [((~and x (~literal #%expression)) e)
+         #:when (or (type-inst-property #'x)
+                    (type-ascription-property stx))
+         (define e+ (readd-props (loop #'e skip-dom? trusted-fn*) #'e))
+         (define e++
+           (with-syntax ([e+ e+])
+             (syntax/loc stx (x e+))))
+         (readd-props e++ stx)]
+        [(x* ...)
+         (define stx+
+           (syntax*->syntax stx
+             (for/list ((x (in-list (syntax-e #'(x* ...)))))
+               (readd-props (loop x skip-dom? trusted-fn*) x))))
+         (readd-props stx+ stx)]
+        [_
+         stx])))
+  (values (reverse (unbox rev-extra-def*)) rewritten-stx))
+
+(define (with-extended-env tvarss-list thunk)
+  (define ns (flatten tvarss-list))
+  (let outer ([tvarss-list tvarss-list])
+    (if (or (null? tvarss-list)
+            (null? (car tvarss-list)))
+      (thunk)
+      (let inner ([tvarss (get-poly-layer tvarss-list)])
+        ;; loop copied from typecheck/tc-lambda-unit
+        (match tvarss
+          [(list) (outer (remove-poly-layer tvarss-list))]
+          [(cons (list (list tvars ...) dotted) rest-tvarss)
+           (extend-indexes dotted
+              (extend-tvars/new tvars ns
+                (inner rest-tvarss)))]
+          [(cons tvars rest-tvarss)
+           (extend-tvars/new tvars ns
+             (inner rest-tvarss))])))))
+
+(define (readd-props! new-stx old-stx)
+  (maybe-add-typeof-expr new-stx old-stx)
+  (maybe-add-test-position new-stx old-stx)
+  (maybe-add-scoped-tvar new-stx old-stx)
+  (maybe-register-ignored new-stx old-stx)
+  (void))
+
+(define (readd-props pre-stx old-stx)
+  (define new-stx (copy-syntax-property* pre-stx old-stx))
+  (readd-props! new-stx old-stx)
+  new-stx)
+
+(define (copy-syntax-property* new-stx old-stx)
+  (for/fold ((new-stx new-stx))
+            ((k (in-list (syntax-property-symbol-keys old-stx))))
+    (syntax-property new-stx k (syntax-property old-stx k))))
+
+(define (register-ignored stx)
+  (register-ignored! stx)
+  stx)
+
+(define (maybe-add-typeof-expr new-stx old-stx)
+  (let ((old-type (maybe-type-of old-stx)))
+    (when old-type
+      (add-typeof-expr new-stx old-type))))
+
+(define (maybe-add-test-position new-stx old-stx)
+  (maybe-add-test-true new-stx old-stx)
+  (maybe-add-test-false new-stx old-stx)
+  (void))
+
+(define (maybe-add-scoped-tvar new-stx old-stx)
+  (let ([old-layer (lookup-scoped-tvar-layer old-stx)])
+    (when old-layer
+      (add-scoped-tvars new-stx old-layer))))
+
+(define (maybe-add-test-true new-stx old-stx)
+  (when (test-position-takes-true-branch old-stx)
+    (test-position-add-true new-stx))
+  (void))
+
+(define (maybe-add-test-false new-stx old-stx)
+  (when (test-position-takes-false-branch old-stx)
+    (test-position-add-false new-stx))
+  (void))
+
+(define (maybe-register-ignored new-stx old-stx)
+  (when (is-ignored? old-stx)
+    (register-ignored! new-stx))
+  (void))
+
+(define (formals-length stx)
+  (formals-fold 0 (lambda (acc v) (add1 acc)) stx))
+
+(define (formals-fold init f stx)
+  (let loop ((v stx))
+    (if (or (identifier? v)
+            (null? v)
+            (and (syntax? v) (null? (syntax-e v))))
+      init
+      (let*-values (((fst rst)
+                     (cond
+                       [(pair? v)
+                        (values (car v) (cdr v))]
+                       [(syntax? v)
+                        (let ((e (syntax-e v)))
+                          (values (car e) (cdr e)))]
+                       [else
+                         (raise-syntax-error 'formals-fold "lambda formals" stx)])))
+        (f (loop rst) fst)))))
+
+;; is-application? : Syntax -> Boolean
+;; Returns #true if `stx` is a function application (an app that may need dynamic checking)
+(define (is-application? stx)
+  (syntax-parse stx
+   [((~literal #%plain-app) . _)
+    (has-type-annotation? stx)]
+   [_
+    #false]))
+
+(define (has-type-annotation? x)
+  (match (maybe-type-of x)
+   [(tc-results: _ #f)
+    ;; #f = don't handle rest dots TODO wait why not???? ... use  maybe-type-of only?
+     #true]
+   [_
+     #false]))
+
+;; split-application : Syntax -> (Values (Syntaxof List) Syntax (Syntaxof List))
+(define (split-application stx)
+  (syntax-parse stx
+   #:literals (#%plain-app)
+   #:datum-literals (apply)
+   [((~and a #%plain-app) (~and b apply) f . arg*)
+    (values #'(a b) #'f #'arg*)]
+   [((~and a #%plain-app) f . arg*)
+    (values #'(a) #'f #'arg*)]
+   [_
+    (raise-argument-error 'split-application "(Syntaxof App)" stx)]))
+
+(define (syntax->arrows stx)
+  (define raw-type (tc-results->type1 (type-of stx)))
+  (let loop ([ty (and raw-type (normalize-type raw-type))])
+    (match ty
+     [(Fun: arrs)
+      arrs]
+     [(Union: _ ts)
+      (apply append (map loop ts))]
+     [(or (Poly: n* b)
+          (PolyRow: n* b _))
+      (loop (subst-all (make-simple-substitution n* (map make-F n*)) b))]
+     [(PolyDots: (list n* ... n-dot) b)
+      (define subst
+        (make-simple-substitution n* (map make-F n*))
+        ;; ben 2022-03-29: should we substitute the n-dot variable too? I would
+        ;; think yes, but tests pass without and fail with (error = "substitute
+        ;; used on ... variable")
+        #;(hash-set (make-simple-substitution n* (map make-F n*))
+                  n-dot (i-subst/dotted (list (make-F n-dot)) (make-F n-dot) n-dot)))
+      (loop (subst-all subst b))]
+     [(Refine: parent pred)
+      (raise-user-error 'refine "~s~n ~s~n ~s~n" ty parent pred)]
+     [(DepFun: _ _ _)
+      ty]
+     [_
+      (raise-arguments-error 'syntax->arrow-type "failed to parse arrow from type of syntax object"
+        "e" (syntax->datum stx)
+        "stx" stx
+        "type" ty)])))
+
+(define (syntax*->syntax ctx stx*)
+  (datum->syntax ctx
+    (if (null? stx*)
+      '()
+      (cons (car stx*) (syntax*->syntax ctx (cdr stx*))))
+    ctx ctx))
+
+(define (tc-results->type* r)
+  (match r
+   [(tc-results: (list (tc-result: ts _ _) ...) #f)
+    ts]
+   [_
+    #f]))
+
+(define (tc-results->type1 r)
+  (match r
+   [(tc-result1: t)
+    t]
+   [_
+    #f]))
+
+(define (parameter-set-app? f args-stx)
+  (define f-type (tc-results->type1 (maybe-type-of f)))
+  (and
+    f-type
+    (Param? f-type)
+    (not (null? (syntax-e args-stx)))))
+
+(define (trusted-codomain? stx)
+  (or
+    (and (identifier? stx)
+         (syntax-property stx 'constructor-for)) ;; 2020-03: could register in env/lexical-env instead
+    (let ([cod-ty (tc-results->type1 (maybe-type-of stx))])
+      ;; ? error when cod-ty is #f?
+      (and cod-ty (shallow-trusted-positive? cod-ty)))
+    (literal-function stx)))
+
+;; cdr-list? : (-> identifier? _ _)
+(define (cdr-list?  f post*)
+  ;; TODO put this in optimizer? / reuse optimizer?
+  (define f-depth
+    (cond
+      [(or (free-identifier=? f #'unsafe-cdr)
+           (free-identifier=? f #'cdr))
+       1]
+      [(free-identifier=? f #'cddr)
+       2]
+      [(free-identifier=? f #'cdddr)
+       3]
+      [(free-identifier=? f #'cddddr)
+       4]
+      [else #f]))
+  (define t
+    (and f-depth
+         (let ((e (syntax-e post*)))
+           (and (pair? e) (tc-results->type1 (type-of (car e)))))))
+  (and (Type? t)
+       (let loop ((t t)
+                  (d f-depth))
+         (match t
+          [(Listof: _)
+           #true]
+          [(Pair: _ t-cdr)
+           (or (zero? d)
+               (loop t-cdr (- d 1)))]
+          [_
+           (and (zero? d) (eq? t -Null))]))))
+
+(define (module-path-index-join* . x*)
+  (let loop ((x* x*))
+    (if (null? (cdr x*))
+      (module-path-index-join (car x*) #f)
+      (module-path-index-join (car x*) (loop (cdr x*))))))
+
+;; from-require/typed? : Identifier -> Boolean
+;; Typed Racket adds this property to all require/typed identifiers,
+;;  see `utils/require-contract.rkt`
+(define (from-require/typed? stx)
+  (syntax-property stx 'not-provide-all-defined))
+
+(define (typed-racket-identifier? stx)
+  (define ib (identifier-binding stx))
+  (and (pair? ib)
+       (or (identifier-binding-from-this-module? ib)
+           (identifier-binding-from-typed-racket-module? ib))))
+
+(define (identifier-binding-from-this-module? ib)
+  (match ib
+   [(list src-mpi _src-id nom-src-mpi nom-src-id 0 0 0)
+    (and (equal? src-mpi (module-path-index-join #f #f))
+         (equal? src-mpi nom-src-mpi))]
+   [_
+    #false]))
+
+(define (identifier-binding-from-typed-racket-module? ib)
+  (match ib
+   [(list src-mpi _src-id _nom-src-mpi _nom-src-id 0 0 0)
+    (typed-racket-mpi? src-mpi)]
+   [_
+    #false]))
+
+(define typed-racket-mpi?
+  (let ([cache (make-hash)])
+    (λ (mpi)
+      (hash-ref! cache mpi
+        (λ () ;; Typed Racket always installs a `#%type-decl` submodule
+          (let* ([mpi+ (module-path-index-join '(submod "." #%type-decl) mpi)])
+            (parameterize ([current-namespace (make-base-namespace)])
+              (with-handlers ([exn:fail:contract? (lambda (exn) #f)])
+                (and mpi+
+                     (dynamic-require mpi+ #f)
+                     #t)))))))))
+
+(define (protect-domain dom-type dom-stx ctx ctc-cache)
+  (define-values [extra-def* ctc-stx]
+    (if dom-type
+      (type->flat-contract dom-type ctc-cache)
+      (values '() #f)))
+  (define dom-stx+
+    (if (not ctc-stx)
+      #f
+      (with-syntax ([ctc ctc-stx]
+                    [dom dom-stx]
+                    [ty-str (format "~a" dom-type)]
+                    [ctx ctx])
+        (register-ignored
+          (syntax/loc dom-stx
+            (#%plain-app shallow-shape-check dom ctc 'ty-str 'ctx))))))
+  (values extra-def* dom-stx+))
+
+(define (protect-codomain cod-tc-res app-stx ctx ctc-cache)
+  (define t* (tc-results->type* cod-tc-res))
+  (cond
+   [(or (not t*) (null? t*))
+    (values '() #f)]
+   [else
+    (define-values [extra-def* ctc-stx*]
+      (type->flat-contract* t* ctc-cache))
+    (define cod-stx+
+      (if (not (ormap values ctc-stx*))
+        ;; Nothing to check
+        #f
+        ;; Assemble everything into a syntax object that:
+        ;; - performs the application
+        ;; - binds the result(s) to temporary variable(s)
+        ;; - checks the tag of each temporary
+        (with-syntax ([app app-stx])
+          (define var-name 'dyn-cod)
+          ;; - application returns +1 results:
+          ;;   - bind all,
+          ;;   - check the ones with matching contracts,
+          ;;   - return all
+          (with-syntax* ([v*
+                          (for/list ([_t (in-list t*)])
+                            (generate-temporary var-name))]
+                         [(check-v* ...)
+                          (for/list ((ctc-stx (in-list ctc-stx*))
+                                     (type (in-list t*))
+                                     (v-stx (in-list (syntax-e #'v*)))
+                                     (i (in-naturals))
+                                     #:when ctc-stx)
+                            (define if-stx
+                              (with-syntax ([ctc ctc-stx]
+                                            [v v-stx]
+                                            [ty-str (format "~a" type)]
+                                            [ctx ctx])
+                                #'(#%plain-app shallow-shape-check v ctc 'ty-str 'ctx)))
+                            (register-ignored! if-stx)
+                            if-stx)])
+            (define new-stx
+              (quasisyntax/loc app-stx
+                (let-values ([v* app])
+                  (begin check-v* ...  (#%plain-app values . v*)))))
+            (void
+              (add-typeof-expr new-stx cod-tc-res)
+              (register-ignored! (caddr (syntax-e new-stx))))
+            new-stx))))
+    (values extra-def* cod-stx+)]))
+
+(define (literal-function x)
+  (syntax-parse x
+   [((~or (~literal lambda)
+          (~literal #%plain-lambda)
+          (~literal case-lambda)) . _) #true]
+   [_ #false]))
+
+(define (type->flat-contract t ctc-cache)
+  (cond
+    [(eq? t Univ)
+     (values '() #f)]
+    [else
+     (define (fail #:reason r)
+       (raise-user-error 'type->flat-contract "failed to convert type ~a to flat contract because ~a" t r))
+     (match-define (list defs ctc)
+       (type->contract t fail #:typed-side 'both #:cache ctc-cache))
+     (match t
+      [(Refine: _ _)
+       ;; do not lift defs; they may use a local var
+       ;; e.g. (lambda (a) (lambda (b : (Refine ... a b ...)) ....))
+       (define ctc+ (quasisyntax/loc ctc (let-values () #,@defs #,ctc)))
+       (register-ignored! ctc+)
+       (values '() ctc+)]
+      [_
+       (define ctc+ ;; type variables make an any/c, for example
+         (if (free-identifier=? ctc #'any/c) #f ctc))
+       (for-each register-ignored! defs)
+       (values defs ctc+)])]))
+
+(define (type->flat-contract* t* ctc-cache)
+  (for/fold ((extra-def* '())
+             (ctc-stx* '())
+             #:result (values (reverse extra-def*) (reverse ctc-stx*)))
+            ((t (in-list t*)))
+    (define-values [ex* ctc-stx] (type->flat-contract t ctc-cache))
+    (values (rev-append ex* extra-def*) (cons ctc-stx ctc-stx*))))
+
+(define (rev-append a* b*)
+  (let loop ((a* a*) (b* b*))
+    (if (null? a*) b* (loop (cdr a*) (cons (car a*) b*)))))
+

--- a/typed-racket-lib/typed-racket/private/shallow-rewrite.rkt
+++ b/typed-racket-lib/typed-racket/private/shallow-rewrite.rkt
@@ -737,5 +737,5 @@
              #:result (values (reverse extra-def*) (reverse ctc-stx*)))
             ((t (in-list t*)))
     (define-values [ex* ctc-stx] (type->flat-contract t ctc-cache))
-    (values (append (reverse ex*) extra-def*) (cons ctc-stx ctc-stx*))))
+    (values (rev-append ex* extra-def*) (cons ctc-stx ctc-stx*))))
 

--- a/typed-racket-lib/typed-racket/private/shallow-rewrite.rkt
+++ b/typed-racket-lib/typed-racket/private/shallow-rewrite.rkt
@@ -32,6 +32,7 @@
   typed-racket/utils/plambda-utils
   typed-racket/utils/shallow-utils
   (only-in typed-racket/optimizer/unboxed-let escapes?)
+  (only-in typed-racket/utils/utils rev-append)
   (only-in typed-racket/private/type-annotation type-annotation get-type)
   (only-in typed-racket/private/syntax-properties
     type-ascription-property
@@ -736,9 +737,5 @@
              #:result (values (reverse extra-def*) (reverse ctc-stx*)))
             ((t (in-list t*)))
     (define-values [ex* ctc-stx] (type->flat-contract t ctc-cache))
-    (values (rev-append ex* extra-def*) (cons ctc-stx ctc-stx*))))
-
-(define (rev-append a* b*)
-  (let loop ((a* a*) (b* b*))
-    (if (null? a*) b* (loop (cdr a*) (cons (car a*) b*)))))
+    (values (append (reverse ex*) extra-def*) (cons ctc-stx ctc-stx*))))
 

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -52,14 +52,17 @@
  ;; TODO make this from contract-req
  (prefix-in c: racket/contract)
  (contract-req)
+ (only-in racket/unsafe/undefined unsafe-undefined)
  (for-syntax racket/base)
- (for-template racket/base racket/contract "../utils/any-wrap.rkt"))
+ (for-template racket/base racket/contract "../utils/any-wrap.rkt" "../utils/shallow-contract.rkt"))
 
 (provide
   (c:contract-out
     [type->static-contract
       (c:parametric->/c (a) ((Type? (c:-> #:reason (c:or/c #f string?) a))
-                             (#:typed-side boolean?) . c:->* . (c:or/c a static-contract?)))]))
+                             (#:typed-side boolean?
+                              #:enforcement-mode type-enforcement-mode?)
+                             . c:->* . (c:or/c a static-contract?)))]))
 
 (provide change-contract-fixups
          change-provide-fixups
@@ -68,7 +71,7 @@
          include-extra-requires?)
 
 ;; submod for testing
-(module* test-exports #f (provide type->contract))
+(module* test-exports #f (provide type->contract has-contract-def-property? make-procedure-arity-flat/sc))
 
 
 (define num-existentials (make-parameter 0))
@@ -81,7 +84,12 @@
           #t)]
     [_ #f]))
 
-(struct contract-def (type flat? maker? typed-side) #:prefab)
+;; type : (syntaxof Type?)
+;; flat? : boolean?
+;; maker? : boolean?
+;; typed-side : (or/c 'untyped 'typed)
+;; te-mode : type-enforcement-mode?
+(struct contract-def (type flat? maker? typed-side te-mode) #:prefab)
 
 ;; get-contract-def-property : Syntax -> (U False Contract-Def)
 ;; Checks if the given syntax needs to be fixed up for contract generation
@@ -114,7 +122,7 @@
 ;; (such as mutually recursive class types).
 (define (generate-contract-def stx cache)
   (define prop (get-contract-def-property stx))
-  (match-define (contract-def type-stx flat? maker? typed-side) prop)
+  (match-define (contract-def type-stx flat? maker? typed-side te-mode) prop)
   (define *typ (if type-stx (parse-type type-stx) t:-Dead-Code))
   (define kind (if (and type-stx flat?) 'flat 'impersonator))
   (syntax-parse stx #:literals (define-values)
@@ -134,6 +142,7 @@
         ;; this value is from the typed side (require/typed, make-predicate, etc)
         ;; unless it's used for with-type
         #:typed-side (from-typed? typed-side)
+        #:enforcement-mode te-mode
         #:kind kind
         #:cache cache
         (type->contract-fail
@@ -147,14 +156,15 @@
 
 ;; Generate a contract for a TR provide form
 (define (generate-contract-def/provide stx cache)
-  (match-define (list type untyped-id orig-id blame-id)
+  (match-define (list type untyped-id orig-id blame-id te-mode)
     (contract-def/provide-property stx))
   (define failure-reason #f)
   (define result
     (type->contract type
-                    #:typed-side #t
+                    #:typed-side (if (eq? 'deep (current-type-enforcement-mode)) #t 'both)
                     #:kind 'impersonator
                     #:cache cache
+                    #:enforcement-mode te-mode
                     ;; FIXME: get rid of this interface, make it functional
                     (λ (#:reason [reason #f]) (set! failure-reason reason))))
   (syntax-parse stx
@@ -217,7 +227,8 @@
       typed-racket/utils/simple-result-arrow
       typed-racket/utils/eq-contract
       racket/sequence
-      racket/contract/parametric))
+      racket/contract/parametric
+      typed-racket/utils/shallow-contract))
 
 ;; Should the above requires be included in the output?
 ;;   This box is only used for contracts generated for `require/typed`
@@ -225,8 +236,7 @@
 ;;   submodule, which always has the above `require`s.
 (define include-extra-requires? (box #f))
 
-(define (change-contract-fixups forms)
-  (define ctc-cache (make-hash))
+(define (change-contract-fixups forms [ctc-cache (make-hash)])
   (with-new-name-tables
    (for/list ((e (in-list forms)))
      (if (not (has-contract-def-property? e))
@@ -236,7 +246,7 @@
 
 ;; TODO: These are probably all in a specific place, which could avoid
 ;;       the big traversal
-(define (change-provide-fixups forms  [ctc-cache (make-hash)])
+(define (change-provide-fixups forms [ctc-cache (make-hash)])
   (with-new-name-tables
    (for/list ([form (in-list forms)])
      (syntax-parse form #:literal-sets (kernel-literals)
@@ -293,38 +303,50 @@
 (define (contract-kind->keyword sym)
   (string->keyword (symbol->string sym)))
 
+(define typed-side?-str "(or/c 'typed 'untyped 'both)")
+
 (define (from-typed? side)
   (case side
    [(typed both) #t]
-   [(untyped) #f]))
+   [(untyped) #f]
+   [else (raise-argument-error 'from-typed? typed-side?-str side)]))
 
 (define (from-untyped? side)
   (case side
    [(untyped both) #t]
-   [(typed) #f]))
+   [(typed) #f]
+   [else (raise-argument-error 'from-untyped? typed-side?-str side)]))
 
 (define (flip-side side)
   (case side
    [(typed) 'untyped]
    [(untyped) 'typed]
-   [(both) 'both]))
+   [(both) 'both]
+   [else (raise-argument-error 'flip-side typed-side?-str side)]))
 
 ;; type->contract : Type Procedure
-;;                  #:typed-side Boolean #:kind Symbol #:cache Hash
+;;                  #:typed-side (U 'both Boolean) #:kind Symbol #:cache Hash
 ;;                  -> (U Any (List (Listof Syntax) Syntax))
 (define (type->contract ty init-fail
                         #:typed-side [typed-side #t]
-                        #:kind [kind 'impersonator]
-                        #:cache [cache (make-hash)])
+                        #:kind [pre-kind 'impersonator]
+                        #:cache [cache (make-hash)]
+                        #:enforcement-mode [te-mode (current-type-enforcement-mode)])
   (let/ec escape
     (define (fail #:reason [reason #f]) (escape (init-fail #:reason reason)))
-    (instantiate/optimize
-     (type->static-contract ty #:typed-side typed-side fail)
-     fail
-     kind
-     #:cache cache
-     #:trusted-positive typed-side
-     #:trusted-negative (not typed-side))))
+    (define sc
+      (type->static-contract ty fail
+                             #:typed-side typed-side
+                             #:enforcement-mode te-mode))
+    (define kind (if (eq? deep te-mode) pre-kind 'flat))
+    (define-values [trust-pos? trust-neg?]
+      (if (eq? typed-side 'both)
+        (values #f #f)
+        (values typed-side (not typed-side))))
+    (instantiate/optimize sc fail kind
+      #:cache cache
+      #:trusted-positive trust-pos?
+      #:trusted-negative trust-neg?)))
 
 (define any-wrap/sc (chaperone/sc #'any-wrap/c))
 
@@ -336,13 +358,25 @@
   (case side
     ((untyped) (triple-untyped trip))
     ((typed) (triple-typed trip))
-    ((both) (triple-both trip))))
+    ((both) (triple-both trip))
+    (else (raise-argument-error 'triple-lookup typed-side?-str 1 trip side))))
 (define (same sc)
   (triple sc sc sc))
 
 
 (define (type->static-contract type init-fail
-                               #:typed-side [typed-side #t])
+                               #:typed-side [typed-side #t]
+                               #:enforcement-mode [te-mode (current-type-enforcement-mode)])
+  (case te-mode
+    [(shallow)
+     (type->static-contract/shallow type #:typed-side typed-side)]
+    [(optional)
+     any/sc]
+    [else ; (deep #f)
+     (type->static-contract/deep type init-fail #:typed-side typed-side)]))
+
+(define (type->static-contract/deep type init-fail
+                                       #:typed-side [typed-side #t])
   (let/ec return
     (define (fail #:reason reason) (return (init-fail #:reason reason)))
     (let loop ([type type] [typed-side (if typed-side 'typed 'untyped)] [recursive-values (hash)])
@@ -385,20 +419,6 @@
            (and-prop/sc (map prop->sc ps))]
           [(OrProp: ps)
            (or-prop/sc (map prop->sc ps))]))
-
-      (define (obj->sc o)
-        (match o
-          [(Path: pes (? identifier? x))
-           (for/fold ([obj (id/sc x)])
-                     ([pe (in-list (reverse pes))])
-             (match pe
-               [(CarPE:) (acc-obj/sc #'car obj)]
-               [(CdrPE:) (acc-obj/sc #'cdr obj)]
-               [(VecLenPE:) (acc-obj/sc #'vector-length obj)]))]
-          [(LExp: const terms)
-           (linear-exp/sc const
-                          (for/hash ([(obj coeff) (in-terms terms)])
-                            (values (obj->sc obj) coeff)))]))
       (define (only-untyped sc)
         (if (from-typed? typed-side)
             (and/sc sc any-wrap/sc)
@@ -446,20 +466,26 @@
                (lookup-name-sc type typed-side)])]
        ;; Ordinary type applications or struct type names, just resolve
        [(or (App: _ _) (Name/struct:)) (t->sc (resolve-once type))]
-       [(Univ:) (if (from-typed? typed-side) any-wrap/sc any/sc)]
+       [(Univ:) (only-untyped any/sc)]
        [(Bottom:) (or/sc)]
        [(Listof: elem-ty) (listof/sc (t->sc elem-ty))]
        ;; This comes before Base-ctc to use the Value-style logic
        ;; for the singleton base types (e.g. -Null, 1, etc)
        [(Val-able: v)
-        (if (and (c:flat-contract? v)
-                 ;; numbers used as contracts compare with =, but TR
-                 ;; requires an equal? check
-                 (not (number? v))
-                 ;; regexps don't match themselves when used as contracts
-                 (not (or (regexp? v) (byte-regexp? v))))
-            (flat/sc #`(quote #,v))
-            (flat/sc #`(flat-named-contract '#,v (lambda (x) (equal? x '#,v))) v))]
+        (cond
+          [(eof-object? v)
+           (flat/sc #'eof-object?)]
+          [(void? v)
+           (flat/sc #'void?)]
+          [(and (c:flat-contract? v)
+                ;; numbers used as contracts compare with =, but TR
+                ;; requires an equal? check
+                (not (number? v))
+                ;; regexps don't match themselves when used as contracts
+                (not (or (regexp? v) (byte-regexp? v))))
+            (flat/sc #`(quote #,v))]
+          [else
+           (flat/sc #`(flat-named-contract '#,v (lambda (x) (equal? x '#,v))))])]
        [(Base-name/contract: sym ctc) (flat/sc ctc)]
        [(Distinction: _ _ t) ; from define-new-subtype
         (t->sc t)]
@@ -539,7 +565,7 @@
                (sequence/sc (t->sc t)))]
        [(Sequence: ts) (apply sequence/sc (map t->sc ts))]
        [(SequenceTop:)
-        (only-untyped (flat/sc #'sequence?))]
+        (only-untyped sequence?/sc)]
        [(Immutable-HeterogeneousVector: ts)
         (apply immutable-vector/sc (map t->sc ts))]
        [(Immutable-Vector: t)
@@ -570,11 +596,11 @@
        [(Promise: t)
         (promise/sc (t->sc t))]
        [(Opaque: p?)
-        (flat/sc #`(flat-named-contract (quote #,(syntax-e p?)) #,p?))]
+        (flat/sc p?)]
        [(Continuation-Mark-Keyof: t)
         (continuation-mark-key/sc (t->sc t))]
        ;; TODO: this is not quite right for case->
-       [(Prompt-Tagof: s (Fun: (list (Arrow: ts _ _ _))))
+       [(Prompt-Tagof: s (Fun: (list (Arrow: ts _ _ _ _))))
         (prompt-tag/sc (map t->sc ts) (list (t->sc s)))]
        [(Some: (list n) (? Fun? t-body))
         (t->sc/fun t-body #:maybe-existential n)]
@@ -595,6 +621,7 @@
        [(Async-ChannelTop:) (only-untyped async-channel?/sc)]
        [(MPairTop:) (only-untyped mpair?/sc)]
        [(ThreadCellTop:) (only-untyped thread-cell?/sc)]
+       [(ThreadCell: _) (fail #:reason "contract generation not supported for this type")]
        [(Prompt-TagTop:) (only-untyped prompt-tag?/sc)]
        [(Continuation-Mark-KeyTop:) (only-untyped continuation-mark-key?/sc)]
        [(ClassTop:) (only-untyped class?/sc)]
@@ -634,7 +661,8 @@
            (recursive-sc
             n*s
             (list untyped typed both)
-            (recursive-sc-use (if (from-typed? typed-side) typed-n* untyped-n*)))])]
+            (recursive-sc-use (if (from-typed? typed-side) typed-n* untyped-n*)))]
+          [else (raise-argument-error 'Mu-case typed-side?-str typed-side)])]
        ;; Don't directly use the class static contract generated for Name,
        ;; because that will get an #:opaque class contract. This will do the
        ;; wrong thing for object types since it errors too eagerly.
@@ -750,29 +778,7 @@
             (struct-type/sc null))]
        [(Struct-Property: s _) (struct-property/sc (t->sc s))]
        [(Has-Struct-Property: orig-id)
-        ;; we can't call syntax-local-value/immediate in has-struct-property case in parse-type
-        (define-values (a prop-name) (syntax-local-value/immediate orig-id (λ () (values #t orig-id))))
-        (match-define (Struct-Property: _ pred?) (lookup-id-type/lexical prop-name))
-        ;; if original-name is only set when the type is added via require/typed
-
-        ;; the original-name of `prop-name` is its original referece in the unexpanded program.
-        (define real-prop-var (or (syntax-property prop-name 'original-name) prop-name))
-
-        ;; a property is wrapped so we need its original reference
-        (define real-pred-var (or (syntax-property pred? 'original-name) (syntax-e pred?)))
-
-        ;; the `pred?` could be provided to a property through require/typed,
-        ;; so we need to check if it is produced by the property
-        (flat/sc #`(flat-named-contract '#,real-pred-var
-                                        (lambda (x)
-                                          (if (not (struct-type-property-predicate-procedure? #,pred? #,real-prop-var))
-                                              (raise-arguments-error 'struct-property
-                                                                     "predicate does not match property"
-                                                                     "predicate"
-                                                                     #,pred?
-                                                                     "property"
-                                                                     #,real-prop-var)
-                                              (#,pred? x)))))]
+        (has-struct-property->sc orig-id)]
        [(Prefab: (and key (list key-sym rst ...)) (list flds ...))
         (cond
           [(hash-ref recursive-values key #f)]
@@ -809,6 +815,317 @@
        [_
         (fail #:reason "contract generation not supported for this type")]))))
 
+(define (type->static-contract/shallow orig-type #:typed-side [typed-side? #t])
+  (let t->sc ([type orig-type]
+              [bound-all-vars '()])
+    (define (prop->sc p)
+      ;;bg copied from above, but uses different t->sc
+      (match p
+        [(TypeProp: o t)
+         (define sc (t->sc t bound-all-vars))
+         (cond
+           [(not (equal? flat-sym (get-max-contract-kind sc)))
+            (raise-user-error 'type->static-contract/shallow "proposition contract generation not supported for non-flat types")]
+           [else (is-flat-type/sc (obj->sc o) sc)])]
+        [(NotTypeProp: o t)
+         (define sc (t->sc t bound-all-vars))
+         (cond
+           [(not (equal? flat-sym (get-max-contract-kind sc)))
+            (raise-user-error 'type->static-contract/shallow "proposition contract generation not supported for non-flat types")]
+           [else (not-flat-type/sc (obj->sc o) sc)])]
+        [(LeqProp: (app obj->sc lhs) (app obj->sc rhs))
+         (leq/sc lhs rhs)]
+        [(AndProp: ps)
+         (and-prop/sc (map prop->sc ps))]
+        [(OrProp: ps)
+         (or-prop/sc (map prop->sc ps))]))
+    (match type
+     ;; Implicit recursive aliases
+     [(Name: _name-id _args #f)
+      (cond [(lookup-name-sc type 'both) ]
+            [else
+             (define resolved-name (resolve-once type))
+             (register-name-sc type
+                               (λ () (t->sc resolved-name bound-all-vars))
+                               (λ () (t->sc resolved-name bound-all-vars))
+                               (λ () (t->sc resolved-name bound-all-vars)))
+             (lookup-name-sc type 'both)])]
+     ;; Ordinary type applications or struct type names, just resolve
+     [(or (App: _ _)
+          (Name/struct:))
+      (t->sc (resolve-once type) bound-all-vars)]
+     [(Univ:) any/sc]
+     [(Bottom:) (shallow-or/sc)]
+     ;; This comes before Base-ctc to use the Value-style logic
+     ;; for the singleton base types (e.g. -Null, 1, etc)
+     [(Val-able: v)
+      (cond
+       [(eof-object? v)
+        (flat/sc #'eof-object?)]
+       [(void? v)
+        (flat/sc #'void?)]
+       [(or (symbol? v) (boolean? v) (keyword? v) (null? v) (eq? unsafe-undefined v))
+        (flat/sc #`(lambda (x) (eq? x '#,v)))]
+       [(or (number? v) (regexp? v) (byte-regexp? v) (string? v) (bytes? v) (char? v))
+        (flat/sc #`(lambda (x) (equal? x '#,v)))]
+       [else
+        (raise-arguments-error 'type->static-contract/shallow "unexpected Val-able value" "value" v "original type" type)])]
+     [(Base-name/contract: sym ctc) (flat/sc ctc)]
+     [(Distinction: _ _ t) ; from define-new-subtype
+      (t->sc t bound-all-vars)]
+     [(Refinement: par p?)
+      (shallow-and/sc (t->sc par bound-all-vars) (flat/sc p?))]
+     [(BaseUnion: bbits nbits)
+      (define numeric (make-BaseUnion #b0 nbits))
+      (define other-scs
+        (for/list ((base-t (in-list (bbits->base-types bbits))))
+          (t->sc base-t bound-all-vars)))
+      (define numeric-sc (numeric-type->static-contract numeric))
+      (if numeric-sc
+          (apply shallow-or/sc numeric-sc other-scs)
+          (apply shallow-or/sc (append other-scs
+                                         (for/list ((base-t (in-list (nbits->base-types nbits))))
+                                            (t->sc base-t bound-all-vars)))))]
+     [(? Union? t)
+      (match (normalize-type t)
+        [(Union-all-flat: elems)
+         (let* ([sc* (for/list ((e (in-list elems)))
+                       (t->sc e bound-all-vars))]
+                [sc* (remove-duplicates sc*)]
+                [sc* (remove-overlap sc*
+                       (list
+                         (cons vector?/sc (list mutable-vector?/sc immutable-vector?/sc))
+                         (cons hash?/sc (list mutable-hash?/sc weak-hash?/sc immutable-hash?/sc))))])
+           (apply shallow-or/sc sc*))]
+        [t (t->sc t bound-all-vars)])]
+     [(Intersection: ts raw-prop)
+      (define scs
+        (for/list ((t (in-list ts)))
+          (t->sc t bound-all-vars)))
+      (define prop/sc
+        (cond
+          [(TrueProp? raw-prop) #f]
+          [else (define x (genid))
+                (define prop (Intersection-prop (-id-path x) type))
+                (define name (format "~a" `(λ (,(syntax->datum x)) ,prop)))
+                (flat-named-lambda/sc name
+                                      (id/sc x)
+                                      (prop->sc prop))]))
+      (apply shallow-and/sc (append scs (if prop/sc (list prop/sc) '())))]
+     [(Fun: arrows)
+      (if (null? arrows)
+        procedure?/sc
+        (apply shallow-and/sc
+               (for/list ((arr (in-list arrows)))
+                 (arrow->sc/shallow arr typed-side?))))]
+     [(DepFun: raw-dom _ rng)
+      (define num-mand-args (length raw-dom))
+      (if (and (not typed-side?) (arrow-rng-has-prop? rng))
+        none/sc
+        (make-procedure-arity-flat/sc num-mand-args '() '()))]
+     [(Set: _) set?/sc]
+     [(or (Sequence: _)
+          (SequenceTop:)
+          (SequenceDots: _ _ _))
+      sequence?/sc]
+     [(Immutable-HeterogeneousVector: ts)
+      (immutable-vector-length/sc (length ts))]
+     [(Immutable-Vector: _)
+      immutable-vector?/sc]
+     [(Mutable-HeterogeneousVector: ts)
+      (mutable-vector-length/sc (length ts))]
+     [(or (Mutable-Vector: _)
+          (Mutable-VectorTop:))
+      mutable-vector?/sc]
+     [(or (Box: _)
+          (BoxTop:))
+      box?/sc]
+     [(or (Weak-Box: _)
+          (Weak-BoxTop:))
+      weak-box?/sc]
+     [(or (Listof: _)
+          (ListDots: _ _))
+      list?/sc]
+     [(Pair: _ t-cdr)
+      ;; look ahead, try making list/sc
+      (let cdr-loop ((t t-cdr)
+                     (num-elems 1))
+        (match t
+         [(Pair: _ t-cdr)
+          (cdr-loop t-cdr (+ num-elems 1))]
+         [(== -Null)
+          (list-length/sc num-elems)]
+         [_
+          cons?/sc]))]
+     [(or (Async-Channel: _)
+          (Async-ChannelTop:))
+      async-channel?/sc]
+     [(Promise: _)
+      promise?/sc]
+     [(Opaque: p?)
+      (flat/sc p?)]
+     [(or (Continuation-Mark-Keyof: _)
+          (Continuation-Mark-KeyTop:))
+      continuation-mark-key?/sc]
+     [(or (Prompt-Tagof: _ _)
+          (Prompt-TagTop:))
+      prompt-tag?/sc]
+     [(F: v)
+      (if (member v bound-all-vars)
+        none/sc
+        any/sc)]
+     [(or (MPair: _ _)
+          (MPairTop:))
+      mpair?/sc]
+     [(or (ThreadCell: _)
+          (ThreadCellTop:))
+      thread-cell?/sc]
+     [(ClassTop:) class?/sc]
+     [(UnitTop:) unit?/sc]
+     [(or (Poly: vs b)
+          (PolyDots: (list vs ... _) b)
+          (PolyRow: vs b _))
+      (t->sc b (append bound-all-vars vs))]
+     [(Mu: n b)
+      (t->sc b bound-all-vars)]
+     [(Instance: (? Name? t))
+      #:when (Class? (resolve-once t))
+      (cond [(lookup-name-sc type 'both)]
+            [else
+             (define resolved (make-Instance (resolve-once t)))
+             (register-name-sc type
+                               (λ () (t->sc resolved bound-all-vars))
+                               (λ () (t->sc resolved bound-all-vars))
+                               (λ () (t->sc resolved bound-all-vars)))
+             (lookup-name-sc type 'both)])]
+     [(Instance: (Class: _ _ fields methods _ _))
+      (make-object-shape/sc (map car fields) (map car methods))]
+     [(Class: row-var inits fields publics augments _)
+      (make-class-shape/sc (map car inits) (map car fields) (map car publics) (map car augments))]
+     [(Unit: imports exports init-depends results)
+      unit?/sc]
+     [(or (Struct: _ _ _ _ _ pred? _)
+          (StructTop: (Struct: _ _ _ _ _ pred? _)))
+      (flat/sc #`(lambda (x) (#,pred? x)))]
+     [(StructTypeTop:)
+      struct-type?/sc]
+     [(StructType: s)
+      (t->sc s bound-all-vars)]
+     [(Struct-Property: s _)
+      struct-type-property?/sc]
+     [(Has-Struct-Property: orig-id)
+      (has-struct-property->sc orig-id)]
+     [(or (Prefab: key _)
+          (PrefabTop: key))
+      (flat/sc #`(struct-type-make-predicate
+                  (prefab-key->struct-type (quote #,(abbreviate-prefab-key key))
+                                           #,(prefab-key->field-count key))))]
+     [(Syntax: (? Base:Symbol?))
+      identifier?/sc]
+     [(Syntax: t)
+      syntax?/sc]
+     [(Param: in out)
+      parameter?/sc]
+     [(or (Mutable-HashTable: _ _)
+          (Mutable-HashTableTop:))
+      mutable-hash?/sc]
+     [(Immutable-HashTable: _ _)
+      immutable-hash?/sc]
+     [(or (Weak-HashTable: _ _)
+          (Weak-HashTableTop:))
+      weak-hash?/sc]
+     [(or (Channel: _)
+          (ChannelTop:))
+      channel?/sc]
+     [(Evt: t)
+      evt?/sc]
+     [(? Prop? rep) (prop->sc rep)]
+     [(Ephemeron: _)
+      ephemeron?/sc]
+     [(Future: _)
+      future?/sc]
+     [_
+      (raise-arguments-error 'type->static-contract/shallow "contract generation not supported for this type" "type" type "original" orig-type)])))
+
+(define (remove-overlap sc* pattern*)
+  (for/fold ((acc sc*))
+            ((kv* (in-list pattern*)))
+    (define replacement (car kv*))
+    (define tgt* (cdr kv*))
+    (define-values [success? acc+] (remove** tgt* acc))
+    (if success?
+      (cons replacement acc+)
+      acc)))
+
+(define (remove** target* sc*)
+  (for/fold ((success? #t)
+             (sc* sc*))
+            ((t (in-list target*)))
+    (values (and success?
+                 (member t sc*))
+            (filter (lambda (x) (not (equal? x t))) sc*))))
+
+(define (obj->sc o)
+  (match o
+    [(Path: pes (? identifier? x))
+     (for/fold ([obj (id/sc x)])
+               ([pe (in-list (reverse pes))])
+       (match pe
+         [(CarPE:) (acc-obj/sc #'car obj)]
+         [(CdrPE:) (acc-obj/sc #'cdr obj)]
+         [(VecLenPE:) (acc-obj/sc #'vector-length obj)]))]
+    [(LExp: const terms)
+     (linear-exp/sc const
+                    (for/hash ([(obj coeff) (in-terms terms)])
+                      (values (obj->sc obj) coeff)))]
+    [else
+      (raise-argument-error 'obj->sc "Object?" o)]))
+
+(define (partition-kws kws)
+  (partition (match-lambda [(Keyword: _ _ mand?) mand?]) kws))
+
+(define arrow->sc/shallow
+  (let ((conv (match-lambda [(Keyword: kw _ _) kw])))
+    (lambda (orig-ty typed-side?)
+      (match orig-ty
+        [(Arrow: _ _ _ rng _)
+         #:when (and (not typed-side?) (arrow-rng-has-prop? rng))
+         none/sc]
+        [(Arrow: _ (RestDots: _ _) _ _ _)
+         procedure?/sc]
+        [(Arrow: dom _ kws _ _)
+         (define num-mand-args (length dom))
+         (define-values [mand-kws opt-kws]
+           (let-values ([(mand-kws opt-kws) (partition-kws kws)])
+             (values (map conv mand-kws) (map conv opt-kws))))
+         (make-procedure-arity-flat/sc num-mand-args mand-kws opt-kws)]))))
+
+(define (arrow-rng-has-prop? rng)
+  (match rng
+    [(Values: (list (Result: _
+                             (PropSet: (TrueProp:)
+                                       (TrueProp:))
+                             (Empty:)) ...))
+     #f]
+    ;; Functions that don't return
+    [(Values: (list (Result: (== -Bottom) _ _) ...))
+     #f]
+    ;; functions with props or objects
+    [(Values: (list (Result: rngs _ _) ...))
+     #true]
+    [(? ValuesDots?)
+     #f]
+    [(? AnyValues?)
+     #f]))
+
+(define (make-procedure-arity-flat/sc num-mand mand-kws opt-kws)
+  (flat/sc
+    #`(λ (f)
+        (and (procedure? f)
+             (procedure-arity-includes? f '#,num-mand '#,(not (null? mand-kws)))
+             #,@(if (and (null? mand-kws) (null? opt-kws))
+                  #'()
+                  #`((procedure-arity-includes-keywords? f '#,mand-kws '#,opt-kws)))))))
 
 (define (t->sc/function f fail typed-side recursive-values loop method? #:maybe-existential [opt-exi #f])
   (define (t->sc t #:recursive-values (recursive-values recursive-values))
@@ -822,12 +1139,12 @@
           (set-member? (free-vars-names (free-vars* t)) exi)))
 
     (match* (rng prop+type)
-      [((Fun: (list (Arrow: (list-rest (F: n1) a ... _) rst_i kw_i r))) (F: n1))
+      [((Fun: (list (Arrow: (list-rest (F: n1) a ... _) rst_i kw_i _ _))) (F: n1))
        #:when (and (not (ormap occur? (list rst kw rst_i kw_i)))
                    (eq? n1 exi))
        (void)]
       [(_ _) (fail #:reason
-                   "contract generation only supports Some Type in this form: (Some (X) (-> ty1 ... (-> X ty ... ty2) : X)) or (-> ty1 ... (Some (X) (-> X ty ... ty2) : X)))")])
+                   "contract generation only supports Some Type in this form: (Some (X) (-> ty1 ... (-> X ty ... ty2) : X)) or (-> ty1 ... (Some (X) (-> X ty ... ty2) : X))")])
 
     (define/with-syntax name exi)
     (define lhs (t->sc/neg dom))
@@ -843,7 +1160,7 @@
   ;; and call the given thunk or raise an error
   (define (handle-arrow-range arrow proceed)
     (match arrow
-      [(or (Arrow: _ _ _ rng)
+      [(or (Arrow: _ _ _ rng _)
            (DepFun: _ _ rng))
        (handle-range rng proceed)]))
   (define (handle-range rng proceed)
@@ -892,7 +1209,7 @@
         (define last-arrow (last arrows))
         (define (convert-arrow)
           (match-define (Arrow: first-dom _ kws
-                                (Values: (list (Result: rngs _ _) ...)))
+                                (Values: (list (Result: rngs _ _) ...)) _)
             first-arrow)
           (define rst (Arrow-rst last-arrow))
 
@@ -910,16 +1227,16 @@
         (handle-arrow-range first-arrow convert-arrow)]
        [else
         (define/match (convert-single-arrow arr)
-          [((Arrow: (list dom) rst kws (Values: (list (Result: rng (PropSet: (TypeProp: _ prop+type) _) _ 0)))))
+          [((Arrow: (list dom) rst kws (Values: (list (Result: rng (PropSet: (TypeProp: _ prop+type) _) _ 0))) _))
            #:when opt-exi
            (let-values ([(mand-kws opt-kws) (partition-kws kws)])
              (arr-params->exist/sc opt-exi dom rst kws rng prop+type))]
 
-          [((Arrow: (list dom) rst kws (Values: (list (ExistentialResult: rng (PropSet: (TypeProp: _ prop+type) _) _ vars)))))
+          [((Arrow: (list dom) rst kws (Values: (list (ExistentialResult: rng (PropSet: (TypeProp: _ prop+type) _) _ vars))) _))
            (let*-values ([(mand-kws opt-kws) (partition-kws kws)])
              (arr-params->exist/sc (F-n (car vars)) dom rst kws rng prop+type))]
 
-          [((Arrow: dom rst kws (Values: (list (Result: rngs _ _ n-exiss) ...))))
+          [((Arrow: dom rst kws (Values: (list (Result: rngs _ _ n-exiss) ...)) _))
            (define-values (mand-kws opt-kws) (partition-kws kws))
            (function/sc
                  (from-typed? typed-side)
@@ -938,7 +1255,7 @@
                  (map t->sc rngs))])
 
         (define/match (convert-one-arrow-in-many arr)
-          [((Arrow: dom rst kws (Values: (list (Result: rngs _ _ n-exis) ...))))
+          [((Arrow: dom rst kws (Values: (list (Result: rngs _ _ n-exis) ...)) _))
            (let-values ([(mand-kws opt-kws) (partition-kws kws)])
              ;; Garr, I hate case->!
              (when (and (not (empty? kws)))
@@ -1074,6 +1391,31 @@
           (sealing->/sc temporaries (take constraints 3)
             (t->sc b #:recursive-values rv))))))
 
+(define (has-struct-property->sc orig-id)
+  ;; we can't call syntax-local-value/immediate in has-struct-property case in parse-type
+  (define-values (a prop-name) (syntax-local-value/immediate orig-id (λ () (values #t orig-id))))
+  (match-define (Struct-Property: _ pred?) (lookup-id-type/lexical prop-name))
+  ;; if original-name is only set when the type is added via require/typed
+
+  ;; the original-name of `prop-name` is its original referece in the unexpanded program.
+  (define real-prop-var (or (syntax-property prop-name 'original-name) prop-name))
+
+  ;; a property is wrapped so we need its original reference
+  (define real-pred-var (or (syntax-property pred? 'original-name) (syntax-e pred?)))
+
+  ;; the `pred?` could be provided to a property through require/typed,
+  ;; so we need to check if it is produced by the property
+  (flat/sc #`(flat-named-contract '#,real-pred-var
+                                  (lambda (x)
+                                    (if (not (struct-type-property-predicate-procedure? #,pred? #,real-prop-var))
+                                        (raise-arguments-error 'struct-property
+                                                               "predicate does not match property"
+                                                               "predicate"
+                                                               #,pred?
+                                                               "property"
+                                                               #,real-prop-var)
+                                        (#,pred? x))))))
+
 ;; Predicate that checks for an App type with a recursive
 ;; Name type in application position
 (define (has-name-app? type)
@@ -1089,7 +1431,7 @@
   (match arrs
     [(list (Arrow: (list (Univ:))
                    #f '()
-                   (Values: (list (Result: t _ _)))))
+                   (Values: (list (Result: t _ _))) _))
      (t:subtype -Boolean t)]
     [_ #f]))
 
@@ -1205,11 +1547,11 @@
        [_ #false]))))
 
 (module predicates racket/base
-  (require racket/extflonum (only-in racket/contract/base >=/c <=/c))
+  (require racket/extflonum)
   (provide nonnegative? nonpositive?
            extflonum? extflzero? extflnonnegative? extflnonpositive?)
-  (define nonnegative? (>=/c 0))
-  (define nonpositive? (<=/c 0))
+  (define nonnegative? (lambda (x) (>= x 0)))
+  (define nonpositive? (lambda (x) (<= x 0)))
   (define extflzero? (lambda (x) (extfl= x 0.0t0)))
   (define extflnonnegative? (lambda (x) (extfl>= x 0.0t0)))
   (define extflnonpositive? (lambda (x) (extfl<= x 0.0t0))))
@@ -1222,7 +1564,7 @@
       racket/base
       racket/contract
       (submod ".." predicates)
-      (prefix-in t: "../types/numeric-predicates.rkt")))
+      (prefix-in t: (types numeric-predicates))))
   (provide (all-defined-out))
 
   (define-syntax-rule (numeric/sc name body) (flat/sc #'body))
@@ -1261,17 +1603,18 @@
   (define inexact-real/sc (numeric/sc Inexact-Real inexact-real?))
   (define real-zero/sc (numeric/sc Real-Zero (and/c real? zero?)))
   (define positive-real/sc (numeric/sc Positive-Real (and/c real? positive?)))
-  (define nonnegative-real/sc (numeric/sc Nonnegative-Real nonnegative?)) ; implies `real?`
+  (define nonnegative-real/sc (numeric/sc Nonnegative-Real (and/c real? nonnegative?)))
   (define negative-real/sc (numeric/sc Negative-Real (and/c real? negative?)))
-  (define nonpositive-real/sc (numeric/sc Nonpositive-Real nonpositive?)) ; implies `real?`
+  (define nonpositive-real/sc (numeric/sc Nonpositive-Real (and/c real? nonpositive?)))
   (define real/sc (numeric/sc Real real?))
   (define exact-number/sc (numeric/sc Exact-Number (and/c number? exact?)))
   (define inexact-complex/sc
     (numeric/sc Inexact-Complex
-                 (and/c number?
-                   (lambda (x)
-                     (and (inexact-real? (imag-part x))
-                          (inexact-real? (real-part x)))))))
+                (and/c
+                  number?
+                  (lambda (x)
+                    (and (inexact-real? (imag-part x))
+                         (inexact-real? (real-part x)))))))
   (define number/sc (numeric/sc Number number?))
 
   (define extflonum-zero/sc (numeric/sc ExtFlonum-Zero (and/c extflonum? extflzero?)))

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -600,7 +600,7 @@
        [(Continuation-Mark-Keyof: t)
         (continuation-mark-key/sc (t->sc t))]
        ;; TODO: this is not quite right for case->
-       [(Prompt-Tagof: s (Fun: (list (Arrow: ts _ _ _ _))))
+       [(Prompt-Tagof: s (Fun: (list (Arrow: ts _ _ _))))
         (prompt-tag/sc (map t->sc ts) (list (t->sc s)))]
        [(Some: (list n) (? Fun? t-body))
         (t->sc/fun t-body #:maybe-existential n)]
@@ -1088,12 +1088,12 @@
   (let ((conv (match-lambda [(Keyword: kw _ _) kw])))
     (lambda (orig-ty typed-side?)
       (match orig-ty
-        [(Arrow: _ _ _ rng _)
+        [(Arrow: _ _ _ rng)
          #:when (and (not typed-side?) (arrow-rng-has-prop? rng))
          none/sc]
-        [(Arrow: _ (RestDots: _ _) _ _ _)
+        [(Arrow: _ (RestDots: _ _) _ _)
          procedure?/sc]
-        [(Arrow: dom _ kws _ _)
+        [(Arrow: dom _ kws _)
          (define num-mand-args (length dom))
          (define-values [mand-kws opt-kws]
            (let-values ([(mand-kws opt-kws) (partition-kws kws)])
@@ -1139,7 +1139,7 @@
           (set-member? (free-vars-names (free-vars* t)) exi)))
 
     (match* (rng prop+type)
-      [((Fun: (list (Arrow: (list-rest (F: n1) a ... _) rst_i kw_i _ _))) (F: n1))
+      [((Fun: (list (Arrow: (list-rest (F: n1) a ... _) rst_i kw_i _))) (F: n1))
        #:when (and (not (ormap occur? (list rst kw rst_i kw_i)))
                    (eq? n1 exi))
        (void)]
@@ -1160,7 +1160,7 @@
   ;; and call the given thunk or raise an error
   (define (handle-arrow-range arrow proceed)
     (match arrow
-      [(or (Arrow: _ _ _ rng _)
+      [(or (Arrow: _ _ _ rng)
            (DepFun: _ _ rng))
        (handle-range rng proceed)]))
   (define (handle-range rng proceed)
@@ -1209,7 +1209,7 @@
         (define last-arrow (last arrows))
         (define (convert-arrow)
           (match-define (Arrow: first-dom _ kws
-                                (Values: (list (Result: rngs _ _) ...)) _)
+                                (Values: (list (Result: rngs _ _) ...)))
             first-arrow)
           (define rst (Arrow-rst last-arrow))
 
@@ -1227,16 +1227,16 @@
         (handle-arrow-range first-arrow convert-arrow)]
        [else
         (define/match (convert-single-arrow arr)
-          [((Arrow: (list dom) rst kws (Values: (list (Result: rng (PropSet: (TypeProp: _ prop+type) _) _ 0))) _))
+          [((Arrow: (list dom) rst kws (Values: (list (Result: rng (PropSet: (TypeProp: _ prop+type) _) _ 0)))))
            #:when opt-exi
            (let-values ([(mand-kws opt-kws) (partition-kws kws)])
              (arr-params->exist/sc opt-exi dom rst kws rng prop+type))]
 
-          [((Arrow: (list dom) rst kws (Values: (list (ExistentialResult: rng (PropSet: (TypeProp: _ prop+type) _) _ vars))) _))
+          [((Arrow: (list dom) rst kws (Values: (list (ExistentialResult: rng (PropSet: (TypeProp: _ prop+type) _) _ vars)))))
            (let*-values ([(mand-kws opt-kws) (partition-kws kws)])
              (arr-params->exist/sc (F-n (car vars)) dom rst kws rng prop+type))]
 
-          [((Arrow: dom rst kws (Values: (list (Result: rngs _ _ n-exiss) ...)) _))
+          [((Arrow: dom rst kws (Values: (list (Result: rngs _ _ n-exiss) ...))))
            (define-values (mand-kws opt-kws) (partition-kws kws))
            (function/sc
                  (from-typed? typed-side)
@@ -1255,7 +1255,7 @@
                  (map t->sc rngs))])
 
         (define/match (convert-one-arrow-in-many arr)
-          [((Arrow: dom rst kws (Values: (list (Result: rngs _ _ n-exis) ...)) _))
+          [((Arrow: dom rst kws (Values: (list (Result: rngs _ _ n-exis) ...))))
            (let-values ([(mand-kws opt-kws) (partition-kws kws)])
              ;; Garr, I hate case->!
              (when (and (not (empty? kws)))
@@ -1431,7 +1431,7 @@
   (match arrs
     [(list (Arrow: (list (Univ:))
                    #f '()
-                   (Values: (list (Result: t _ _))) _))
+                   (Values: (list (Result: t _ _)))))
      (t:subtype -Boolean t)]
     [_ #f]))
 

--- a/typed-racket-lib/typed-racket/rep/rep-utils.rkt
+++ b/typed-racket-lib/typed-racket/rep/rep-utils.rkt
@@ -395,8 +395,6 @@
      ;; Error checking
      ;; - - - - - - - - - - - - - - -
 
-     ;; build convenient boolean flags
-     (define is-a-type? (and (attribute parent) (eq? 'Type (syntax-e #'parent))))
      ;; singletons cannot have fields or #:no-provide
      (when (and (attribute singleton)
                 (or (attribute no-provide?-kw)

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -716,14 +716,14 @@
     (syntax-case stx ()
       [(_ dom rst kws rng)
        #'(? Arrow? (app (lambda (arrow)
-                           (match-define (Arrow: d r k r _) arrow)
-                           (list d r k r))
-                         (list dom rst kws rng)))]
+                          (match-define (Arrow: domain rest keywords range _) arrow)
+                          (list domain rest keywords range))
+                        (list dom rst kws rng)))]
       [(_ dom rst kws rng rng-T+)
        #'(? Arrow? (app (lambda (arrow)
-                           (match-define (Arrow: d r k r T+) arrow)
-                           (list d r k r T+))
-                         (list dom rst kws rng rng-T+)))])))
+                          (match-define (Arrow: domain rest keywords range rng-shallow-safe?) arrow)
+                          (list domain rest keywords range rng-shallow-safe?))
+                        (list dom rst kws rng rng-T+)))])))
 
 ;; a standard function
 ;; + all functions are case-> under the hood (i.e. see 'arrows')

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -69,7 +69,8 @@
          variances-in-type
          DepFun/ids:
          HasArrows:
-         (rename-out [Union:* Union:]
+         (rename-out [Arrow:* Arrow:]
+                     [Union:* Union:]
                      [Intersection:* Intersection:]
                      [make-Intersection* make-Intersection]
                      [Class:* Class:]
@@ -616,6 +617,7 @@
                 [kws (and/c (listof Keyword?) keyword-sorted/c)]
                 [rng SomeValues?]
                 [rng-shallow-safe? boolean?])
+  #:no-provide (Arrow:)
   [#:frees (f)
    (combine-frees
     (list* (f rng)
@@ -708,6 +710,20 @@
     [else
      (error 'Arrow-domain-at-arity
             "invalid arity! ~a @ ~a" a arity)]))
+
+(define-match-expander Arrow:*
+  (lambda (stx)
+    (syntax-case stx ()
+      [(_ dom rst kws rng)
+       #'(? Arrow? (app (lambda (arrow)
+                           (match-define (Arrow: d r k r _) arrow)
+                           (list d r k r))
+                         (list dom rst kws rng)))]
+      [(_ dom rst kws rng rng-T+)
+       #'(? Arrow? (app (lambda (arrow)
+                           (match-define (Arrow: d r k r T+) arrow)
+                           (list d r k r T+))
+                         (list dom rst kws rng rng-T+)))])))
 
 ;; a standard function
 ;; + all functions are case-> under the hood (i.e. see 'arrows')

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/derived.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/derived.rkt
@@ -6,11 +6,12 @@
 
 (require "simple.rkt" "structural.rkt"
          (for-template racket/base racket/list racket/set racket/promise
-                       racket/class racket/unit racket/async-channel))
+                       racket/class racket/unit racket/async-channel racket/future))
 (provide (all-defined-out))
 
 (define identifier?/sc (flat/sc #'identifier?))
 (define box?/sc (flat/sc #'box?))
+(define weak-box?/sc (flat/sc #'weak-box?))
 (define syntax?/sc (flat/sc #'syntax?))
 (define promise?/sc (flat/sc #'promise?))
 
@@ -19,7 +20,7 @@
 
 (define mpair?/sc (flat/sc #'mpair?))
 
-(define set?/sc (flat/sc #'set?))
+(define set?/sc (flat/sc #'(lambda (x) (or (set? x) (set-mutable? x) (set-weak? x)))))
 (define empty-set/sc (and/sc set?/sc (flat/sc #'set-empty?)))
 
 (define vector?/sc (flat/sc #'vector?))
@@ -41,8 +42,16 @@
 (define thread-cell?/sc (flat/sc #'thread-cell?))
 (define prompt-tag?/sc (flat/sc #'continuation-prompt-tag?))
 (define continuation-mark-key?/sc (flat/sc #'continuation-mark-key?))
+(define sequence?/sc (flat/sc #'sequence?))
+(define evt?/sc (flat/sc #'evt?))
+(define parameter?/sc (flat/sc #'parameter?))
+(define ephemeron?/sc (flat/sc #'ephemeron?))
+(define future?/sc (flat/sc #'future?))
+(define procedure?/sc (flat/sc #'procedure?))
 
 (define class?/sc (flat/sc #'class?))
 (define unit?/sc (flat/sc #'unit?))
 
 (define struct-type?/sc (flat/sc #'struct-type?))
+(define struct-type-property?/sc (flat/sc #'struct-type-property?))
+

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/name.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/name.rkt
@@ -72,7 +72,8 @@
        (case typed-side
          [(both)    (car result)]
          [(typed)   (cadr result)]
-         [(untyped) (caddr result)])))
+         [(untyped) (caddr result)]
+         [else (raise-argument-error 'lookup-name-sc "side?" typed-side)])))
 
 (define (register-name-sc type typed-thunk untyped-thunk both-thunk)
   (define-values (typed-name untyped-name both-name)

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
@@ -18,6 +18,7 @@
                        racket/promise
                        "../../utils/evt-contract.rkt"
                        "../../utils/hash-contract.rkt"
+                       "../../utils/shallow-contract.rkt"
                        "../../utils/vector-contract.rkt"
                        "../../utils/promise-not-name-contract.rkt")
          racket/contract
@@ -153,6 +154,8 @@
 (combinator-structs
   ((or/sc . (#:covariant)) or/c #:flat)
   ((and/sc . (#:covariant)) and/c #:flat)
+  ((shallow-or/sc . (#:covariant)) shallow-or/c #:flat)
+  ((shallow-and/sc . (#:covariant)) shallow-and/c #:flat)
   ((list/sc . (#:covariant)) list/c #:flat)
   ((listof/sc (#:covariant)) listof #:flat)
   ((cons/sc (#:covariant) (#:covariant)) cons/c #:flat)

--- a/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
@@ -26,11 +26,11 @@
 (provide/cond-contract
  [instantiate/optimize
      (parametric->/c (a) ((static-contract? (-> #:reason (or/c #f string?) a))
-                          (contract-kind? #:cache hash? #:trusted-positive boolean? #:trusted-negative boolean?)
+                          (contract-kind? #:cache (or/c #f hash?) #:trusted-positive boolean? #:trusted-negative boolean?)
                           . ->* . (or/c a (list/c (listof syntax?) syntax?))))]
  [instantiate
      (parametric->/c (a) ((static-contract? (-> #:reason (or/c #f string?) a))
-                          (contract-kind? #:cache hash? #:recursive-kinds (or/c hash? #f))
+                          (contract-kind? #:cache (or/c #f hash?) #:recursive-kinds (or/c hash? #f))
                           . ->* . (or/c a (list/c (listof syntax?) syntax?))))]
  [should-inline-contract? (-> syntax? boolean?)])
 

--- a/typed-racket-lib/typed-racket/typecheck/check-below.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-below.rkt
@@ -10,6 +10,7 @@
          "../types/abbrev.rkt"
          "../types/tc-result.rkt"
          "../utils/tc-utils.rkt"
+         "../utils/shallow-utils.rkt"
          "../rep/type-rep.rkt"
          "../rep/object-rep.rkt"
          "../rep/prop-rep.rkt"
@@ -102,7 +103,7 @@
             (expected-but-got t2 t1)))]
        [else (unless (subtype t1 t2 o1)
                (expected-but-got t2 t1))])
-     t2]
+     (upgrade-trusted-rng t1 t2)]
     ;; This case has to be first so that bottom (exceptions, etc.) can be allowed in cases
     ;; where multiple values are expected.
     ;; We can ignore the props and objects in the actual value because they would never be about a value
@@ -141,7 +142,7 @@
           (type-mismatch (format "`~a' and `~a'" p2 (print-object o2))
                          (format "`~a' and `~a'" p1 (print-object o1))
                          "mismatch in proposition and object")])
-       (ret t2 (fix-props p2 p1) (fix-object o2 o1)))
+       (ret (upgrade-trusted-rng t1 t2) (fix-props p2 p1) (fix-object o2 o1)))
      (cond
        [(with-refinements?)
         (with-naively-extended-lexical-env
@@ -193,6 +194,13 @@
     [((? Type? t1) (? Type? t2))
      (unless (subtype t1 t2)
        (expected-but-got t2 t1))
-     expected]
+     (upgrade-trusted-rng t1 expected)]
 
     [(a b) (int-err "unexpected input for check-below: ~a ~a" a b)]))
+
+;; shallow: if the top-level arrow on t1 is reliable, then upgrade the top-level arrow in t2
+(define (upgrade-trusted-rng t1 t2)
+  (if (shallow-trusted-positive? t1)
+    (set-shallow-trusted-positive t2)
+    t2))
+

--- a/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -1029,7 +1029,7 @@
 (define (setter->type id)
   (define f-type (lookup-id-type/lexical id))
   (match f-type
-    [(Fun: (list (Arrow: (list _ t) _ _ _ _))) t]
+    [(Fun: (list (Arrow: (list _ t) _ _ _))) t]
     [_ (int-err "setter->type ~a" (syntax-e id))]))
 
 ;; check-init-arg : Id Type Syntax -> Void
@@ -1044,7 +1044,7 @@
            (define type
              (tc-expr/check/t init-val (ret (->* null init-type))))
            (match type
-             [(Fun: (list (Arrow: _ _ _ (Values: (list (Result: result _ _))) _)))
+             [(Fun: (list (Arrow: _ _ _ (Values: (list (Result: result _ _))))))
               (check-below result init-type)]
              [_ (int-err "unexpected init value ~a"
                          (syntax->datum init-val))])]

--- a/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -3,6 +3,7 @@
 ;; This module provides a unit for type-checking classes
 
 (require "../utils/utils.rkt"
+         "../utils/class-utils.rkt"
          racket/dict
          racket/format
          racket/list
@@ -69,57 +70,6 @@
             (format "TR class time @ ~a: ~a"
                     str (- (current-inexact-milliseconds) (start-time))))
          #'(void))]))
-
-;; Syntax classes for use in functions below
-(define-syntax-class name-pair
-  (pattern (internal:id external:id)))
-
-(define-syntax-class internal-class-data
-  #:literal-sets (kernel-literals)
-  #:literals (class-internal values)
-  (pattern (let-values ([() (begin (quote-syntax
-                                    (class-internal
-                                     (#:forall type-parameter:id ...)
-                                     (#:all-inits all-init-names:id ...)
-                                     (#:init init-names:name-pair ...)
-                                     (#:init-field init-field-names:name-pair ...)
-                                     (#:init-rest (~optional init-rest-name:id))
-                                     (#:optional-init optional-names:id ...)
-                                     (#:field field-names:name-pair ...)
-                                     (#:public public-names:name-pair ...)
-                                     (#:override override-names:name-pair ...)
-                                     (#:private privates:id ...)
-                                     (#:private-field private-fields:id ...)
-                                     (#:inherit inherit-names:name-pair ...)
-                                     (#:inherit-field inherit-field-names:name-pair ...)
-                                     (#:augment augment-names:name-pair ...)
-                                     (#:pubment pubment-names:name-pair ...))
-                                    #:local)
-                                   (#%plain-app values))])
-             _)
-           #:with type-parameters #'(type-parameter ...)
-           #:with all-init-internals #'(all-init-names ...)
-           #:with init-internals #'(init-names.internal ...)
-           #:with init-externals #'(init-names.external ...)
-           #:with init-field-internals #'(init-field-names.internal ...)
-           #:with init-field-externals #'(init-field-names.external ...)
-           #:with optional-inits #'(optional-names ...)
-           #:with field-internals #'(field-names.internal ...)
-           #:with field-externals #'(field-names.external ...)
-           #:with public-internals #'(public-names.internal ...)
-           #:with public-externals #'(public-names.external ...)
-           #:with override-internals #'(override-names.internal ...)
-           #:with override-externals #'(override-names.external ...)
-           #:with inherit-externals #'(inherit-names.external ...)
-           #:with inherit-internals #'(inherit-names.internal ...)
-           #:with inherit-field-externals #'(inherit-field-names.external ...)
-           #:with inherit-field-internals #'(inherit-field-names.internal ...)
-           #:with augment-externals #'(augment-names.external ...)
-           #:with augment-internals #'(augment-names.internal ...)
-           #:with pubment-externals #'(pubment-names.external ...)
-           #:with pubment-internals #'(pubment-names.internal ...)
-           #:with private-names #'(privates ...)
-           #:with private-field-names #'(private-fields ...)))
 
 (define-syntax-class initializer-body
   #:literals (letrec-values let-values #%expression)
@@ -363,91 +313,19 @@
      (define super-type (tc-expr #'cls.superclass-expr))
      (define class-name-table
        (car (trawl-for-property #'cls.make-methods tr:class:name-table-property)))
-     (syntax-parse class-name-table
-       [tbl:internal-class-data
-        ;; Save parse attributes to pass through to helper functions
-        (define type-parameters (syntax->datum #'tbl.type-parameters))
-        (define fresh-parameters (map gensym type-parameters))
-        (define parse-info
-          (hash 'type-parameters     type-parameters
-                'fresh-parameters    fresh-parameters
-                'superclass-expr     #'cls.superclass-expr
-                'make-methods        #'cls.make-methods
-                'initializer-self-id #'cls.initializer-self-id
-                'initializer-args-id #'cls.initializer-args-id
-                'initializer-body    #'cls.initializer-body
-                'optional-inits      (syntax->datum #'tbl.optional-inits)
-                'only-init-internals (syntax->datum #'tbl.init-internals)
-                'only-init-names     (syntax->datum #'tbl.init-externals)
-                ;; the order of these names reflect the order in the class,
-                ;; so use this list when retaining the order is important
-                'init-internals      (syntax->datum #'tbl.all-init-internals)
-                'init-rest-name     (and (attribute tbl.init-rest-name)
-                                         (syntax-e (attribute tbl.init-rest-name)))
-                'public-internals   (syntax->datum #'tbl.public-internals)
-                'override-internals (syntax->datum #'tbl.override-internals)
-                'pubment-internals  (syntax->datum #'tbl.pubment-internals)
-                'augment-internals  (syntax->datum #'tbl.augment-internals)
-                'method-internals
-                (set-union (syntax->datum #'tbl.public-internals)
-                           (syntax->datum #'tbl.override-internals))
-                'field-internals
-                (set-union (syntax->datum #'tbl.field-internals)
-                           (syntax->datum #'tbl.init-field-internals))
-                'inherit-internals
-                (syntax->datum #'tbl.inherit-internals)
-                'inherit-field-internals
-                (syntax->datum #'tbl.inherit-field-internals)
-                'init-names
-                (set-union (syntax->datum #'tbl.init-externals)
-                           (syntax->datum #'tbl.init-field-externals))
-                'field-names
-                (set-union (syntax->datum #'tbl.field-externals)
-                           (syntax->datum #'tbl.init-field-externals))
-                'public-names   (syntax->datum #'tbl.public-externals)
-                'override-names (syntax->datum #'tbl.override-externals)
-                'pubment-names  (syntax->datum #'tbl.pubment-externals)
-                'augment-names  (syntax->datum #'tbl.augment-externals)
-                'inherit-names  (syntax->datum #'tbl.inherit-externals)
-                'inherit-field-names
-                (syntax->datum #'tbl.inherit-field-externals)
-                'private-names  (syntax->datum #'tbl.private-names)
-                'private-fields (syntax->datum #'tbl.private-field-names)
-                'overridable-names
-                (set-union (syntax->datum #'tbl.public-externals)
-                           (syntax->datum #'tbl.override-externals))
-                'augmentable-names
-                (set-union (syntax->datum #'tbl.pubment-externals)
-                           (syntax->datum #'tbl.augment-externals))
-                'method-names
-                (set-union (syntax->datum #'tbl.public-externals)
-                           (syntax->datum #'tbl.override-externals)
-                           (syntax->datum #'tbl.augment-externals)
-                           (syntax->datum #'tbl.pubment-externals))
-                'all-internal
-                (append (syntax->datum #'tbl.init-internals)
-                        (syntax->datum #'tbl.init-field-internals)
-                        (syntax->datum #'tbl.field-internals)
-                        (syntax->datum #'tbl.public-internals)
-                        (syntax->datum #'tbl.override-internals)
-                        (syntax->datum #'tbl.inherit-internals)
-                        (syntax->datum #'tbl.inherit-field-internals)
-                        (syntax->datum #'tbl.pubment-internals)
-                        (syntax->datum #'tbl.augment-internals))
-                'all-external
-                (append (syntax->datum #'tbl.init-externals)
-                        (syntax->datum #'tbl.init-field-externals)
-                        (syntax->datum #'tbl.field-externals)
-                        (syntax->datum #'tbl.public-externals)
-                        (syntax->datum #'tbl.override-externals)
-                        (syntax->datum #'tbl.inherit-externals)
-                        (syntax->datum #'tbl.inherit-field-externals)
-                        (syntax->datum #'tbl.pubment-externals)
-                        (syntax->datum #'tbl.augment-externals))))
-        (with-timing
-          (do-timestamp (format "methods ~a" (dict-ref parse-info 'method-names)))
-          (extend-tvars/new type-parameters fresh-parameters
-                            (do-check expected super-type parse-info)))])]))
+     (define parse-info
+       (hash-set*
+         (parse-internal-class-data class-name-table)
+         'superclass-expr     #'cls.superclass-expr
+         'make-methods        #'cls.make-methods
+         'initializer-self-id #'cls.initializer-self-id
+         'initializer-args-id #'cls.initializer-args-id
+         'initializer-body    #'cls.initializer-body))
+     (with-timing
+       (do-timestamp (format "methods ~a" (dict-ref parse-info 'method-names)))
+       (extend-tvars/new (hash-ref parse-info 'type-parameters)
+                         (hash-ref parse-info 'fresh-parameters)
+                         (do-check expected super-type parse-info)))]))
 
 ;; do-check : Type Type Dict -> Type
 ;; The actual type-checking
@@ -476,10 +354,7 @@
   (define super-method-names  (dict-keys super-methods))
   (define super-augment-names (dict-keys super-augments))
   ;; establish a mapping between internal and external names
-  (define internal-external-mapping
-    (for/hash ([internal (hash-ref parse-info 'all-internal)]
-               [external (hash-ref parse-info 'all-external)])
-      (values internal external)))
+  (define internal-external-mapping (make-internal-external-mapping parse-info))
   ;; trawl the body for top-level expressions
   (define make-methods-stx (hash-ref parse-info 'make-methods))
   (define top-level-exprs
@@ -1154,8 +1029,8 @@
 (define (setter->type id)
   (define f-type (lookup-id-type/lexical id))
   (match f-type
-    [(Fun: (list (Arrow: (list _ t) _ _ _))) t]
-    [#f (int-err "setter->type ~a" (syntax-e id))]))
+    [(Fun: (list (Arrow: (list _ t) _ _ _ _))) t]
+    [_ (int-err "setter->type ~a" (syntax-e id))]))
 
 ;; check-init-arg : Id Type Syntax -> Void
 ;; Check the initialization of an init arg variable against the
@@ -1169,7 +1044,7 @@
            (define type
              (tc-expr/check/t init-val (ret (->* null init-type))))
            (match type
-             [(Fun: (list (Arrow: _ _ _ (Values: (list (Result: result _ _))))))
+             [(Fun: (list (Arrow: _ _ _ (Values: (list (Result: result _ _))) _)))
               (check-below result init-type)]
              [_ (int-err "unexpected init value ~a"
                          (syntax->datum init-val))])]
@@ -1481,32 +1356,6 @@
            (when maybe-expected
              (tc-expr/check init-arg (ret (car maybe-expected)))))]))
 
-;; Syntax (Syntax -> Any) -> Listof<Syntax>
-;; Look through the expansion of the class macro in search for
-;; syntax with some property (e.g., methods)
-(define (trawl-for-property form accessor)
-  (define (recur-on-all stx-list)
-    (apply append (map (λ (stx) (trawl-for-property stx accessor))
-                       (syntax->list stx-list))))
-  (syntax-parse form
-    #:literals (let-values letrec-values #%plain-app
-                #%plain-lambda #%expression)
-    [stx
-     #:when (accessor #'stx)
-     (list form)]
-    [(let-values (b ...) body ...)
-     (recur-on-all #'(b ... body ...))]
-    ;; for letrecs, traverse the RHSs too
-    [(letrec-values ([(x ...) rhs ...] ...) body ...)
-     (recur-on-all #'(rhs ... ... body ...))]
-    [(#%plain-app e ...)
-     (recur-on-all #'(e ...))]
-    [(#%plain-lambda (x ...) e ...)
-     (recur-on-all #'(e ...))]
-    [(#%expression e)
-     (recur-on-all #'(e))]
-    [_ '()]))
-
 ;; setup-pubment-defaults : Listof<Symbol> Hash Hash -> Void
 ;; this does a second pass through the type annotations and adds
 ;; the pubment types as default augment types if an augment type
@@ -1623,8 +1472,8 @@
     [(Fun: arrows)
      (define fixed-arrows
        (map (match-lambda
-              [(Arrow: dom rst kws rng)
-               (make-Arrow (cons self-type dom) rst kws rng)])
+              [(Arrow: dom rst kws rng rng-T+)
+               (make-Arrow (cons self-type dom) rst kws rng rng-T+)])
             arrows))
      (make-Fun fixed-arrows)]
     [(Poly-names: ns body)
@@ -1642,8 +1491,8 @@
     [(Fun: arrows)
      (define fixed-arrows
        (map (match-lambda
-              [(Arrow: (cons _ dom) rst kws rng)
-               (make-Arrow dom rst kws rng)])
+              [(Arrow: (cons _ dom) rst kws rng rng-T+)
+               (make-Arrow dom rst kws rng rng-T+)])
             arrows))
      (make-Fun fixed-arrows)]
     [(Poly-names: ns body)
@@ -1735,3 +1584,4 @@
                      "type mismatch"
                      #:more (~a "the class has a " kind " that should be absent")
                      kind too-many)))
+

--- a/typed-racket-lib/typed-racket/typecheck/check-subforms-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-subforms-unit.rkt
@@ -56,7 +56,7 @@
                      (Arrow: (list arg1)
                              (not (? RestDots?))
                              (list (Keyword: _ _ #f) ...)
-                             _ )
+                             _ _)
                      _ ...))
          #:when (subtype prop-type arg1)
          (tc/funapp #'here #'(here) t (list (ret arg1)) #f)]
@@ -64,7 +64,7 @@
                      (Arrow: (list)
                              (Rest: (list rst-t))
                              (list (Keyword: _ _ #f) ...)
-                             _ )
+                             _ _)
                      _ ...))
          #:when (subtype prop-type rst-t)
          (tc/funapp #'here #'(here) t (list (ret rst-t)) #f)]

--- a/typed-racket-lib/typed-racket/typecheck/check-subforms-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-subforms-unit.rkt
@@ -56,7 +56,7 @@
                      (Arrow: (list arg1)
                              (not (? RestDots?))
                              (list (Keyword: _ _ #f) ...)
-                             _ _)
+                             _)
                      _ ...))
          #:when (subtype prop-type arg1)
          (tc/funapp #'here #'(here) t (list (ret arg1)) #f)]
@@ -64,7 +64,7 @@
                      (Arrow: (list)
                              (Rest: (list rst-t))
                              (list (Keyword: _ _ #f) ...)
-                             _ _)
+                             _)
                      _ ...))
          #:when (subtype prop-type rst-t)
          (tc/funapp #'here #'(here) t (list (ret rst-t)) #f)]

--- a/typed-racket-lib/typed-racket/typecheck/check-unit-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-unit-unit.rkt
@@ -759,7 +759,7 @@
 ;; Based on the function of the same name in check-class-unit.rkt
 ;; trawl-for-property : Syntax (Syntax -> Any) [(Syntax -> A)] -> (Listof A)
 ;; Search through the given syntax for pieces of syntax that satisfy
-;; the accessor predicate, then apply the extractor function to  all such syntaxes 
+;; the accessor predicate, then apply the extractor function to  all such syntaxes
 (define (trawl-for-property form accessor [extractor values])
   (define (recur-on-all stx-list)
     (apply append (map (λ (stx) (trawl-for-property stx accessor extractor)) stx-list)))
@@ -771,3 +771,4 @@
     [_
      (define list? (syntax->list form))
      (if list? (recur-on-all list?) '())]))
+

--- a/typed-racket-lib/typed-racket/typecheck/possible-domains.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/possible-domains.rkt
@@ -65,7 +65,7 @@
         (eq? expected-ty #t) ; expected is tc-anyresults, anything is fine
         (and expected-ty ; not some unknown expected tc-result
              (match fun-ty
-               [(Fun: (list (Arrow: _ _ _ rng)))
+               [(Fun: (list (Arrow: _ _ _ rng _)))
                 (let ([rng (match rng
                              [(Values: (list (Result: t _ _)))
                               t]
@@ -85,7 +85,7 @@
                                                 [(Values: (list (Result: t _ _) ...))
                                                  (-values t)]
                                                 [(ValuesDots: (list (Result: t _ _) ...) _ _)
-                                                 (-values t)]))))))
+                                                 (-values t)]) #f)))))
 
   ;; iterate in lock step over the function types we analyze and the parts
   ;; that we will need to print the error message, to make sure we throw
@@ -116,11 +116,11 @@
   ;; function types with a return type of any then test for subtyping
   (define fun-tys-ret-any
     (map (match-lambda
-          [(Fun: (list (Arrow: dom rst _ _)))
+          [(Fun: (list (Arrow: dom rst _ _ _)))
            (make-Fun (list (make-Arrow dom
                                        rst
                                        null
-                                       (-values (list Univ)))))])
+                                       (-values (list Univ)) #f)))])
          candidates))
 
   ;; Heuristic: often, the last case in the definition (first at this
@@ -155,7 +155,7 @@
 (define (cleanup-type t [expected #f] [permissive? #t])
   (match t
     ;; function type, prune if possible.
-    [(Fun: (list (Arrow: doms rests _ rngs) ...))
+    [(Fun: (list (Arrow: doms rests _ rngs rngs-T+) ...))
      (match-let ([(list pdoms rngs rests)
                   (possible-domains doms rests rngs
                                     (and expected (ret expected))
@@ -168,7 +168,8 @@
            ;; pruning helped, return pruned type
            (make-Fun (for/list ([pdom (in-list pdoms)]
                                 [rst (in-list rests)]
-                                [rng (in-list rngs)])
-                       (make-Arrow pdom rst null rng)))))]
+                                [rng (in-list rngs)]
+                                [T+ (in-list rngs-T+)])
+                       (make-Arrow pdom rst null rng T+)))))]
     ;; not a function type. keep as is.
     [_ t]))

--- a/typed-racket-lib/typed-racket/typecheck/possible-domains.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/possible-domains.rkt
@@ -65,7 +65,7 @@
         (eq? expected-ty #t) ; expected is tc-anyresults, anything is fine
         (and expected-ty ; not some unknown expected tc-result
              (match fun-ty
-               [(Fun: (list (Arrow: _ _ _ rng _)))
+               [(Fun: (list (Arrow: _ _ _ rng)))
                 (let ([rng (match rng
                              [(Values: (list (Result: t _ _)))
                               t]
@@ -116,7 +116,7 @@
   ;; function types with a return type of any then test for subtyping
   (define fun-tys-ret-any
     (map (match-lambda
-          [(Fun: (list (Arrow: dom rst _ _ _)))
+          [(Fun: (list (Arrow: dom rst _ _)))
            (make-Fun (list (make-Arrow dom
                                        rst
                                        null

--- a/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
@@ -36,7 +36,7 @@
   (add-typeof-expr f-stx (ret (make-Fun (list ftype0))))
   (match* (ftype0 arg-ress)
     ;; we check that all kw args are optional
-    [((Arrow: dom rst (list (Keyword: _ _ #f) ...) rng)
+    [((Arrow: dom rst (list (Keyword: _ _ #f) ...) rng _)
       (list (tc-result1: t-a _ o-a) ...))
      #:when (not (RestDots? rst))
 
@@ -106,16 +106,16 @@
            [res res])))]
     ;; this case should only match if the function type has mandatory keywords
     ;; but no keywords were provided in the application
-    [((Arrow: _ _ kws _) _)
+    [((Arrow: _ _ kws _ _) _)
      #:when (ormap Keyword-required? kws)
      (when check?
        (tc-error/fields "could not apply function"
                         #:more "a required keyword was not supplied"
                         "missing keyword"
                         (car (filter Keyword-required? kws))))]
-    [((Arrow: _ (? RestDots? drest) '() _) _)
+    [((Arrow: _ (? RestDots? drest) '() _ _) _)
      (int-err "funapp with drest args ~a ~a NYI" drest arg-ress)]
-    [((Arrow: _ _ kws _) _)
+    [((Arrow: _ _ kws _ _) _)
      (int-err "funapp with keyword args ~a NYI" kws)]))
 
 
@@ -274,7 +274,8 @@
                             (make-Arrow (car pdoms)
                                         (car rests)
                                         null
-                                        (car rngs))
+                                        (car rngs)
+                                        #f)
                             arg-tys expected)
                 return]
                [else
@@ -309,20 +310,20 @@
           (Fun: (list (Arrow: msg-doms
                               msg-rests
                               (list (Keyword: _ _ #f) ...)
-                              msg-rngs)
+                              msg-rngs _)
                       ...)))
          (PolyDots-names:
           msg-vars
           (Fun: (list (Arrow: msg-doms
                               msg-rests
                               (list (Keyword: _ _ #f) ...)
-                              msg-rngs)
+                              msg-rngs _)
                       ...)))
          (PolyRow-names:
           msg-vars (Fun: (list (Arrow: msg-doms
                               msg-rests
                               (list (Keyword: _ _ #f) ...)
-                              msg-rngs)
+                              msg-rngs _)
                       ...))
           _))
      (let ([fcn-string (name->function-str name)])
@@ -368,13 +369,13 @@
                                 #:arg-names names))))]
     [(or (Poly-names:
           msg-vars
-          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs) ...)))
+          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs _) ...)))
          (PolyDots-names:
           msg-vars
-          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs) ...)))
+          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs _) ...)))
          (PolyRow-names:
           msg-vars
-          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs) ...))
+          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs _) ...))
           _))
      (let ([fcn-string (if name
                            (format "function with keywords ~a" (syntax->datum name))

--- a/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
@@ -36,7 +36,7 @@
   (add-typeof-expr f-stx (ret (make-Fun (list ftype0))))
   (match* (ftype0 arg-ress)
     ;; we check that all kw args are optional
-    [((Arrow: dom rst (list (Keyword: _ _ #f) ...) rng _)
+    [((Arrow: dom rst (list (Keyword: _ _ #f) ...) rng)
       (list (tc-result1: t-a _ o-a) ...))
      #:when (not (RestDots? rst))
 
@@ -106,16 +106,16 @@
            [res res])))]
     ;; this case should only match if the function type has mandatory keywords
     ;; but no keywords were provided in the application
-    [((Arrow: _ _ kws _ _) _)
+    [((Arrow: _ _ kws _) _)
      #:when (ormap Keyword-required? kws)
      (when check?
        (tc-error/fields "could not apply function"
                         #:more "a required keyword was not supplied"
                         "missing keyword"
                         (car (filter Keyword-required? kws))))]
-    [((Arrow: _ (? RestDots? drest) '() _ _) _)
+    [((Arrow: _ (? RestDots? drest) '() _) _)
      (int-err "funapp with drest args ~a ~a NYI" drest arg-ress)]
-    [((Arrow: _ _ kws _ _) _)
+    [((Arrow: _ _ kws _) _)
      (int-err "funapp with keyword args ~a NYI" kws)]))
 
 
@@ -310,20 +310,20 @@
           (Fun: (list (Arrow: msg-doms
                               msg-rests
                               (list (Keyword: _ _ #f) ...)
-                              msg-rngs _)
+                              msg-rngs)
                       ...)))
          (PolyDots-names:
           msg-vars
           (Fun: (list (Arrow: msg-doms
                               msg-rests
                               (list (Keyword: _ _ #f) ...)
-                              msg-rngs _)
+                              msg-rngs)
                       ...)))
          (PolyRow-names:
           msg-vars (Fun: (list (Arrow: msg-doms
                               msg-rests
                               (list (Keyword: _ _ #f) ...)
-                              msg-rngs _)
+                              msg-rngs)
                       ...))
           _))
      (let ([fcn-string (name->function-str name)])
@@ -369,13 +369,13 @@
                                 #:arg-names names))))]
     [(or (Poly-names:
           msg-vars
-          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs _) ...)))
+          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs) ...)))
          (PolyDots-names:
           msg-vars
-          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs _) ...)))
+          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs) ...)))
          (PolyRow-names:
           msg-vars
-          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs _) ...))
+          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs) ...))
           _))
      (let ([fcn-string (if name
                            (format "function with keywords ~a" (syntax->datum name))

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-apply.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-apply.rkt
@@ -27,9 +27,10 @@
   (pattern ((~or apply k:apply) (~and f values) e)
     (match (single-value #'e)
       [(tc-result1: (ListDots: dty dbound))
+       (add-typeof-expr #'f (ret (make-Fun (list (make-arr-dots '() (-values-dots '() dty dbound) dty dbound #:T+ #false)))))
        (ret null null null dty dbound)]
       [(tc-result1: (List: ts))
-       (add-typeof-expr #'f (ret (->* ts (-values ts))))
+       (add-typeof-expr #'f (ret (->* ts (-values ts) :T+ #false)))
        (ret ts)]
       [_ (tc/apply #'f #'(e))]))
   (pattern ((~or apply k:apply) f . args)

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-contracts.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-contracts.rkt
@@ -8,6 +8,8 @@
          "utils.rkt"
          syntax/parse
          "../signatures.rkt"
+         (only-in typed-racket/types/type-table add-typeof-expr)
+         (only-in typed-racket/types/tc-result ret)
          (for-template racket/base
                        ;; shift -1 because it's provided +1
                        racket/contract/private/provide))
@@ -27,8 +29,11 @@
 ;; put things in the base type environment if they have impersonator
 ;; contracts installed.
 (define (check-contract orig-value-id other-args expected)
+  (define ctc-id (contract-rename-id-property orig-value-id))
+  (define ctc-ty (tc-expr/t ctc-id))
+  (add-typeof-expr orig-value-id (ret ctc-ty))
   (tc-expr/check #`(#%plain-app
-                    #,(contract-rename-id-property orig-value-id)
+                    #,ctc-id
                     . #,other-args)
                  expected))
 

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-hetero.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-hetero.rkt
@@ -83,7 +83,7 @@
     [(valid-index? i-val i-bound)
      (define val-t (list-ref es-t i-val))
      (tc-expr/check val-e (ret val-t))
-     (add-typeof-expr op (ret (-> vec-t -Fixnum val-t -Void)))
+     (add-typeof-expr op (ret (-> vec-t -Fixnum val-t -Void :T+ #t)))
      (ret -Void)]
     [(not i-val)
      (define val-res (single-value val-e))
@@ -91,7 +91,7 @@
        (check-below val-res (ret es-type)))
      (define val-t
        (match val-res [(tc-result1: t) t]))
-     (add-typeof-expr op (ret (-> vec-t -Fixnum val-t -Void)))
+     (add-typeof-expr op (ret (-> vec-t -Fixnum val-t -Void :T+ #t)))
      (ret -Void)]
     [else
      (single-value val-e)
@@ -203,7 +203,7 @@
                       t))
                   (define return-ty
                     (?make-HV arg-tys))
-                  (add-typeof-expr #'op (ret (->* arg-tys return-ty)))
+                  (add-typeof-expr #'op (ret (->* arg-tys return-ty :T+ #t)))
                   (ret return-ty)]
                  [(tc-result1: (app resolve (Is-a: (?match-HV ts))))
                   (cond
@@ -214,7 +214,7 @@
                         (tc-expr/check/t e (ret t))))
                     (define return-ty
                       (?make-HV arg-tys))
-                    (add-typeof-expr #'op (ret (->* arg-tys return-ty)))
+                    (add-typeof-expr #'op (ret (->* arg-tys return-ty :T+ #t)))
                     (ret return-ty -true-propset)]
                    [else
                     (tc-error/expr
@@ -236,6 +236,6 @@
                       (tc-hv-elem e)))
                   (define return-ty
                     (?make-HV arg-tys))
-                  (add-typeof-expr #'op (ret (->* arg-tys return-ty)))
+                  (add-typeof-expr #'op (ret (->* arg-tys return-ty :T+ #t)))
                   (ret return-ty)])]))))]))
   (values (make-tc-app-hetero-vector 'immutable) (make-tc-app-hetero-vector 'mutable))))

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-keywords.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-keywords.rkt
@@ -52,7 +52,7 @@
                      #'kw-arg-list #'pos-args expected))
 
       (define (tc/app-poly-fun vars arrow fail)
-        (match-define (and ar (Arrow: dom rst kw-formals rng _)) arrow)
+        (match-define (and ar (Arrow: dom rst kw-formals rng)) arrow)
         ;; if the types of the keyword arguments have type variables or rst is
         ;; set, stop.
         (unless (or (set-empty? (fv/list kw-formals)) (not rst))
@@ -86,7 +86,7 @@
 
 (define (tc-keywords/internal arity kws kw-args error?)
   (match arity
-    [(Arrow: dom (not (? RestDots?)) ktys rng _)
+    [(Arrow: dom (not (? RestDots?)) ktys rng)
      ;; assumes that everything is in sorted order
      (let loop ([actual-kws kws]
                 [actuals (stx-map tc-expr/t kw-args)]

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-lambda.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-lambda.rkt
@@ -48,7 +48,7 @@
              (match (type-of arg)
               [(tc-result1: t) t]))]
           [cod-t (tc-results->values res)])
-     (add-typeof-expr #'lam (ret (->* dom-ts cod-t)))
+     (add-typeof-expr #'lam (ret (->* dom-ts cod-t :T+ #t)))
      res))
   ;; inference for ((lambda with dotted rest
   (pattern ((~and lam (#%plain-lambda (x ... . rst:id) . body)) args ...)

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-main.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-main.rkt
@@ -69,7 +69,7 @@
              (Values: (list (Result: v
                                      (PropSet: (TrueProp:) (TrueProp:))
                                      (Empty:))
-                            ...)))
+                            ...)) _)
      (Arrow-includes-arity? domain rst args)]
     [_ #f]))
 
@@ -80,7 +80,7 @@
              (list (Keyword: _ _ #f) ...)
              (Values: (list (Result: v
                                      (PropSet: (TrueProp:) (TrueProp:))
-                                     (Empty:)) ...)))
+                                     (Empty:)) ...)) _)
      #f]
     [else #t]))
 
@@ -109,7 +109,7 @@
           (parameterize ([with-refinements? #t])
             (tc/funapp #'f #'args f-ty (map tc-dep-fun-arg args*) expected))]
          [(Fun: (app matching-arities
-                     (list (Arrow: doms rsts _ _) ..1)))
+                     (list (Arrow: doms rsts _ _ _) ..1)))
           (define check-arg (if (and (identifier? #'f)
                                      (with-refinements?)
                                      (has-linear-integer-refinements? #'f))

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-main.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-main.rkt
@@ -69,7 +69,7 @@
              (Values: (list (Result: v
                                      (PropSet: (TrueProp:) (TrueProp:))
                                      (Empty:))
-                            ...)) _)
+                            ...)))
      (Arrow-includes-arity? domain rst args)]
     [_ #f]))
 
@@ -80,7 +80,7 @@
              (list (Keyword: _ _ #f) ...)
              (Values: (list (Result: v
                                      (PropSet: (TrueProp:) (TrueProp:))
-                                     (Empty:)) ...)) _)
+                                     (Empty:)) ...)))
      #f]
     [else #t]))
 
@@ -109,7 +109,7 @@
           (parameterize ([with-refinements? #t])
             (tc/funapp #'f #'args f-ty (map tc-dep-fun-arg args*) expected))]
          [(Fun: (app matching-arities
-                     (list (Arrow: doms rsts _ _ _) ..1)))
+                     (list (Arrow: doms rsts _ _) ..1)))
           (define check-arg (if (and (identifier? #'f)
                                      (with-refinements?)
                                      (has-linear-integer-refinements? #'f))

--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-special.rkt
@@ -59,7 +59,7 @@
     (match (single-value #'arg)
       [(tc-result1: t (PropSet: p+ p-) _)
        (define new-prop (make-PropSet p- p+))
-       (add-typeof-expr #'op-name (ret (-> Univ -Boolean)))
+       (add-typeof-expr #'op-name (ret (-> Univ -Boolean :T+ #t)))
        (ret -Boolean new-prop)]))
   ;; special case for (current-contract-region)'s default expansion
   ;; just let it through without any typechecking, since module-name-fixup

--- a/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
@@ -53,7 +53,7 @@
     (match f-ty
       [(tc-result1:
          (and t (AnyPoly-names: _ _
-                                (Fun: (list (Arrow: doms rests (list (Keyword: _ _ #f) ...) rngs) ..1)))))
+                                (Fun: (list (Arrow: doms rests (list (Keyword: _ _ #f) ...) rngs _) ..1)))))
        (domain-mismatches f args t doms rests rngs arg-tres full-tail-ty #f
                           #:msg-thunk (lambda (dom)
                                         (string-append
@@ -70,7 +70,7 @@
      (or
       (for/or ([arrow (in-list arrows)])
         (match arrow
-          [(Arrow: domain rst _ rng)
+          [(Arrow: domain rst _ rng _)
            ;; Takes a possible substitution and computes
            ;; the substituted range type if it is not #f
            (define (finish substitution)

--- a/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
@@ -53,7 +53,7 @@
     (match f-ty
       [(tc-result1:
          (and t (AnyPoly-names: _ _
-                                (Fun: (list (Arrow: doms rests (list (Keyword: _ _ #f) ...) rngs _) ..1)))))
+                                (Fun: (list (Arrow: doms rests (list (Keyword: _ _ #f) ...) rngs) ..1)))))
        (domain-mismatches f args t doms rests rngs arg-tres full-tail-ty #f
                           #:msg-thunk (lambda (dom)
                                         (string-append
@@ -70,7 +70,7 @@
      (or
       (for/or ([arrow (in-list arrows)])
         (match arrow
-          [(Arrow: domain rst _ rng _)
+          [(Arrow: domain rst _ rng)
            ;; Takes a possible substitution and computes
            ;; the substituted range type if it is not #f
            (define (finish substitution)

--- a/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
@@ -131,7 +131,7 @@
        (cond
          ;; find the first function where the argument types match
          [(ormap (match-lambda
-                   [(and a (Arrow: dom rst _ _))
+                   [(and a (Arrow: dom rst _ _ _))
                     (and (subtypes/varargs argtys dom rst) a)])
                  arrows)
           => (λ (a)
@@ -141,7 +141,7 @@
          [else
           ;; if nothing matched, error
           (match arrows
-            [(list (Arrow: doms rsts _ rngs) ...)
+            [(list (Arrow: doms rsts _ rngs _) ...)
              (domain-mismatches
               f-stx args-stx f-type doms rsts rngs args-res #f #f
               #:expected expected
@@ -158,7 +158,7 @@
                      (ormap Keyword-required? kws)))
        (for/first-valid-inference
            #:in-arrs [a (in-list arrows)]
-         #:arr-match (Arrow: dom rst _ rng)
+         #:arr-match (Arrow: dom rst _ rng _)
          #:function-syntax f-stx
          #:args-syntax args-stx
          #:infer-when
@@ -202,7 +202,7 @@
                      (RestDots? (Arrow-rst a))))
        (for/first-valid-inference
            #:in-arrs [a (in-list arrows)]
-           #:arr-match (Arrow: dom rst kws rng)
+           #:arr-match (Arrow: dom rst kws rng _)
            #:function-syntax f-stx
            #:args-syntax args-stx
            ;; only try inference if the argument lengths are appropriate

--- a/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
@@ -131,7 +131,7 @@
        (cond
          ;; find the first function where the argument types match
          [(ormap (match-lambda
-                   [(and a (Arrow: dom rst _ _ _))
+                   [(and a (Arrow: dom rst _ _))
                     (and (subtypes/varargs argtys dom rst) a)])
                  arrows)
           => (λ (a)
@@ -141,7 +141,7 @@
          [else
           ;; if nothing matched, error
           (match arrows
-            [(list (Arrow: doms rsts _ rngs _) ...)
+            [(list (Arrow: doms rsts _ rngs) ...)
              (domain-mismatches
               f-stx args-stx f-type doms rsts rngs args-res #f #f
               #:expected expected
@@ -158,7 +158,7 @@
                      (ormap Keyword-required? kws)))
        (for/first-valid-inference
            #:in-arrs [a (in-list arrows)]
-         #:arr-match (Arrow: dom rst _ rng _)
+         #:arr-match (Arrow: dom rst _ rng)
          #:function-syntax f-stx
          #:args-syntax args-stx
          #:infer-when
@@ -202,7 +202,7 @@
                      (RestDots? (Arrow-rst a))))
        (for/first-valid-inference
            #:in-arrs [a (in-list arrows)]
-           #:arr-match (Arrow: dom rst kws rng _)
+           #:arr-match (Arrow: dom rst kws rng)
            #:function-syntax f-stx
            #:args-syntax args-stx
            ;; only try inference if the argument lengths are appropriate

--- a/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
@@ -311,7 +311,7 @@
 (define (restrict-Arrow-to-arity arrow n)
   (match arrow
     ;; currently does not handle rest arguments
-    [(Arrow: args #f '() _ _)
+    [(Arrow: args #f '() _)
      #:when (= n (length args))
      arrow]
     [_ #f]))
@@ -460,7 +460,7 @@
   (match* (arities f-or-arrow)
     [((case-arities fixed-arities rest-pos)
       (or (formals (app length arity) rst _)
-          (Arrow:  (app length arity) rst _ _ _)))
+          (Arrow:  (app length arity) rst _ _)))
      (or (>= arity rest-pos)
          (and (not rst) (memv arity fixed-arities) #t))]))
 
@@ -551,7 +551,7 @@
          ;; if this clause has an orig-arrow, we already checked it once and that
          ;; was it's arrow type -- we don't want to check it again at the same arrow
          [_ #:when (member arrow orig-arrows) arrow]
-         [(Arrow: dom rst '() rng _)
+         [(Arrow: dom rst '() rng)
           (define expected
             (values->tc-results rng (formals->objects clause-formals)))
           (tc/lambda-clause/check

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -420,7 +420,7 @@
   (define bindings
     (list* (make-def-binding struct-type (make-StructType sty))
            (make-def-binding predicate
-                             (make-pred-ty (mk-pred-ty st-type-alias-maybe-with-proc) #t))
+                             (unsafe-shallow:make-pred-ty (mk-pred-ty st-type-alias-maybe-with-proc)))
            (append*
             (mk-operator-bindings! getters add-struct-accessor-fn! mk-getter-vals)
             (maybe-cons (and self-mutable (mk-operator-bindings! setters add-struct-mutator-fn! mk-setter-vals))))))

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -114,7 +114,6 @@
                  [(? Struct?) sty]
                  [(Poly: names (? Struct? sty)) sty])))
 
-
 (define/cond-contract (tc/struct-prop-values st-tname pnames pvals)
   (c:-> identifier? (c:listof identifier?) (c:listof syntax?) void?)
   (unless (null? pnames)
@@ -421,7 +420,7 @@
   (define bindings
     (list* (make-def-binding struct-type (make-StructType sty))
            (make-def-binding predicate
-                             (make-pred-ty (mk-pred-ty st-type-alias-maybe-with-proc)))
+                             (make-pred-ty (mk-pred-ty st-type-alias-maybe-with-proc) #t))
            (append*
             (mk-operator-bindings! getters add-struct-accessor-fn! mk-getter-vals)
             (maybe-cons (and self-mutable (mk-operator-bindings! setters add-struct-mutator-fn! mk-setter-vals))))))

--- a/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
@@ -83,11 +83,12 @@
     (match rep
       ;; Functions
       ;; increment the level of the substituted object
-      [(Arrow: dom rst kws rng)
+      [(Arrow: dom rst kws rng rng-T+)
        (make-Arrow (map subst dom)
                    (and rst (subst rst))
                    (map subst kws)
-                   (subst/lvl rng (add1 lvl)))]
+                   (subst/lvl rng (add1 lvl))
+                   rng-T+)]
       [(DepFun: dom pre rng)
        (make-DepFun (for/list ([d (in-list dom)])
                       (subst/lvl d (add1 lvl)))

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -111,7 +111,7 @@
       [t:type-refinement
        (match (lookup-id-type/lexical #'t.predicate)
               [(and t (Fun: (list (Arrow: (list dom) #f '()
-                                          (Values: (list (Result: rng _ _))) _))))
+                                          (Values: (list (Result: rng _ _)))))))
                (let ([new-t (make-pred-ty (list dom)
                                           rng
                                           (make-Refinement dom #'t.predicate))])

--- a/typed-racket-lib/typed-racket/typed-racket.rkt
+++ b/typed-racket-lib/typed-racket/typed-racket.rkt
@@ -12,7 +12,7 @@
 
 (provide (rename-out [module-begin #%module-begin]
                      [top-interaction #%top-interaction])
-         with-type
+         with-type with-type-shallow with-type-optional
          (for-syntax do-standard-inits))
 
 (define-syntax-rule (drivers [name sym] ...)
@@ -26,4 +26,4 @@
               (do-time "Finished, returning to Racket")))
     ...))
 
-(drivers [module-begin mb-core] [top-interaction ti-core] [with-type wt-core])
+(drivers [module-begin mb-core] [top-interaction ti-core] [with-type wt-core] [with-type-shallow wt-core-shallow] [with-type-optional wt-core-optional])

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -210,19 +210,16 @@
 
 (define/cond-contract make-pred-ty
   (c:case-> (c:-> Type? Type?)
-            (c:-> Type? boolean? Type?)
             (c:-> (c:listof Type?) Type? Type? Type?)
-            (c:-> (c:listof Type?) Type? Type? boolean? Type?)
+            (c:-> (c:listof Type?) Type? Type? Object? Type?)
             (c:-> (c:listof Type?) Type? Type? Object? boolean? Type?))
   (case-lambda
     [(in out t o T+)
      (->* in out : (-PS (-is-type o t) (-not-type o t)) :T+ T+)]
-    [(in out t T+)
-     (make-pred-ty in out t (make-Path null (cons 0 0)) T+)]
+    [(in out t o)
+     (make-pred-ty in out t o #f)]
     [(in out t)
      (make-pred-ty in out t (make-Path null (cons 0 0)) #f)]
-    [(t T+)
-     (make-pred-ty (list Univ) -Boolean t (make-Path null (cons 0 0)) T+)]
     [(t)
      (make-pred-ty (list Univ) -Boolean t (make-Path null (cons 0 0)) #f)]))
 
@@ -231,9 +228,9 @@
     [(in out t o)
      (make-pred-ty in out t o #true)]
     [(in out t)
-     (make-pred-ty in out t #true)]
+     (make-pred-ty in out t (make-Path null (cons 0 0)) #true)]
     [(t)
-     (make-pred-ty t #true)]))
+     (make-pred-ty (list Univ) -Boolean t (make-Path null (cons 0 0)) #true)]))
 
 (define/decl -true-propset (-PS -tt -ff))
 (define/decl -false-propset (-PS -ff -tt))

--- a/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -205,6 +205,9 @@
 (define (asym-pred dom rng prop [T+ #f])
   (make-Fun (list (-Arrow (list dom) rng #:props prop #:T+ T+))))
 
+(define (unsafe-shallow:asym-pred dom rng prop)
+  (asym-pred dom rng prop #true))
+
 (define/cond-contract make-pred-ty
   (c:case-> (c:-> Type? Type?)
             (c:-> Type? boolean? Type?)
@@ -222,6 +225,15 @@
      (make-pred-ty (list Univ) -Boolean t (make-Path null (cons 0 0)) T+)]
     [(t)
      (make-pred-ty (list Univ) -Boolean t (make-Path null (cons 0 0)) #f)]))
+
+(define unsafe-shallow:make-pred-ty
+  (case-lambda
+    [(in out t o)
+     (make-pred-ty in out t o #true)]
+    [(in out t)
+     (make-pred-ty in out t #true)]
+    [(t)
+     (make-pred-ty t #true)]))
 
 (define/decl -true-propset (-PS -tt -ff))
 (define/decl -false-propset (-PS -ff -tt))

--- a/typed-racket-lib/typed-racket/types/match-expanders.rkt
+++ b/typed-racket-lib/typed-racket/types/match-expanders.rkt
@@ -177,7 +177,7 @@
        #'(Fun: (list (Arrow: (list _)
                              _
                              _
-                             (Values: (list (Result: _ ps _))))))])))
+                             (Values: (list (Result: _ ps _))) _)))])))
 
 (define-match-expander HashTableTop:
   (lambda (stx)

--- a/typed-racket-lib/typed-racket/types/match-expanders.rkt
+++ b/typed-racket-lib/typed-racket/types/match-expanders.rkt
@@ -177,7 +177,7 @@
        #'(Fun: (list (Arrow: (list _)
                              _
                              _
-                             (Values: (list (Result: _ ps _))) _)))])))
+                             (Values: (list (Result: _ ps _))))))])))
 
 (define-match-expander HashTableTop:
   (lambda (stx)

--- a/typed-racket-lib/typed-racket/types/path-type.rkt
+++ b/typed-racket-lib/typed-racket/types/path-type.rkt
@@ -90,7 +90,7 @@
       [((Distinction: _ _ t) _) (path-type path t resolved)]
 
       ;; for private fields in classes
-      [((Fun: (list (Arrow: doms _ _ (Values: (list (Result: rng _ _))))))
+      [((Fun: (list (Arrow: doms _ _ (Values: (list (Result: rng _ _))) _)))
         (cons (FieldPE:) rst))
        (path-type rst rng (hash))]
 

--- a/typed-racket-lib/typed-racket/types/path-type.rkt
+++ b/typed-racket-lib/typed-racket/types/path-type.rkt
@@ -90,7 +90,7 @@
       [((Distinction: _ _ t) _) (path-type path t resolved)]
 
       ;; for private fields in classes
-      [((Fun: (list (Arrow: doms _ _ (Values: (list (Result: rng _ _))) _)))
+      [((Fun: (list (Arrow: doms _ _ (Values: (list (Result: rng _ _))))))
         (cons (FieldPE:) rst))
        (path-type rst rng (hash))]
 

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -353,7 +353,7 @@
 ;; Convert an arr (see type-rep.rkt) to its printable form
 (define (arr->sexp arr)
   (match arr
-    [(Arrow: dom rst kws rng _)
+    [(Arrow: dom rst kws rng)
      (define arrow-star? (and (Rest? rst) (> (length (Rest-tys rst)) 1)))
      (define dom-sexps (map type->sexp dom))
      (append
@@ -427,8 +427,8 @@
   ;; see type-contract.rkt, which does something similar and this code
   ;; was stolen from/inspired by/etc.
   (match* ((first arrs) (last arrs))
-    [((Arrow: first-dom _ kws rng _)
-      (Arrow: last-dom rst _ _ _))
+    [((Arrow: first-dom _ kws rng)
+      (Arrow: last-dom rst _ _))
      (define-values (mand-kws opt-kws) (partition-kws kws))
      (define opt-doms (drop last-dom (length first-dom)))
      `(->*

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -353,7 +353,7 @@
 ;; Convert an arr (see type-rep.rkt) to its printable form
 (define (arr->sexp arr)
   (match arr
-    [(Arrow: dom rst kws rng)
+    [(Arrow: dom rst kws rng _)
      (define arrow-star? (and (Rest? rst) (> (length (Rest-tys rst)) 1)))
      (define dom-sexps (map type->sexp dom))
      (append
@@ -427,8 +427,8 @@
   ;; see type-contract.rkt, which does something similar and this code
   ;; was stolen from/inspired by/etc.
   (match* ((first arrs) (last arrs))
-    [((Arrow: first-dom _ kws rng)
-      (Arrow: last-dom rst _ _))
+    [((Arrow: first-dom _ kws rng _)
+      (Arrow: last-dom rst _ _ _))
      (define-values (mand-kws opt-kws) (partition-kws kws))
      (define opt-doms (drop last-dom (length first-dom)))
      `(->*

--- a/typed-racket-lib/typed-racket/types/prop-ops.rkt
+++ b/typed-racket-lib/typed-racket/types/prop-ops.rkt
@@ -420,7 +420,7 @@
 ;; useful to express properties of the form: if this function returns at all,
 ;; we learn this about its arguments (like fx primitives, or car/cdr, etc.)
 (define/match (add-unconditional-prop-all-args arr type)
-  [((Fun: (list (Arrow: dom rst kws rng))) type)
+  [((Fun: (list (Arrow: dom rst kws rng rng-T+))) type)
    (match rng
      [(Values: (list (Result: tp (PropSet: p+ p-) op)))
       (let ([new-props (apply -and (build-list (length dom)
@@ -432,7 +432,8 @@
                             (list (-result tp
                                            (-PS (-and p+ new-props)
                                                 (-and p- new-props))
-                                           op)))))))])])
+                                           op)))
+                           rng-T+))))])])
 
 ;; tc-results/c -> tc-results/c
 (define/match (erase-props tc)

--- a/typed-racket-lib/typed-racket/types/substitute.rkt
+++ b/typed-racket-lib/typed-racket/types/substitute.rkt
@@ -108,7 +108,7 @@
                  (for/list ([img (in-list images)])
                    (-result (substitute img name expanded))))))])]
          [else (make-ValuesDots (map sub types) (sub dty) dbound)])]
-      [(Arrow: dom (RestDots: dty dbound) kws rng)
+      [(Arrow: dom (RestDots: dty dbound) kws rng rng-T+)
        #:when (eq? name dbound)
        (make-Arrow
         (append
@@ -119,7 +119,8 @@
                 images)))
         (if (Type? rimage) (make-Rest (list rimage)) rimage)
         (map sub kws)
-        (sub rng))]
+        (sub rng)
+        rng-T+)]
       [_ (Rep-fmap target sub)])))
 
 ;; implements curly brace substitution from the formalism, with the addition
@@ -146,7 +147,7 @@
                                   pre-image)
                           (sub dty)
                           image-bound)]
-      [(Arrow: dom (RestDots: dty dbound) kws rng)
+      [(Arrow: dom (RestDots: dty dbound) kws rng rng-T+)
        #:when (eq? name dbound)
        (make-Arrow
         (append (map sub dom) pre-image)
@@ -154,7 +155,8 @@
          (substitute image dbound (sub dty))
          image-bound)
         (map sub kws)
-        (sub rng))]
+        (sub rng)
+        rng-T+)]
       [_ (Rep-fmap target sub)])))
 
 ;; substitute many variables

--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -233,8 +233,8 @@
 (define/cond-contract (arrow-subtype* A arr1 arr2)
   (-> list? Arrow? Arrow? (or/c #f list?))
   (match* (arr1 arr2)
-    [((Arrow: dom1 rst1 kws1 raw-rng1 _)
-      (Arrow: dom2 rst2 kws2 raw-rng2 _))
+    [((Arrow: dom1 rst1 kws1 raw-rng1)
+      (Arrow: dom2 rst2 kws2 raw-rng2))
      (define A* (subtype-seq A
                              (Arrow-domain-subtypes* dom1 rst1 dom2 rst2)
                              (kw-subtypes* kws1 kws2)))
@@ -261,7 +261,7 @@
 (define/cond-contract (arrow-subtype-dfun* A arrow dfun)
   (-> list? Arrow? DepFun? (or/c #f list?))
   (match* (arrow dfun)
-    [((Arrow: dom1 rst1 kws1 raw-rng1 _)
+    [((Arrow: dom1 rst1 kws1 raw-rng1)
       (DepFun: raw-dom2 raw-pre2  raw-rng2))
      #:when (Arrow-includes-arity? arrow (length raw-dom2))
      (define arity (length raw-dom2))
@@ -579,7 +579,7 @@
 (define/cond-contract (collapsable-arrows? arrows)
   (-> (listof Arrow?) (or/c Arrow? #f))
   (match arrows
-    [(cons (Arrow: (list dom1) #f '() rng _) remaining)
+    [(cons (Arrow: (list dom1) #f '() rng) remaining)
      (match remaining
        [(list (Arrow: (list dom2) #f '() (== rng) rng-T+2)
               (Arrow: (list doms) #f '() (== rng) rng-T+*) ...)
@@ -794,7 +794,7 @@
                   ([a2 (in-list arrows2)]
                    #:break (not A))
           (match a2
-            [(Arrow: dom2 rst2 kws2 raw-rng2 _)
+            [(Arrow: dom2 rst2 kws2 raw-rng2)
              (define A* (subtype-seq A
                                      (subtypes* dom2 dom1)
                                      (kw-subtypes* '() kws2)))

--- a/typed-racket-lib/typed-racket/types/update.rkt
+++ b/typed-racket-lib/typed-racket/types/update.rkt
@@ -92,9 +92,9 @@
          ;; is an object type that doesn't mention private fields. Thus we use the
          ;; FieldPE path element as a marker to refine the result of the accessor
          ;; function.
-         [((Fun: (list (Arrow: doms _ _ (Values: (list (Result: rng _ _))))))
+         [((Fun: (list (Arrow: doms _ _ (Values: (list (Result: rng _ _))) rng-T+)))
            (FieldPE:))
-          (make-Fun (list (-Arrow doms (update rng rst))))]
+          (make-Fun (list (-Arrow doms (update rng rst) #:T+ rng-T+)))]
 
          [((Union: _ ts) _)
           ;; Note: if there is a path element, then all Base types are

--- a/typed-racket-lib/typed-racket/types/utils.rkt
+++ b/typed-racket-lib/typed-racket/types/utils.rkt
@@ -115,11 +115,11 @@
   (and (pair? arrows)
        (pair? (cdr arrows)) ;; i.e. (> (length arrows) 1)
        (match arrows
-         [(cons (Arrow: dom #f kws rng) as)
+         [(cons (Arrow: dom #f kws rng _) as)
           (let loop ([dom dom]
                      [to-check (cdr arrows)])
             (match to-check
-              [(cons (Arrow: next-dom next-rst next-kws next-rng)
+              [(cons (Arrow: next-dom next-rst next-kws next-rng _)
                      remaining)
                (cond
                  ;; a #:rest must be the LAST clause,

--- a/typed-racket-lib/typed-racket/types/utils.rkt
+++ b/typed-racket-lib/typed-racket/types/utils.rkt
@@ -115,11 +115,11 @@
   (and (pair? arrows)
        (pair? (cdr arrows)) ;; i.e. (> (length arrows) 1)
        (match arrows
-         [(cons (Arrow: dom #f kws rng _) as)
+         [(cons (Arrow: dom #f kws rng) as)
           (let loop ([dom dom]
                      [to-check (cdr arrows)])
             (match to-check
-              [(cons (Arrow: next-dom next-rst next-kws next-rng _)
+              [(cons (Arrow: next-dom next-rst next-kws next-rng)
                      remaining)
                (cond
                  ;; a #:rest must be the LAST clause,

--- a/typed-racket-lib/typed-racket/utils/any-wrap.rkt
+++ b/typed-racket-lib/typed-racket/utils/any-wrap.rkt
@@ -224,15 +224,17 @@
 (define (on-opaque-error v blame neg-party)
   (raise-any-wrap/c-opaque-error v blame neg-party))
 
-;; on-opaque-display-warning : Val Blame Neg-Party -> Val
+;; make-on-opaque-display-warning : (-> (Val Blame Neg-Party -> Val))
 ;; To be passed as the #:on-opaque argument to make any-wrap/c display
 ;; a warning, but keep going with possible unsoundness.
-(define (on-opaque-display-warning v blame neg-party)
-  ;; this can lead to unsoundness, see https://github.com/racket/typed-racket/issues/379.
-  ;; an error here would make this sound, but it breaks the math library as of 2016-07-08,
-  ;; see https://github.com/racket/typed-racket/pull/385#issuecomment-231354377.
-  (display-any-wrap/c-opaque-warning v blame neg-party)
-  (chaperone-struct v))
+(define (make-on-opaque-display-warning)
+  (define display-warning (make-display-any-wrap/c-opaque-warning))
+  (lambda (v blame neg-party)
+    ;; this can lead to unsoundness, see https://github.com/racket/typed-racket/issues/379.
+    ;; an error here would make this sound, but it breaks the math library as of 2016-07-08,
+    ;; see https://github.com/racket/typed-racket/pull/385#issuecomment-231354377.
+    (display-warning v blame neg-party)
+    (chaperone-struct v)))
 
 ;; make-any-wrap/c : (-> #:on-opaque (-> Val Blame Neg-Party (U Val Error)) Chaperone-Contract)
 (define (make-any-wrap/c #:on-opaque on-opaque)
@@ -244,8 +246,8 @@
 (define any-wrap/c
   (make-any-wrap/c #:on-opaque on-opaque-error))
 
-(define any-wrap-warning/c
-  (make-any-wrap/c #:on-opaque on-opaque-display-warning))
+(define (make-any-wrap-warning/c)
+  (make-any-wrap/c #:on-opaque (make-on-opaque-display-warning)))
 
 ;; struct?/inspector : (-> Inspector (-> Any Boolean))
 (define ((struct?/inspector inspector) v)
@@ -262,19 +264,23 @@
     "  value: ~e\n")
    v))
 
-;; display-any-wrap/c-opaque-warning : (-> Any Blame Neg-Party Void)
-(define (display-any-wrap/c-opaque-warning v blame neg-party)
-  (displayln
-   ((current-blame-format)
-    (blame-add-missing-party blame neg-party)
-    v
-    (format
-     (string-append
-      "any-wrap/c: Unable to protect opaque value passed as `Any`\n"
-      "  value: ~e\n"
-      "  This warning will become an error in a future release.\n")
-     v))
-   (current-error-port)))
+;; make-display-any-wrap/c-opaque-warning : (-> (-> Any Blame Neg-Party Void))
+(define (make-display-any-wrap/c-opaque-warning)
+  (define seen (make-hasheq))
+  (lambda (v blame neg-party)
+    (unless (hash-has-key? seen v)
+      (hash-set! seen v #true)
+      (displayln
+       ((current-blame-format)
+        (blame-add-missing-party blame neg-party)
+        v
+        (format
+         (string-append
+          "any-wrap/c: Unable to protect opaque value passed as `Any`\n"
+          "  value: ~e\n"
+          "  This warning will become an error in a future release.\n")
+         v))
+       (current-error-port)))))
 
 ;; Contract for "safe" struct predicate procedures.
 ;; We can trust that these obey the type (-> Any Boolean).
@@ -284,4 +290,4 @@
            (struct-type-property-predicate-procedure? x))
        (not (impersonator? x))))
 
-(provide any-wrap/c any-wrap-warning/c struct-predicate-procedure?/c)
+(provide any-wrap/c make-any-wrap-warning/c struct-predicate-procedure?/c)

--- a/typed-racket-lib/typed-racket/utils/class-utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/class-utils.rkt
@@ -1,0 +1,173 @@
+#lang racket/base
+
+(provide
+  trawl-for-property
+  parse-internal-class-data
+  make-internal-external-mapping
+  internal-class-data)
+
+(require
+  syntax/parse
+  racket/set
+  (for-template racket/base typed-racket/private/class-literals))
+
+(define-syntax-class name-pair
+  (pattern (internal:id external:id)))
+
+(define-syntax-class internal-class-data
+  #:literal-sets (kernel-literals)
+  #:literals (class-internal values)
+  (pattern (let-values ([() (begin (quote-syntax
+                                    (class-internal
+                                     (#:forall type-parameter:id ...)
+                                     (#:all-inits all-init-names:id ...)
+                                     (#:init init-names:name-pair ...)
+                                     (#:init-field init-field-names:name-pair ...)
+                                     (#:init-rest (~optional init-rest-name:id))
+                                     (#:optional-init optional-names:id ...)
+                                     (#:field field-names:name-pair ...)
+                                     (#:public public-names:name-pair ...)
+                                     (#:override override-names:name-pair ...)
+                                     (#:private privates:id ...)
+                                     (#:private-field private-fields:id ...)
+                                     (#:inherit inherit-names:name-pair ...)
+                                     (#:inherit-field inherit-field-names:name-pair ...)
+                                     (#:augment augment-names:name-pair ...)
+                                     (#:pubment pubment-names:name-pair ...))
+                                    #:local)
+                                   (#%plain-app values))])
+             _)
+           #:with type-parameters #'(type-parameter ...)
+           #:with all-init-internals #'(all-init-names ...)
+           #:with init-internals #'(init-names.internal ...)
+           #:with init-externals #'(init-names.external ...)
+           #:with init-field-internals #'(init-field-names.internal ...)
+           #:with init-field-externals #'(init-field-names.external ...)
+           #:with optional-inits #'(optional-names ...)
+           #:with field-internals #'(field-names.internal ...)
+           #:with field-externals #'(field-names.external ...)
+           #:with public-internals #'(public-names.internal ...)
+           #:with public-externals #'(public-names.external ...)
+           #:with override-internals #'(override-names.internal ...)
+           #:with override-externals #'(override-names.external ...)
+           #:with inherit-externals #'(inherit-names.external ...)
+           #:with inherit-internals #'(inherit-names.internal ...)
+           #:with inherit-field-externals #'(inherit-field-names.external ...)
+           #:with inherit-field-internals #'(inherit-field-names.internal ...)
+           #:with augment-externals #'(augment-names.external ...)
+           #:with augment-internals #'(augment-names.internal ...)
+           #:with pubment-externals #'(pubment-names.external ...)
+           #:with pubment-internals #'(pubment-names.internal ...)
+           #:with private-names #'(privates ...)
+           #:with private-field-names #'(private-fields ...)))
+
+
+;; Syntax (Syntax -> Any) -> Listof<Syntax>
+;; Look through the expansion of the class macro in search for
+;; syntax with some property (e.g., methods)
+(define (trawl-for-property form accessor)
+  (define (recur-on-all stx-list)
+    (apply append (map (λ (stx) (trawl-for-property stx accessor))
+                       (syntax->list stx-list))))
+  (syntax-parse form
+    #:literals (let-values letrec-values #%plain-app
+                #%plain-lambda #%expression)
+    [stx
+     #:when (accessor #'stx)
+     (list form)]
+    [(let-values (b ...) body ...)
+     (recur-on-all #'(b ... body ...))]
+    ;; for letrecs, traverse the RHSs too
+    [(letrec-values ([(x ...) rhs ...] ...) body ...)
+     (recur-on-all #'(rhs ... ... body ...))]
+    [(#%plain-app e ...)
+     (recur-on-all #'(e ...))]
+    [(#%plain-lambda (x ...) e ...)
+     (recur-on-all #'(e ...))]
+    [(#%expression e)
+     (recur-on-all #'(e))]
+    [_ '()]))
+
+(define (parse-internal-class-data class-name-table)
+  (syntax-parse class-name-table
+    [tbl:internal-class-data
+     ;; Save parse attributes to pass through to helper functions
+     (define type-parameters (syntax->datum #'tbl.type-parameters))
+     (define fresh-parameters (map gensym type-parameters))
+     (hash 'type-parameters     type-parameters
+           'fresh-parameters    fresh-parameters
+           'optional-inits      (syntax->datum #'tbl.optional-inits)
+           'only-init-internals (syntax->datum #'tbl.init-internals)
+           'only-init-names     (syntax->datum #'tbl.init-externals)
+           ;; the order of these names reflect the order in the class,
+           ;; so use this list when retaining the order is important
+           'init-internals      (syntax->datum #'tbl.all-init-internals)
+           'init-rest-name     (and (attribute tbl.init-rest-name)
+                                    (syntax-e (attribute tbl.init-rest-name)))
+           'public-internals   (syntax->datum #'tbl.public-internals)
+           'override-internals (syntax->datum #'tbl.override-internals)
+           'pubment-internals  (syntax->datum #'tbl.pubment-internals)
+           'augment-internals  (syntax->datum #'tbl.augment-internals)
+           'method-internals
+           (set-union (syntax->datum #'tbl.public-internals)
+                      (syntax->datum #'tbl.override-internals))
+           'field-internals
+           (set-union (syntax->datum #'tbl.field-internals)
+                      (syntax->datum #'tbl.init-field-internals))
+           'inherit-internals
+           (syntax->datum #'tbl.inherit-internals)
+           'inherit-field-internals
+           (syntax->datum #'tbl.inherit-field-internals)
+           'init-names
+           (set-union (syntax->datum #'tbl.init-externals)
+                      (syntax->datum #'tbl.init-field-externals))
+           'field-names
+           (set-union (syntax->datum #'tbl.field-externals)
+                      (syntax->datum #'tbl.init-field-externals))
+           'public-names   (syntax->datum #'tbl.public-externals)
+           'override-names (syntax->datum #'tbl.override-externals)
+           'pubment-names  (syntax->datum #'tbl.pubment-externals)
+           'augment-names  (syntax->datum #'tbl.augment-externals)
+           'inherit-names  (syntax->datum #'tbl.inherit-externals)
+           'inherit-field-names
+           (syntax->datum #'tbl.inherit-field-externals)
+           'private-names  (syntax->datum #'tbl.private-names)
+           'private-fields (syntax->datum #'tbl.private-field-names)
+           'overridable-names
+           (set-union (syntax->datum #'tbl.public-externals)
+                      (syntax->datum #'tbl.override-externals))
+           'augmentable-names
+           (set-union (syntax->datum #'tbl.pubment-externals)
+                      (syntax->datum #'tbl.augment-externals))
+           'method-names
+           (set-union (syntax->datum #'tbl.public-externals)
+                      (syntax->datum #'tbl.override-externals)
+                      (syntax->datum #'tbl.augment-externals)
+                      (syntax->datum #'tbl.pubment-externals))
+           'all-internal
+           (append (syntax->datum #'tbl.init-internals)
+                   (syntax->datum #'tbl.init-field-internals)
+                   (syntax->datum #'tbl.field-internals)
+                   (syntax->datum #'tbl.public-internals)
+                   (syntax->datum #'tbl.override-internals)
+                   (syntax->datum #'tbl.inherit-internals)
+                   (syntax->datum #'tbl.inherit-field-internals)
+                   (syntax->datum #'tbl.pubment-internals)
+                   (syntax->datum #'tbl.augment-internals))
+           'all-external
+           (append (syntax->datum #'tbl.init-externals)
+                   (syntax->datum #'tbl.init-field-externals)
+                   (syntax->datum #'tbl.field-externals)
+                   (syntax->datum #'tbl.public-externals)
+                   (syntax->datum #'tbl.override-externals)
+                   (syntax->datum #'tbl.inherit-externals)
+                   (syntax->datum #'tbl.inherit-field-externals)
+                   (syntax->datum #'tbl.pubment-externals)
+                   (syntax->datum #'tbl.augment-externals)))]))
+
+(define (make-internal-external-mapping parse-info)
+  (for/hash ([internal (hash-ref parse-info 'all-internal)]
+             [external (hash-ref parse-info 'all-external)])
+    (values internal external)))
+
+

--- a/typed-racket-lib/typed-racket/utils/plambda-utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/plambda-utils.rkt
@@ -1,0 +1,49 @@
+#lang racket/base
+
+(provide
+  plambda-prop
+  has-poly-annotation?
+  get-poly-layer
+  remove-poly-layer
+  get-poly-tvarss)
+
+(require
+  racket/list
+  racket/match
+  typed-racket/env/scoped-tvar-env
+  typed-racket/private/syntax-properties)
+
+
+(define (plambda-prop stx)
+  (define d (plambda-property stx))
+  (and d (car (flatten d))))
+
+(define (has-poly-annotation? form)
+  (or (plambda-prop form) (pair? (lookup-scoped-tvar-layer form))))
+
+(define (get-poly-layer tvarss)
+  (map car tvarss))
+
+(define (remove-poly-layer tvarss)
+  (filter pair? (map rest tvarss)))
+
+(define (get-poly-tvarss form)
+  (let ([plambda-tvars
+          (let ([p (plambda-prop form)])
+            (match (and p (map syntax-e (syntax->list p)))
+              [#f #f]
+              [(list var ... dvar '...)
+               (list (list var dvar))]
+              [(list id ...)
+               (list id)]))]
+        [scoped-tvarss
+          (for/list ((tvarss (in-list (lookup-scoped-tvar-layer form))))
+            (for/list ((tvar (in-list tvarss)))
+              (match tvar
+                [(list (list v ...) dotted-v)
+                 (list (map syntax-e v) (syntax-e dotted-v))]
+                [(list v ...) (map syntax-e v)])))])
+    (if plambda-tvars
+        (cons plambda-tvars scoped-tvarss)
+        scoped-tvarss)))
+

--- a/typed-racket-lib/typed-racket/utils/shallow-contract.rkt
+++ b/typed-racket-lib/typed-racket/utils/shallow-contract.rkt
@@ -1,0 +1,79 @@
+#lang racket/base
+
+;; Extra contracts and tools for the Shallow runtime,
+;; which is based on Michael Vitousek's Transient semantics
+
+(provide
+  procedure-arity-includes-keywords?
+  shallow-and/c
+  shallow-or/c
+  shallow-shape-check
+  raise-shallow-check-error)
+
+;; ---------------------------------------------------------------------------------------------------
+
+;; procedure-arity-includes-keywords? : (-> procedure? (listof keyword?) (listof keyword?) boolean?)
+;; Returns true if the procedure accepts calls that supply all mandatory keywords
+;; and some optional keywords --- in the sense of racket/contract arity checking.
+;; + function must declare all optional keywords as optional
+;; + function may declare all mandatory keywords as either mandatory or optional
+(define (procedure-arity-includes-keywords? f mand-kw* opt-kw*)
+  (define-values [f-mand-kw* f-opt-kw*] (procedure-keywords f))
+  ;; note: f-opt-kw* = (sort f-opt-kw* keyword<?)
+  (define mand-ok/extra*
+    ;; subtract f's mandatory keywords from the expected list (must be a prefix)
+    (let loop ((expected-kw* mand-kw*)
+               (actual-kw* f-mand-kw*))
+      (cond
+        [(null? actual-kw*)
+         expected-kw*]
+        [(null? expected-kw*)
+         #f]
+        [else
+         (and (eq? (car expected-kw*) (car actual-kw*))
+              (loop (cdr expected-kw*) (cdr actual-kw*)))])))
+  (and mand-ok/extra*
+       (let loop ((expected-kw* (sort (append mand-ok/extra* opt-kw*) keyword<?))
+                  (actual-kw* f-opt-kw*))
+         ;; match the remaining keywords against f's optionals
+         (cond
+          ((null? expected-kw*)
+           #true)
+          ((or (null? actual-kw*) (keyword<? (car expected-kw*) (car actual-kw*)))
+           #false)
+          ((eq? (car actual-kw*) (car expected-kw*))
+           (loop (cdr expected-kw*) (cdr actual-kw*)))
+          (else ;#(keyword<? actual expected)
+           (loop expected-kw* (cdr actual-kw*)))))))
+
+(define (shallow-and/c . pred*)
+  (lambda (x)
+    (let loop ((p?* pred*))
+      (if (null? p?*)
+        #true
+        (if ((car p?*) x)
+          (loop (cdr p?*))
+          #false)))))
+
+(define (shallow-or/c . pred*)
+  (lambda (x)
+    (let loop ((p?* pred*))
+      (if (null? p?*)
+        #false
+        (if ((car p?*) x)
+          #true
+          (loop (cdr p?*)))))))
+
+(define (shallow-shape-check val pred ty-str ctx)
+  (if (pred val)
+    val
+    (raise-shallow-check-error val ty-str ctx)))
+
+(define (raise-shallow-check-error val ty ctx)
+  (raise-arguments-error 'shape-check
+                         "value does not match expected type"
+                         "value" val
+                         "type" (unquoted-printing-string ty)
+                         "lang" 'typed/racket/shallow
+                         "src" ctx))
+

--- a/typed-racket-lib/typed-racket/utils/shallow-utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/shallow-utils.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+
+(provide
+  shallow-trusted-positive?
+  (all-from-out (submod typed-racket/rep/type-rep shallow-exports)))
+
+(require
+  racket/match
+  typed-racket/types/match-expanders
+  typed-racket/rep/type-rep
+  (submod typed-racket/rep/type-rep shallow-exports)
+  typed-racket/types/tc-result
+  typed-racket/types/type-table
+  typed-racket/types/union)
+
+
+(define (ArrowT+? arr)
+  (and (Arrow? arr) (Arrow-rng-shallow-safe? arr)))
+
+(define (shallow-trusted-positive? orig-ty)
+  (let loop ((ty (normalize-type orig-ty)))
+    (match ty
+      [(Fun: arr*)
+       (andmap ArrowT+? arr*)]
+      [(Union: _ ts)
+       (andmap loop ts)]
+      [(or (Poly: _ b)
+           (PolyDots-unsafe: _ b)
+           (PolyRow-unsafe: b _))
+       (loop b)]
+      [_
+        #false])))
+

--- a/typed-racket-lib/typed-racket/utils/tc-utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/tc-utils.rkt
@@ -298,9 +298,6 @@ don't depend on any other portion of the system
 (define deep 'deep)
 (define shallow 'shallow)
 (define optional 'optional)
-(define guarded deep)
-(define transient shallow)
-(define erasure optional)
 
 (define (type-enforcement-mode? x)
   (and (symbol? x)

--- a/typed-racket-lib/typed-racket/utils/tc-utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/tc-utils.rkt
@@ -38,6 +38,14 @@ don't depend on any other portion of the system
          int-err
 
          typed-context?
+
+         type-enforcement-mode
+         current-type-enforcement-mode
+         type-enforcement-mode?
+         deep ;; deep types, guarded semantics
+         shallow ;; shallow types, transient semantics
+         optional ;; optional types, no-op / erasure semantics (types are compile-time only)
+
          make-env
          id-from?
          id-from
@@ -280,7 +288,30 @@ don't depend on any other portion of the system
           (current-continuation-marks))))
 
 ;; are we currently expanding in a typed module (or top-level form)?
+;; (box/c (or/c #t #f))
 (define typed-context? (box #f))
+
+;; (box/c type-enforcement-mode?)
+(define type-enforcement-mode (box #f))
+
+;; type enforcement strategies: how to interpret types as run-time checks?
+(define deep 'deep)
+(define shallow 'shallow)
+(define optional 'optional)
+(define guarded deep)
+(define transient shallow)
+(define erasure optional)
+
+(define (type-enforcement-mode? x)
+  (and (symbol? x)
+       (or (eq? x deep)
+           (eq? x shallow)
+           (eq? x optional))))
+
+;; if we are in a typed module, how do we enforce types?
+;; (or/c #f type-enforcement-mode?)
+(define (current-type-enforcement-mode)
+  (unbox type-enforcement-mode))
 
 ;; environment constructor
 (define-syntax (make-env stx)
@@ -309,3 +340,4 @@ don't depend on any other portion of the system
 (define-syntax-class (id-from sym mod)
   (pattern i:id
            #:fail-unless (id-from? #'i sym mod) #f))
+

--- a/typed-racket-lib/typed-racket/utils/utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/utils.rkt
@@ -27,6 +27,7 @@ at least theoretically.
  repeat-list
  ends-with?
  filter-multiple
+ rev-append
  syntax-length
  in-pair
  in-list/rest
@@ -246,6 +247,10 @@ at least theoretically.
 (define (filter-multiple l . fs)
   (apply values
          (map (lambda (f) (filter f l)) fs)))
+
+(define (rev-append a* b*)
+  (let loop ((a* a*) (b* b*))
+    (if (null? a*) b* (loop (cdr a*) (cons (car a*) b*)))))
 
 (define (syntax-length stx)
   (let ((list (syntax->list stx)))

--- a/typed-racket-lib/typed/racket/base.rkt
+++ b/typed-racket-lib/typed/racket/base.rkt
@@ -12,7 +12,8 @@
                          for*/and
                          for*/or for*/sum for*/product for*/first for*/last
                          for*/fold for*/foldr))
-           (basics #%module-begin #%top-interaction))
+           (basics #%module-begin #%top-interaction)
+           (ts-except with-type-shallow with-type-optional))
 
 (require typed-racket/base-env/extra-procs
          (except-in typed-racket/base-env/prims

--- a/typed-racket-lib/typed/racket/base/deep.rkt
+++ b/typed-racket-lib/typed/racket/base/deep.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+(require
+  (for-syntax racket/base)
+  (except-in typed/racket/base #%module-begin #%top-interaction with-type)
+  (only-in typed/racket/base
+           [#%module-begin --#%module-begin]
+           [#%top-interaction --#%top-interaction]
+           [with-type -with-type]))
+
+(provide
+  (all-from-out typed/racket/base)
+  with-type
+  (rename-out [-#%module-begin #%module-begin] [-#%top-interaction #%top-interaction]))
+
+(define-syntax (-#%module-begin stx)
+  (quasisyntax/loc stx (--#%module-begin #:deep . #,(cdr (syntax-e stx)))))
+
+(define-syntax (-#%top-interaction stx)
+  (quasisyntax/loc stx (--#%top-interaction #:deep . #,(cdr (syntax-e stx)))))
+
+(define-syntax (with-type stx)
+  (quasisyntax/loc stx (-with-type . #,(cdr (syntax-e stx)))))
+

--- a/typed-racket-lib/typed/racket/base/deep/lang/reader.rkt
+++ b/typed-racket-lib/typed/racket/base/deep/lang/reader.rkt
@@ -1,0 +1,20 @@
+#lang s-exp syntax/module-reader
+
+typed/racket/base/deep
+
+#:read r:read
+#:read-syntax r:read-syntax
+#:info make-info
+#:language-info make-language-info
+
+(define (make-info key default use-default)
+  (case key
+    [(drracket:opt-in-toolbar-buttons)
+     '(optimization-coach)]
+    [else (use-default key default)]))
+
+(define make-language-info
+  `#(typed-racket/language-info get-info (deep)))
+
+
+(require (prefix-in r: typed-racket/typed-reader))

--- a/typed-racket-lib/typed/racket/base/optional.rkt
+++ b/typed-racket-lib/typed/racket/base/optional.rkt
@@ -1,0 +1,45 @@
+#lang racket/base
+
+(require
+  (only-in racket/require subtract-in)
+  (for-syntax racket/base)
+  typed-racket/base-env/base-env-uncontracted
+  (subtract-in
+    (except-in typed/racket/base
+               #%module-begin #%top-interaction with-type default-continuation-prompt-tag)
+    (submod typed-racket/base-env/prims-contract forms))
+  (only-in (submod typed-racket/base-env/prims-contract forms)
+           make-predicate
+           define-predicate)
+  (only-in (submod typed-racket/base-env/prims-contract forms-optional)
+           (require-typed-signature-optional require-typed-signature)
+           (require/opaque-type-optional require/opaque-type)
+           (require-typed-struct-legacy-optional require-typed-struct-legacy)
+           (require-typed-struct-optional require-typed-struct)
+           (require/typed-legacy-optional require/typed-legacy)
+           (require/typed-optional require/typed)
+           (require/typed/provide-optional require/typed/provide)
+           (require-typed-struct/provide-optional require-typed-struct/provide)
+           (cast-optional cast))
+  (only-in typed-racket/typed-racket with-type-optional)
+  (only-in typed/racket/base
+           [#%module-begin --#%module-begin]
+           [#%top-interaction --#%top-interaction]))
+
+(provide
+  (all-from-out typed/racket/base)
+  (all-from-out typed-racket/base-env/base-env-uncontracted)
+  (all-from-out (submod typed-racket/base-env/prims-contract forms-optional))
+  make-predicate define-predicate
+  with-type
+  (rename-out [-#%module-begin #%module-begin] [-#%top-interaction #%top-interaction]))
+
+(define-syntax (-#%module-begin stx)
+  (quasisyntax/loc stx (--#%module-begin #:optional . #,(cdr (syntax-e stx)))))
+
+(define-syntax (-#%top-interaction stx)
+  (quasisyntax/loc stx (--#%top-interaction #:optional . #,(cdr (syntax-e stx)))))
+
+(define-syntax (with-type stx)
+  (quasisyntax/loc stx (with-type-optional . #,(cdr (syntax-e stx)))))
+

--- a/typed-racket-lib/typed/racket/base/optional/lang/reader.rkt
+++ b/typed-racket-lib/typed/racket/base/optional/lang/reader.rkt
@@ -1,0 +1,20 @@
+#lang s-exp syntax/module-reader
+
+typed/racket/base/optional
+
+#:read r:read
+#:read-syntax r:read-syntax
+#:info make-info
+#:language-info make-language-info
+
+(define (make-info key default use-default)
+  (case key
+    [(drracket:opt-in-toolbar-buttons)
+     '(optimization-coach)]
+    [else (use-default key default)]))
+
+(define make-language-info
+  `#(typed-racket/language-info get-info (optional)))
+
+
+(require (prefix-in r: typed-racket/typed-reader))

--- a/typed-racket-lib/typed/racket/base/shallow.rkt
+++ b/typed-racket-lib/typed/racket/base/shallow.rkt
@@ -1,0 +1,46 @@
+#lang racket/base
+
+(require
+  (only-in racket/require subtract-in)
+  (for-syntax racket/base)
+  typed-racket/base-env/base-env-uncontracted
+  typed-racket/utils/shallow-contract ;; needed for eval, see test in succeed/shallow/scribble-example.rkt
+  (subtract-in
+    (except-in typed/racket/base
+               #%module-begin #%top-interaction with-type default-continuation-prompt-tag)
+    (submod typed-racket/base-env/prims-contract forms))
+  (only-in (submod typed-racket/base-env/prims-contract forms)
+           make-predicate
+           define-predicate)
+  (only-in (submod typed-racket/base-env/prims-contract forms-shallow)
+           (require-typed-signature-shallow require-typed-signature)
+           (require/opaque-type-shallow require/opaque-type)
+           (require-typed-struct-legacy-shallow require-typed-struct-legacy)
+           (require-typed-struct-shallow require-typed-struct)
+           (require/typed-legacy-shallow require/typed-legacy)
+           (require/typed-shallow require/typed)
+           (require/typed/provide-shallow require/typed/provide)
+           (require-typed-struct/provide-shallow require-typed-struct/provide)
+           (cast-shallow cast))
+  (only-in typed-racket/typed-racket with-type-shallow)
+  (only-in typed/racket/base
+           [#%module-begin --#%module-begin]
+           [#%top-interaction --#%top-interaction]))
+
+(provide
+  (all-from-out typed/racket/base)
+  (all-from-out typed-racket/base-env/base-env-uncontracted)
+  (all-from-out (submod typed-racket/base-env/prims-contract forms-shallow))
+  make-predicate define-predicate
+  with-type
+  (rename-out [-#%module-begin #%module-begin] [-#%top-interaction #%top-interaction]))
+
+(define-syntax (-#%module-begin stx)
+  (quasisyntax/loc stx (--#%module-begin #:shallow . #,(cdr (syntax-e stx)))))
+
+(define-syntax (-#%top-interaction stx)
+  (quasisyntax/loc stx (--#%top-interaction #:shallow . #,(cdr (syntax-e stx)))))
+
+(define-syntax (with-type stx)
+  (quasisyntax/loc stx (with-type-shallow . #,(cdr (syntax-e stx)))))
+

--- a/typed-racket-lib/typed/racket/base/shallow/lang/reader.rkt
+++ b/typed-racket-lib/typed/racket/base/shallow/lang/reader.rkt
@@ -1,0 +1,20 @@
+#lang s-exp syntax/module-reader
+
+typed/racket/base/shallow
+
+#:read r:read
+#:read-syntax r:read-syntax
+#:info make-info
+#:language-info make-language-info
+
+(define (make-info key default use-default)
+  (case key
+    [(drracket:opt-in-toolbar-buttons)
+     '(optimization-coach)]
+    [else (use-default key default)]))
+
+(define make-language-info
+  `#(typed-racket/language-info get-info (shallow)))
+
+
+(require (prefix-in r: typed-racket/typed-reader))

--- a/typed-racket-lib/typed/racket/deep.rkt
+++ b/typed-racket-lib/typed/racket/deep.rkt
@@ -1,0 +1,15 @@
+#lang typed-racket/minimal
+
+(require typed/racket/base/deep racket/require
+         (subtract-in racket typed/racket/base/deep racket/contract
+                      typed/racket/class
+                      typed/racket/unit)
+         typed/racket/class
+         typed/racket/unit
+	 (for-syntax racket/base))
+(provide (all-from-out racket
+                       typed/racket/base/deep
+                       typed/racket/class
+                       typed/racket/unit)
+	 (for-syntax (all-from-out racket/base))
+         class)

--- a/typed-racket-lib/typed/racket/deep/lang/reader.rkt
+++ b/typed-racket-lib/typed/racket/deep/lang/reader.rkt
@@ -1,0 +1,21 @@
+#lang s-exp syntax/module-reader
+
+typed/racket/deep
+
+#:read r:read
+#:read-syntax r:read-syntax
+#:info make-info
+#:language-info make-language-info
+
+(define (make-info key default use-default)
+  (case key
+    [(drracket:opt-in-toolbar-buttons)
+     '(optimization-coach)]
+    [else (use-default key default)]))
+
+(define make-language-info
+  `#(typed-racket/language-info get-info (deep)))
+
+
+(require (prefix-in r: typed-racket/typed-reader))
+

--- a/typed-racket-lib/typed/racket/optional.rkt
+++ b/typed-racket-lib/typed/racket/optional.rkt
@@ -1,0 +1,15 @@
+#lang typed-racket/minimal
+
+(require typed/racket/base/optional racket/require
+         (subtract-in racket typed/racket/base/optional racket/contract
+                      typed/racket/class
+                      typed/racket/unit)
+         typed/racket/class
+         typed/racket/unit
+	 (for-syntax racket/base))
+(provide (all-from-out racket
+                       typed/racket/base/optional
+                       typed/racket/class
+                       typed/racket/unit)
+	 (for-syntax (all-from-out racket/base))
+         class)

--- a/typed-racket-lib/typed/racket/optional/lang/reader.rkt
+++ b/typed-racket-lib/typed/racket/optional/lang/reader.rkt
@@ -1,0 +1,20 @@
+#lang s-exp syntax/module-reader
+
+typed/racket/optional
+
+#:read r:read
+#:read-syntax r:read-syntax
+#:info make-info
+#:language-info make-language-info
+
+(define (make-info key default use-default)
+  (case key
+    [(drracket:opt-in-toolbar-buttons)
+     '(optimization-coach)]
+    [else (use-default key default)]))
+
+(define make-language-info
+  `#(typed-racket/language-info get-info (optional)))
+
+
+(require (prefix-in r: typed-racket/typed-reader))

--- a/typed-racket-lib/typed/racket/shallow.rkt
+++ b/typed-racket-lib/typed/racket/shallow.rkt
@@ -1,0 +1,15 @@
+#lang typed-racket/minimal
+
+(require typed/racket/base/shallow racket/require
+         (subtract-in racket typed/racket/base/shallow racket/contract
+                      typed/racket/class
+                      typed/racket/unit)
+         typed/racket/class
+         typed/racket/unit
+	 (for-syntax racket/base))
+(provide (all-from-out racket
+                       typed/racket/base/shallow
+                       typed/racket/class
+                       typed/racket/unit)
+	 (for-syntax (all-from-out racket/base))
+         class)

--- a/typed-racket-lib/typed/racket/shallow/lang/reader.rkt
+++ b/typed-racket-lib/typed/racket/shallow/lang/reader.rkt
@@ -1,0 +1,20 @@
+#lang s-exp syntax/module-reader
+
+typed/racket/shallow
+
+#:read r:read
+#:read-syntax r:read-syntax
+#:info make-info
+#:language-info make-language-info
+
+(define (make-info key default use-default)
+  (case key
+    [(drracket:opt-in-toolbar-buttons)
+     '(optimization-coach)]
+    [else (use-default key default)]))
+
+(define make-language-info
+  `#(typed-racket/language-info get-info (shallow)))
+
+
+(require (prefix-in r: typed-racket/typed-reader))

--- a/typed-racket-lib/typed/untyped-utils.rkt
+++ b/typed-racket-lib/typed/untyped-utils.rkt
@@ -17,10 +17,13 @@
 
 (define-syntax (define-typed/untyped-identifier stx)
   (syntax-parse stx
-    [(_ name:id typed-name:id untyped-name:id)
+    [(_ name:id deep-name:id untyped-name:id (~optional shallow-name:id) (~optional optional-name:id))
      (syntax/loc stx
        (define-syntax name
-         (make-typed-renaming #'typed-name #'untyped-name)))]))
+         (make-typed-renaming #'deep-name #'untyped-name
+                              (~? #'shallow-name #'untyped-name)
+                              (~? #'optional-name #'untyped-name)
+                              )))]))
 
 (define-for-syntax (freshen ids)
   (stx-map (lambda (id) ((make-syntax-introducer) id)) ids))

--- a/typed-racket-more/typed/framework.rkt
+++ b/typed-racket-more/typed/framework.rkt
@@ -89,6 +89,7 @@
  (define -DC<%>-Instance (make-Instance -DC<%>)))
 
 (type-environment
+ #:default-T+ #true
  [application:current-app-name (-Param -String)]
  ;; 3 Autosave
  [autosave:register
@@ -190,7 +191,7 @@
                              -String
                              (-vec -Color%-Instance)
                              (Un (-val 'low) (-val 'high))))))]
- [color:misspelled-text-color-style-name (-> -String)]
+ [color:misspelled-text-color-style-name -String]
  ;; 8 Comment Box
  [comment-box:snip% (parse-type #'Comment-Box:Snip%)]
  [comment-box:snipclass (make-Instance -Snip-Class%)]

--- a/typed-racket-more/typed/images/compile-time.rkt
+++ b/typed-racket-more/typed/images/compile-time.rkt
@@ -1,10 +1,12 @@
 #lang typed/racket
+#:no-optimize
 
-(require (for-syntax racket/base racket/class racket/draw))
+(require (for-syntax racket/base racket/class racket/draw)
+         (only-in typed/racket/unsafe unsafe-provide))
 
 (require typed/racket/draw)
 
-(provide compiled-bitmap compiled-bitmap-list)
+(unsafe-provide compiled-bitmap compiled-bitmap-list)
 
 (begin-for-syntax
   (define (save-png bm)

--- a/typed-racket-more/typed/net/git-checkout.rkt
+++ b/typed-racket-more/typed/net/git-checkout.rkt
@@ -5,6 +5,7 @@
 (require net/git-checkout)
 
 (type-environment
+ #:default-T+ #t
  [git-checkout
   (->key -String -String
          #:dest-dir (-opt -Pathlike) #t

--- a/typed-racket-more/typed/pict.rkt
+++ b/typed-racket-more/typed/pict.rkt
@@ -2,6 +2,8 @@
 
 ;; Typed base-env wrapper for the pict library
 
+;; TODO 2022-01-28 ... add T+ for untrusted ones!!!
+
 (require pict
          "racket/private/gui-types.rkt"
          (for-syntax (only-in typed-racket/rep/type-rep
@@ -9,6 +11,7 @@
                      (submod "racket/private/gui-types.rkt" #%type-decl)))
 
 (begin-for-syntax
+(with-default-T+ #true
  (define (-improper-listof t)
    (-mu -ilof
         (Un (-pair t -ilof) t -Null)))
@@ -42,15 +45,18 @@
           (-> -pict -pict-path (-values (list -Real -Real)))
           #:start-angle (-opt -Real) #f
           #:end-angle (-opt -Real) #f
-          #:start-pull -Real #f
-          #:end-pull -Real #f
-          #:line-width (-opt -Real) #f
+          #:start-pull (-opt -Real) #f
+          #:end-pull (-opt -Real) #f
           #:color (-opt (Un -String -color)) #f
           #:alpha -Real #f
-          #:style -linestyle #f
+          #:line-width (-opt -Real) #f
           #:under? Univ #f
           #:solid? Univ #f
+          #:style (-opt -linestyle) #f
           #:hide-arrowhead? Univ #f
+          #:label (-opt -pict) #f
+          #:x-adjust-label -Real #f
+          #:y-adjust-label -Real #f
           -pict))
  (define -pict-finder
    (-> -pict -pict-path (-values (list -Real -Real))))
@@ -59,9 +65,10 @@
      (->* (list -Real -pict) -pict -pict)
      (->* (list -pict) -pict -pict)))
  (define -superimpose-type
-   (->* (list -pict) -pict -pict)))
+   (->* (list -pict) -pict -pict))))
 
 (type-environment
+ #:default-T+ #true
  ; 1 Pict Datatype
  [#:struct pict ([draw : Univ]
                  [width : -Real]
@@ -157,13 +164,17 @@
          (-> -pict -pict-path (-values (list -Real -Real)))
          #:start-angle (-opt -Real) #f
          #:end-angle (-opt -Real) #f
-         #:start-pull -Real #f
-         #:end-pull -Real #f
-         #:line-width (-opt -Real) #f
+         #:start-pull (-opt -Real) #f
+         #:end-pull (-opt -Real) #f
          #:color (-opt (Un -String -color)) #f
          #:alpha -Real #f
-         #:style -linestyle #f
+         #:line-width (-opt -Real) #f
          #:under? Univ #f
+         #:solid? Univ #f
+         #:style (-opt -linestyle) #f
+         #:label (-opt -pict) #f
+         #:x-adjust-label -Real #f
+         #:y-adjust-label -Real #f
          -pict)]
  [pin-arrow-line -pin-arrow-line]
  [pin-arrows-line -pin-arrow-line]
@@ -269,7 +280,7 @@
  [rc-find -pict-finder]
  [rbl-find -pict-finder]
  [rb-find -pict-finder]
- [pict-path? (make-pred-ty -pict-path)]
+ [pict-path? (make-pred-ty -pict-path #true)]
  [launder (-> -pict -pict)]
 
  ;; 7.1 Dingbats

--- a/typed-racket-more/typed/pict.rkt
+++ b/typed-racket-more/typed/pict.rkt
@@ -280,7 +280,7 @@
  [rc-find -pict-finder]
  [rbl-find -pict-finder]
  [rb-find -pict-finder]
- [pict-path? (make-pred-ty -pict-path #true)]
+ [pict-path? (unsafe-shallow:make-pred-ty -pict-path)]
  [launder (-> -pict -pict)]
 
  ;; 7.1 Dingbats

--- a/typed-racket-more/typed/private/framework-types.rkt
+++ b/typed-racket-more/typed/private/framework-types.rkt
@@ -2,7 +2,10 @@
 
 ;; Types for the framework library
 
-(require "../racket/private/gui-types.rkt")
+(require "../racket/private/gui-types.rkt"
+         (for-template (only-in typed-racket/base-env/extra-env-lang with-default-T+)))
+
+(with-default-T+ #true
 
 ;; Frequently reused types
 (define-type Style-Delta%-Instance (Instance Style-Delta%))
@@ -1831,3 +1834,5 @@
 (require/typed framework
  [#:opaque Color-Prefs:Color-Scheme-Style-Name color-prefs:color-scheme-style-name?]
  [#:opaque Color-Prefs:Color-Scheme-Color-Name color-prefs:color-scheme-color-name?])
+
+)

--- a/typed-racket-more/typed/racket/async-channel.rkt
+++ b/typed-racket-more/typed/racket/async-channel.rkt
@@ -7,10 +7,10 @@
 
 ;; Section 11.2.4 (Buffered Asynchronous Channels)
 (type-environment
- [make-async-channel (-poly (a) (->opt [(-opt -PosInt)] (-async-channel a)))]
+ [make-async-channel (-poly (a) (->opt [(-opt -PosInt)] (-async-channel a) :T+ #t))]
  [async-channel? (make-pred-ty -Async-ChannelTop)]
- [async-channel-get (-poly (a) ((-async-channel a) . -> . a))]
- [async-channel-try-get (-poly (a) ((-async-channel a) . -> . (-opt a)))]
- [async-channel-put (-poly (a) ((-async-channel a) a . -> . -Void))]
- [async-channel-put-evt (-poly (a) (-> (-async-channel a) a (-mu x (-evt x))))])
+ [async-channel-get (-poly (a) ((-async-channel a) . -> . a :T+ #f))]
+ [async-channel-try-get (-poly (a) ((-async-channel a) . -> . (-opt a) :T+ #f))]
+ [async-channel-put (-poly (a) ((-async-channel a) a . -> . -Void :T+ #t))]
+ [async-channel-put-evt (-poly (a) (-> (-async-channel a) a (-mu x (-evt x)) :T+ #f))])
 

--- a/typed-racket-more/typed/racket/draw.rkt
+++ b/typed-racket-more/typed/racket/draw.rkt
@@ -83,6 +83,7 @@
   (define -LoadFileKind (parse-type #'LoadFileKind)))
 
 (type-environment
+ #:default-T+ #t
  [bitmap% (parse-type #'Bitmap%)]
  [bitmap-dc% (parse-type #'Bitmap-DC%)]
  [brush% (parse-type #'Brush%)]
@@ -91,7 +92,7 @@
  [dc-path% (parse-type #'DC-Path%)]
  [font% (parse-type #'Font%)]
  [font-list% (parse-type #'Font-List%)]
- [get-current-gl-context (parse-type #'(-> (U #f GL-Context<%>)))]
+ [get-current-gl-context  (-> (parse-type #'(U #f GL-Context<%>)))]
  [gl-config% (parse-type #'GL-Config%)]
  [linear-gradient% (parse-type #'Linear-Gradient%)]
  [pdf-dc% (parse-type #'PDF-DC%)]

--- a/typed-racket-more/typed/racket/gui/base.rkt
+++ b/typed-racket-more/typed/racket/gui/base.rkt
@@ -25,6 +25,7 @@
  (define -Color%-Obj (make-Instance -Color%)))
 
 (type-environment
+ #:default-T+ #t
  [button% (parse-type #'Button%)]
  [canvas% (parse-type #'Canvas%)]
  [check-box% (parse-type #'Check-Box%)]

--- a/typed-racket-more/typed/racket/private/gui-types.rkt
+++ b/typed-racket-more/typed/racket/private/gui-types.rkt
@@ -40,6 +40,10 @@
          Region%
          SVG-DC%)
 
+(require (for-template (only-in typed-racket/base-env/extra-env-lang with-default-T+)))
+
+(with-default-T+ #true
+
 (define-type LoadFileKind
   (U 'unknown 'unknown/mask 'unknown/alpha
      'gif 'gif/mask 'gif/alpha
@@ -2986,3 +2990,5 @@
   (Class
    [get-map (Char -> (Listof Wordbreak-Map-Value))]
    [set-map (Char (Listof Wordbreak-Map-Value) -> Void)]))
+
+)

--- a/typed-racket-more/typed/syntax/stx.rkt
+++ b/typed-racket-more/typed/syntax/stx.rkt
@@ -33,6 +33,7 @@
              (-Stx-Pairof a lst)))))
 
 (type-environment
+ #:default-T+ #true
  [stx-null? (make-pred-ty -Stx-Null)]
  [stx-pair? (make-pred-ty (-Stx-Pairof Univ Univ))]
  [stx-list? (make-pred-ty (-Stx-Listof Univ))]
@@ -42,11 +43,11 @@
                          (Un (-val #f) (-lst (-Syntax Univ))))))]
  [stx-car (-poly (a b)
             (cl->*
-             (-> (-Stx-Pairof a b) a)
-             (-> (-Stx-Listof a) a)))]
+             (-> (-Stx-Pairof a b) a :T+ #f)
+             (-> (-Stx-Listof a) a :T+ #f)))]
  [stx-cdr (-poly (a b)
             (cl->*
-             (-> (-Stx-Pairof a b) b)
+             (-> (-Stx-Pairof a b) b :T+ #f)
              (-> (-lst a) (-lst a))
              (-> (-Stx-Listof a) (-Stx-Listof a))))]
  [stx-map (-polydots (c a b)

--- a/typed-racket-test/external/succeed/optional-math-untyped-id.rkt
+++ b/typed-racket-test/external/succeed/optional-math-untyped-id.rkt
@@ -1,0 +1,52 @@
+#lang typed/racket/optional
+
+;; TODO uncomment after merging https://github.com/racket/math/pull/68
+
+;;;; Test math-lib identifiers created with `define-typed/untyped-id`
+;;
+;;(require
+;;  typed/rackunit
+;;  (only-in math/array
+;;           array?
+;;           list*->array
+;;           vector*->array
+;;           array-map)
+;;  (only-in math/matrix
+;;           matrix?
+;;           list->matrix
+;;           matrix-transpose
+;;           matrix-map
+;;           matrix*
+;;           matrix+
+;;           matrix-
+;;           matrix-scale
+;;           matrix-sum))
+;;
+;;(void
+;;  list*->array
+;;  vector*->array
+;;  array-map
+;;  matrix-map
+;;  matrix*
+;;  matrix+
+;;  matrix-
+;;  matrix-scale
+;;  matrix-sum)
+;;
+;;(define a0 (list*->array '((5 2 3) (4 1 0)) natural?))
+;;(define a1 (vector*->array '#(#(5 2 3) #(4 1 0)) natural?))
+;;
+;;(void
+;;  (array-map number->string a0)
+;;  (array-map number->string a1))
+;;
+;;(define m0 (list->matrix 2 3 '(5 2 3 4 1 0)))
+;;
+;;(void
+;;  (matrix-map number->string m0)
+;;  (matrix* m0 (matrix-transpose m0))
+;;  (matrix+ m0)
+;;  (matrix- m0 m0)
+;;  (matrix-scale m0 42)
+;;  (matrix-sum (list m0 m0)))
+;;

--- a/typed-racket-test/external/succeed/optional-plot-pict.rkt
+++ b/typed-racket-test/external/succeed/optional-plot-pict.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket/optional
+
+(require
+  plot/no-gui
+  typed/racket/draw
+  typed/rackunit)
+
+(check-not-exn
+  (lambda () (void (plot-pict (function values -10 10)))))
+
+(define bad-renderers (cast (list 42) (Listof renderer2d)))
+(check-exn exn:fail:contract?
+  (lambda () (plot-pict bad-renderers)))
+
+(define bad-point (cast (vector 'X 'Y) (Vector Real Real)))
+(check-exn exn:fail:contract?
+  (lambda () (points (vector bad-point))))
+
+;; check for no type errors
+(void
+  plot/dc plot-bitmap plot-pict plot3d/dc)

--- a/typed-racket-test/external/succeed/shallow-for-array.rkt
+++ b/typed-racket-test/external/succeed/shallow-for-array.rkt
@@ -1,0 +1,18 @@
+#lang typed/racket/shallow
+
+;; Use 'for/array' and `array-shape`
+;; inspired by jpeg benchmark
+;;
+;; Must use both!
+
+(require
+  (only-in math/array for/array: for/array in-array array-shape Array))
+
+(: bg (-> (Array Symbol) Void))
+(define (bg mcu-array)
+  (void
+    ;; well this works ...
+    (for/array #:shape (vector-map (ann values (-> Index Integer)) (array-shape mcu-array))
+               ((mcu : Symbol (in-array mcu-array)))
+      (void))))
+

--- a/typed-racket-test/external/succeed/shallow-in-array.rkt
+++ b/typed-racket-test/external/succeed/shallow-in-array.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/shallow
+
+;; Use 'in-array'
+;; inspired by jpeg benchmark
+
+
+(require (only-in math/array in-array Array))
+
+(: read-dct-scan (-> (Array Integer) Void))
+(define (read-dct-scan dest)
+  (for ((mcu (in-array dest)))
+    (void)))

--- a/typed-racket-test/external/succeed/shallow-math-untyped-id.rkt
+++ b/typed-racket-test/external/succeed/shallow-math-untyped-id.rkt
@@ -1,0 +1,52 @@
+#lang typed/racket/shallow
+
+;; TODO uncomment after merging https://github.com/racket/math/pull/68
+
+;;;; Test math-lib identifiers created with `define-typed/untyped-id`
+;;
+;;(require
+;;  typed/rackunit
+;;  (only-in math/array
+;;           array?
+;;           list*->array
+;;           vector*->array
+;;           array-map)
+;;  (only-in math/matrix
+;;           matrix?
+;;           list->matrix
+;;           matrix-transpose
+;;           matrix-map
+;;           matrix*
+;;           matrix+
+;;           matrix-
+;;           matrix-scale
+;;           matrix-sum))
+;;
+;;(void
+;;  list*->array
+;;  vector*->array
+;;  array-map
+;;  matrix-map
+;;  matrix*
+;;  matrix+
+;;  matrix-
+;;  matrix-scale
+;;  matrix-sum)
+;;
+;;(define a0 (list*->array '((5 2 3) (4 1 0)) natural?))
+;;(define a1 (vector*->array '#(#(5 2 3) #(4 1 0)) natural?))
+;;
+;;(void
+;;  (array-map number->string a0)
+;;  (array-map number->string a1))
+;;
+;;(define m0 (list->matrix 2 3 '(5 2 3 4 1 0)))
+;;
+;;(void
+;;  (matrix-map number->string m0)
+;;  (matrix* m0 (matrix-transpose m0))
+;;  (matrix+ m0)
+;;  (matrix- m0 m0)
+;;  (matrix-scale m0 42)
+;;  (matrix-sum (list m0 m0)))
+;;

--- a/typed-racket-test/external/succeed/shallow-plot-pict.rkt
+++ b/typed-racket-test/external/succeed/shallow-plot-pict.rkt
@@ -1,0 +1,20 @@
+#lang typed/racket/shallow
+
+(require
+  plot/no-gui
+  typed/rackunit)
+
+(check-not-exn
+  (lambda () (void (plot-pict (function values -10 10)))))
+
+(define bad-renderers (cast (list 42) (Listof renderer2d)))
+(check-exn exn:fail:contract?
+  (lambda () (plot-pict bad-renderers)))
+
+(define bad-point (cast (vector 'X 'Y) (Vector Real Real)))
+(check-exn exn:fail:contract?
+  (lambda () (points (vector bad-point))))
+
+;; check for no type errors
+(void
+  plot/dc plot-bitmap plot-pict plot3d/dc)

--- a/typed-racket-test/fail/optional/cast-top-level2.rkt
+++ b/typed-racket-test/fail/optional/cast-top-level2.rkt
@@ -1,0 +1,9 @@
+#;
+(exn-pred exn:fail:syntax? #rx"free variables")
+
+#lang racket/load
+
+(require typed/racket/base/optional)
+
+(define: (a) (f (x : Number)) : a
+  (cast x a))

--- a/typed-racket-test/fail/optional/filter.rkt
+++ b/typed-racket-test/fail/optional/filter.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:contract? #rx"add1")
+
+#lang typed/racket/base/optional
+
+(module u racket/base
+  (provide nats)
+  (define nats '(1 2 three four)))
+
+(require/typed 'u
+  (nats (Listof Natural)))
+
+(: myadd (-> Natural Natural))
+(define (myadd n)
+  (add1 n))
+
+(filter myadd nats)

--- a/typed-racket-test/fail/optional/for.rkt
+++ b/typed-racket-test/fail/optional/for.rkt
@@ -1,0 +1,18 @@
+#;
+(exn-pred exn:fail:contract? #rx"add1")
+
+#lang typed/racket/base/optional
+
+(module u racket/base
+  (provide nats)
+  (define nats '(1 2 three four)))
+
+(require/typed 'u
+  (nats (Listof Natural)))
+
+(: myadd (-> Natural Natural))
+(define (myadd n)
+  (add1 n))
+
+(for ((n (in-list nats)))
+  (myadd n))

--- a/typed-racket-test/fail/optional/occurrence-type.rkt
+++ b/typed-racket-test/fail/optional/occurrence-type.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:contract? #rx"string-length")
+
+#lang typed/racket/base/optional
+
+(require/typed racket/base
+ (values (-> Any Any : String)))
+
+(define x : Any 0)
+
+(define fake-str : String
+  (if (values x)
+    (ann x String)
+    (error 'unreachable)))
+
+(string-length fake-str)
+

--- a/typed-racket-test/fail/optional/opaque-object-contract-2.rkt
+++ b/typed-racket-test/fail/optional/opaque-object-contract-2.rkt
@@ -1,0 +1,21 @@
+#;
+(exn-pred #rx"cannot read or write.*blaming:.*b\\)")
+#lang racket/base
+
+;; Ensure that opaque object contracts prevent access to fields
+;; that should be hidden
+
+(module a typed/racket/deep
+  (provide o)
+  (: o (Object))
+  (define o (new (class object%
+                   (super-new)
+                   (field [x 0])))))
+
+(module b typed/racket/optional
+  (require (submod ".." a))
+  (let ((obj (cast o (Object (field [x Zero])))))
+    (set-field! x obj 0) ;; hidden field, should fail
+    (get-field x obj)))
+
+(require 'b)

--- a/typed-racket-test/fail/optional/opaque-object-contract.rkt
+++ b/typed-racket-test/fail/optional/opaque-object-contract.rkt
@@ -1,0 +1,24 @@
+#;
+(exn-pred #rx"uncontracted typed.*blaming: .*opaque-object-contract.rkt")
+#lang racket/base
+
+(module a typed/racket/optional
+  (provide c%)
+  (define c%
+    (class object%
+      (super-new)
+      (define/public (m) (void)))))
+
+(module b typed/racket/deep
+  (require/typed (submod ".." a) [c% (Class [m (-> Void)])])
+  (provide o)
+  (: o (Object))
+  (define o (new (class c%
+                   (super-new)
+                   (define/public (n) (void))))))
+
+(require 'b)
+(require racket/class)
+
+(send o m)
+(send o n)

--- a/typed-racket-test/fail/optional/optional-deep-id-2.rkt
+++ b/typed-racket-test/fail/optional/optional-deep-id-2.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:syntax? #rx"required a flat contract")
+
+#lang typed/racket/base/deep
+
+;; cannot send syntax to deep
+
+(module optional typed/racket/base/optional
+  (provide xxx)
+  (: xxx (Syntaxof Any))
+  (define xxx
+    #`#,(vector 0)))
+
+(require 'optional)
+xxx
+

--- a/typed-racket-test/fail/optional/optional-shallow-id-0.rkt
+++ b/typed-racket-test/fail/optional/optional-shallow-id-0.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"sym")
+#lang typed/racket/base/shallow
+
+(module uuu racket/base
+  (provide bad-sym)
+  (define bad-sym #f))
+
+(module opt typed/racket/base/optional
+  (provide sym)
+  (require/typed (submod ".." uuu)
+    (bad-sym Symbol))
+  (define sym : Symbol bad-sym))
+
+(require 'opt)
+sym

--- a/typed-racket-test/fail/optional/optional-shallow-id-1.rkt
+++ b/typed-racket-test/fail/optional/optional-shallow-id-1.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"sym")
+#lang typed/racket/base/shallow
+
+(module uuu racket/base
+  (provide bad-sym)
+  (define bad-sym #f))
+
+(module opt typed/racket/base/optional
+  (require/typed (submod ".." uuu)
+    ((bad-sym -bad-sym) Symbol))
+  (define bad-sym -bad-sym)
+  (provide bad-sym))
+
+(require 'opt)
+bad-sym

--- a/typed-racket-test/fail/optional/parameter-class.rkt
+++ b/typed-racket-test/fail/optional/parameter-class.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"pdf-dc")
+
+#lang typed/racket/optional
+(module p racket/base
+  (define world:paper-height (make-parameter 792.0+0.0i))
+  (provide world:paper-height))
+(require/typed 'p (world:paper-height (Parameterof Float)))
+(require (only-in typed/racket/draw pdf-dc%))
+(define dc-output-port (open-output-bytes))
+(define dc
+  (new pdf-dc%
+       [interactive #f][use-paper-bbox #f][as-eps #f]
+       [output dc-output-port]
+       [width 792.0]
+       [height (world:paper-height)]))

--- a/typed-racket-test/fail/optional/poly-bad-0.rkt
+++ b/typed-racket-test/fail/optional/poly-bad-0.rkt
@@ -1,0 +1,12 @@
+#;
+(exn-pred exn:fail:contract? #rx"car")
+
+#lang typed/racket/base/optional
+
+(require/typed racket/base
+  (cdr (All (A) A)))
+
+(let ((v : (Pairof String String)
+       (inst cdr (Pairof String String))))
+  (car v))
+

--- a/typed-racket-test/fail/optional/poly-bad-1.rkt
+++ b/typed-racket-test/fail/optional/poly-bad-1.rkt
@@ -1,0 +1,14 @@
+#;
+(exn-pred exn:fail:contract? #rx"car")
+
+#lang typed/racket/base/optional
+
+(require/typed racket/base
+  (cdr (All (A) (U (Boxof A) A))))
+
+(let ((v : (U (Boxof (Pairof String String)) (Pairof String String))
+       (inst cdr (Pairof String String))))
+  (if (box? v)
+    #f
+    (car v)))
+

--- a/typed-racket-test/fail/optional/poly-bad-2.rkt
+++ b/typed-racket-test/fail/optional/poly-bad-2.rkt
@@ -1,0 +1,12 @@
+#;
+(exn-pred exn:fail:contract? #rx"car")
+
+#lang typed/racket/base/optional
+
+(require/typed racket/base
+  (cdr (All (A) (-> A A))))
+
+(let ((v : (Pairof String String)
+       ((inst cdr (Pairof String String)) '("A" . "B"))))
+  (car v))
+

--- a/typed-racket-test/fail/optional/pr10594.rkt
+++ b/typed-racket-test/fail/optional/pr10594.rkt
@@ -1,0 +1,21 @@
+#;
+(exn-pred exn:fail:contract? #rx"string-append")
+#lang scheme/load
+
+(module T typed/racket/optional
+
+  (define-struct: [a] thing ([get : a]))
+
+  (: thing->string ((thing String) -> String))
+  (define (thing->string x)
+    (string-append "foo" (thing-get x)))
+
+  (provide (all-defined-out)))
+
+(module U scheme
+
+  (require 'T)
+
+  (thing->string (make-thing 5)))
+
+(require 'U)

--- a/typed-racket-test/fail/optional/pr11686.rkt
+++ b/typed-racket-test/fail/optional/pr11686.rkt
@@ -1,0 +1,31 @@
+#;
+(exn-pred exn:fail? #rx"Assertion")
+
+#lang racket/load
+
+(module T typed/racket/optional
+
+  (struct: [X] doll ([contents : X]))
+
+  (define-type RussianDoll
+    (Rec RD (U 'center (doll RD))))
+
+  (: f (RussianDoll -> RussianDoll))
+  (define (f rd)
+    (let ((v (doll-contents (assert rd doll?))))
+      (assert v doll?)))
+
+  (: md (All (x) (x -> (doll x))))
+  (define md doll)
+
+  (provide (all-defined-out)))
+
+(module U racket
+ (require 'T)
+ (f (md 3)))
+
+(require 'U)
+
+
+
+

--- a/typed-racket-test/fail/optional/pr13274.rkt
+++ b/typed-racket-test/fail/optional/pr13274.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"arity mismatch")
+#lang racket/base
+
+(module f-t typed/racket/optional
+  (: flomap-transform (case-> (Integer Integer -> Integer)
+                              (Integer Integer Integer Integer Integer Integer -> Integer)))
+  (define flomap-transform
+    (case-lambda
+      [(fm t)                             fm]
+      [(fm t x-start y-start x-end y-end) fm]))
+  (provide flomap-transform))
+
+(require 'f-t)
+
+(flomap-transform 2 3 4) ; only accepts 2 or 6 arguments

--- a/typed-racket-test/fail/optional/predicate.rkt
+++ b/typed-racket-test/fail/optional/predicate.rkt
@@ -1,0 +1,4 @@
+#;
+(exn-pred #rx"could not be converted")
+#lang typed/racket/optional
+(define-predicate p? (All (A) (Listof A)))

--- a/typed-racket-test/fail/optional/sandboxed-unsafe-ops.rkt
+++ b/typed-racket-test/fail/optional/sandboxed-unsafe-ops.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred #rx"access disallowed by")
+#lang racket/base
+
+;; This test checks that TR's unsafe libraries are not accessible
+;; from a sandboxed context
+
+(require racket/sandbox)
+
+;; this doesn't need a memory limit
+(parameterize ([sandbox-memory-limit #f]
+               [sandbox-eval-limits #f])
+  (define eval (make-evaluator 'typed/racket/optional))
+  (eval '(require typed/racket/unsafe))
+
+  ;; should fail
+  (eval '(unsafe-require/typed racket/base [values 3])))

--- a/typed-racket-test/fail/optional/sealing-contract-2.rkt
+++ b/typed-racket-test/fail/optional/sealing-contract-2.rkt
@@ -1,0 +1,26 @@
+#;
+(exn-pred #rx"superclass already contains")
+#lang racket/base
+
+(module u racket
+  ;; adds m instead of n like the spec says
+  (define (mixin cls)
+    (class cls
+      (super-new)
+      (define/public (m x) x)))
+
+  (provide mixin))
+
+(module t typed/racket/optional
+  ;; expects a mixin that adds n
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r [n (-> Integer Integer)])))])
+
+  (mixin (class object%
+           (super-new)
+           (define/public (m x) x))))
+
+(require 't)

--- a/typed-racket-test/fail/optional/sealing-contract-3.rkt
+++ b/typed-racket-test/fail/optional/sealing-contract-3.rkt
@@ -1,0 +1,26 @@
+#;
+(exn-pred #rx"superclass already contains field")
+#lang racket/base
+
+(module u racket
+  ;; adds f instead of g like the spec says
+  (define (mixin cls)
+    (class cls
+      (super-new)
+      (field [f 0])))
+
+  (provide mixin))
+
+(module t typed/racket/optional
+  ;; expects a mixin that adds g
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r (field [g Integer]))))])
+
+  (mixin (class object%
+           (super-new)
+           (field [f 1]))))
+
+(require 't)

--- a/typed-racket-test/fail/optional/values.rkt
+++ b/typed-racket-test/fail/optional/values.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"unbox")
+
+#lang typed/racket/base/optional
+
+(module u racket/base
+  (provide f)
+  (define (f x)
+    (values x x)))
+
+(require/typed 'u
+  (f (-> Natural (Values (Boxof Symbol) Natural))))
+
+(define-values [a b] (f 2))
+
+(unbox a)

--- a/typed-racket-test/fail/optional/with-type1.rkt
+++ b/typed-racket-test/fail/optional/with-type1.rkt
@@ -1,0 +1,8 @@
+#;
+(exn-pred exn:fail:contract?)
+#lang scheme
+(require typed/racket/optional)
+
+((with-type #:result (Number -> Number)
+   (lambda: ([x : Number]) (add1 x)))
+ #f)

--- a/typed-racket-test/fail/optional/with-type2.rkt
+++ b/typed-racket-test/fail/optional/with-type2.rkt
@@ -1,0 +1,11 @@
+#;
+(exn-pred exn:fail:contract?)
+#lang scheme
+
+(require typed/racket/optional)
+
+(let ([x 'hello])
+  (with-type
+   #:result String
+   #:freevars ([x String])
+   (string-append x ", world")))

--- a/typed-racket-test/fail/shallow/apply.rkt
+++ b/typed-racket-test/fail/shallow/apply.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+;; Test that `(apply f ...)` checks results safely
+
+(module u racket/base
+  (provide f2)
+  (define (f2) (values 'a 'b)))
+
+(require/typed 'u
+  (f2 (-> (Values Integer Symbol))))
+
+(: b Integer)
+(: c Symbol)
+(define-values [b c] (apply f2 '()))

--- a/typed-racket-test/fail/shallow/cast-mod2.rkt
+++ b/typed-racket-test/fail/shallow/cast-mod2.rkt
@@ -1,0 +1,13 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(require typed/rackunit)
+
+(check-not-exn
+  (lambda ()
+    (cast (lambda () 3) (-> String))))
+
+((cast (lambda () 3) (-> String)))
+

--- a/typed-racket-test/fail/shallow/cast-top-level2.rkt
+++ b/typed-racket-test/fail/shallow/cast-top-level2.rkt
@@ -1,0 +1,9 @@
+#;
+(exn-pred exn:fail:syntax? #rx"free variables")
+
+#lang racket/load
+
+(require typed/racket/base/shallow)
+
+(define: (a) (f (x : Number)) : a
+  (cast x a))

--- a/typed-racket-test/fail/shallow/cast.rkt
+++ b/typed-racket-test/fail/shallow/cast.rkt
@@ -1,0 +1,8 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/shallow
+
+;; Bad cast, expect shape-check error
+
+(cast 42 String)

--- a/typed-racket-test/fail/shallow/class-contract-1.rkt
+++ b/typed-racket-test/fail/shallow/class-contract-1.rkt
@@ -1,0 +1,20 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang racket
+
+;; Ensure contracts for inner work correctly
+
+(module t typed/racket/shallow
+  (provide c%)
+  (define c%
+    (class object%
+      (super-new)
+      (: m (-> Void) #:augment (-> String))
+      (define/pubment (m) (inner "hi" m) (void)))))
+
+(require (submod "." t))
+(send (new (class c%
+             (super-new)
+             (define/augment (m) 'not-a-string)))
+      m)

--- a/typed-racket-test/fail/shallow/control-test-3.rkt
+++ b/typed-racket-test/fail/shallow/control-test-3.rkt
@@ -1,0 +1,28 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+#lang racket/load
+
+(module untyped racket
+  (provide call-f)
+
+  (define (call-f f)
+    (call-with-continuation-prompt
+     (λ () (f 0))
+     (default-continuation-prompt-tag)
+     ;; this application should fail due to the any wrapping
+     ;; for the TR function that's aborted here
+     (λ (x) (x "string")))))
+
+(module typed typed/racket/shallow
+  (require/typed 'untyped
+                 [call-f ((Integer -> Integer) -> Integer)])
+
+  (call-f
+   (λ: ([x : Integer])
+     ;; this abort should wrap with an Any wrapper
+     (abort-current-continuation
+      (default-continuation-prompt-tag)
+      (λ (x) x)))))
+
+(require 'typed)
+

--- a/typed-racket-test/fail/shallow/define-predicate-all.rkt
+++ b/typed-racket-test/fail/shallow/define-predicate-all.rkt
@@ -1,0 +1,8 @@
+#;
+(exn-pred #rx"could not be converted")
+
+#lang typed/racket/shallow
+
+(require typed/rackunit)
+
+(define-predicate p? (All (A) (Listof A)))

--- a/typed-racket-test/fail/shallow/filter.rkt
+++ b/typed-racket-test/fail/shallow/filter.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(module u racket/base
+  (provide nats)
+  (define nats '(1 2 three four)))
+
+(require/typed 'u
+  (nats (Listof Natural)))
+
+(: myadd (-> Natural Natural))
+(define (myadd n)
+  (add1 n))
+
+(filter myadd nats)

--- a/typed-racket-test/fail/shallow/find.rkt
+++ b/typed-racket-test/fail/shallow/find.rkt
@@ -1,0 +1,18 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(module a racket/base
+  (provide fake-int* checker)
+  (define fake-int* '(NaN xxx))
+  (define (checker x)
+    #true))
+
+(require/typed 'a
+  (fake-int* (Listof Integer))
+  (checker (-> Integer Boolean)))
+
+(define x : (U #f Integer)
+  (findf checker fake-int*))
+

--- a/typed-racket-test/fail/shallow/fold.rkt
+++ b/typed-racket-test/fail/shallow/fold.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(module a racket/base
+  (provide f)
+  (define (f acc i)
+    'not-int))
+
+(require/typed 'a
+  (f (-> Integer Integer Integer)))
+
+(define x : (U #f Integer)
+  (foldl f 0 '(0 1 2)))
+

--- a/typed-racket-test/fail/shallow/for.rkt
+++ b/typed-racket-test/fail/shallow/for.rkt
@@ -1,0 +1,18 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(module u racket/base
+  (provide nats)
+  (define nats '(1 2 three four)))
+
+(require/typed 'u
+  (nats (Listof Natural)))
+
+(: myadd (-> Natural Natural))
+(define (myadd n)
+  (add1 n))
+
+(for ((n (in-list nats)))
+  (myadd n))

--- a/typed-racket-test/fail/shallow/keyword-mand-opt.rkt
+++ b/typed-racket-test/fail/shallow/keyword-mand-opt.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+;; ERROR when function asks for mandatory kw
+;;  but type makes it optional
+
+(module u racket/base
+  (define (f0 x #:y y)
+    (void))
+  (provide f0))
+
+(require/typed 'u
+  (f0 (->* [Symbol] [#:y Symbol] Void)))
+
+(void f0)

--- a/typed-racket-test/fail/shallow/make-predicate-mod1.rkt
+++ b/typed-racket-test/fail/shallow/make-predicate-mod1.rkt
@@ -1,0 +1,5 @@
+#;
+(exn-pred #rx"could not be converted")
+#lang typed/racket/base/shallow
+
+(make-predicate (Number -> Number))

--- a/typed-racket-test/fail/shallow/nothing.rkt
+++ b/typed-racket-test/fail/shallow/nothing.rkt
@@ -1,0 +1,15 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+;; type `Nothing` should get a none/c check
+
+(module a racket/base
+  (provide f)
+  (define (f) 42))
+
+(require/typed 'a
+  (f (-> Nothing)))
+
+(f)

--- a/typed-racket-test/fail/shallow/occurrence-type.rkt
+++ b/typed-racket-test/fail/shallow/occurrence-type.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(require/typed racket/base
+ (values (-> Any Any : String)))
+
+(define x : Any 0)
+
+(define fake-str : String
+  (if (values x)
+    (ann x String)
+    (error 'unreachable)))
+
+(string-length fake-str)
+

--- a/typed-racket-test/fail/shallow/opaque-object-contract-2.rkt
+++ b/typed-racket-test/fail/shallow/opaque-object-contract-2.rkt
@@ -1,0 +1,21 @@
+#;
+(exn-pred #rx"cannot read or write.*blaming:.*b\\)")
+#lang racket/base
+
+;; Ensure that opaque object contracts prevent access to fields
+;; that should be hidden
+
+(module a typed/racket/deep
+  (provide o)
+  (: o (Object))
+  (define o (new (class object%
+                   (super-new)
+                   (field [x 0])))))
+
+(module b typed/racket/shallow
+  (require (submod ".." a))
+  (let ((obj (cast o (Object (field [x Zero])))))
+    (set-field! x obj 0) ;; hidden field, should fail
+    (get-field x obj)))
+
+(require 'b)

--- a/typed-racket-test/fail/shallow/opaque-object-contract.rkt
+++ b/typed-racket-test/fail/shallow/opaque-object-contract.rkt
@@ -1,0 +1,24 @@
+#;
+(exn-pred #rx"uncontracted typed.*blaming: .*opaque-object-contract.rkt")
+#lang racket/base
+
+(module a typed/racket/shallow
+  (provide c%)
+  (define c%
+    (class object%
+      (super-new)
+      (define/public (m) (void)))))
+
+(module b typed/racket/deep
+  (require/typed (submod ".." a) [c% (Class [m (-> Void)])])
+  (provide o)
+  (: o (Object))
+  (define o (new (class c%
+                   (super-new)
+                   (define/public (n) (void))))))
+
+(require 'b)
+(require racket/class)
+
+(send o m)
+(send o n)

--- a/typed-racket-test/fail/shallow/parameter-class.rkt
+++ b/typed-racket-test/fail/shallow/parameter-class.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/shallow
+(module p racket/base
+  (define world:paper-height (make-parameter 792.0+0.0i))
+  (provide world:paper-height))
+(require/typed 'p (world:paper-height (Parameterof Float)))
+(require (only-in typed/racket/draw pdf-dc%))
+(define dc-output-port (open-output-bytes))
+(define dc
+  (new pdf-dc%
+       [interactive #f][use-paper-bbox #f][as-eps #f]
+       [output dc-output-port]
+       [width 792.0]
+       [height (world:paper-height)]))

--- a/typed-racket-test/fail/shallow/poly-bad-0.rkt
+++ b/typed-racket-test/fail/shallow/poly-bad-0.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+;; Expected: shape-check error
+;;
+;; To remove the error, we need to treat `inst` as an elimination form
+;; when the poly type does not guarantee some kind of shape.
+
+(require/typed racket/base
+  (cdr (All (A) A)))
+
+(let ((v : (Pairof String String)
+       (inst cdr (Pairof String String))))
+  (car v))
+

--- a/typed-racket-test/fail/shallow/poly-bad-1.rkt
+++ b/typed-racket-test/fail/shallow/poly-bad-1.rkt
@@ -1,0 +1,19 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+;; Expected: shape-check error
+;;
+;; To remove the error, we need to treat `inst` as an elimination form
+;; when the poly type does not guarantee some kind of shape.
+
+(require/typed racket/base
+  (cdr (All (A) (U (Boxof A) A))))
+
+(let ((v : (U (Boxof (Pairof String String)) (Pairof String String))
+       (inst cdr (Pairof String String))))
+  (if (box? v)
+    #f
+    (car v)))
+

--- a/typed-racket-test/fail/shallow/poly-bad-2.rkt
+++ b/typed-racket-test/fail/shallow/poly-bad-2.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+;; Expected: shape-check error
+;;
+;; To remove the error, we need to treat `inst` as an elimination form
+;; when the poly type does not guarantee some kind of shape.
+
+(require/typed racket/base
+  (cdr (All (A) (-> A A))))
+
+(let ((v : (Pairof String String)
+       ((inst cdr (Pairof String String)) '("A" . "B"))))
+  (car v))
+

--- a/typed-racket-test/fail/shallow/poly-bad-3.rkt
+++ b/typed-racket-test/fail/shallow/poly-bad-3.rkt
@@ -1,0 +1,22 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+;; Expected: shape-check error
+;;
+;; With a similar program, we can end up passing a bad input to `cdr`,
+;;  which means that Shallow functions need to be careful to protect themselves
+;;  (untyped & typed need to take care too, of course).
+
+(require/typed racket/base
+  (cdr (All (A) (U (Boxof A) (Pairof A A) (-> (Pairof String String) Symbol)))))
+
+(let ((v : (U (Boxof String) (Pairof String String) (-> (Pairof String String) Symbol))
+       (inst cdr String)))
+  (if (box? v)
+    #f
+    (if (pair? v)
+      #f
+      (v (cons "a" "aaa")))))
+

--- a/typed-racket-test/fail/shallow/pr10350.rkt
+++ b/typed-racket-test/fail/shallow/pr10350.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+#lang typed/racket/shallow
+(require/typed
+ scheme/base
+ [values (All (T) ((Any -> Boolean) -> (Any -> Boolean : T)))])
+
+(: number->string? (Any -> Boolean : (Number -> String)))
+(define (number->string? x)
+  (((inst values (Number -> String)) procedure?) x))
+
+(: f (Number -> String))
+(define f
+  (if (number->string? +) + number->string))
+
+(ann (f 3) String)

--- a/typed-racket-test/fail/shallow/pr10594.rkt
+++ b/typed-racket-test/fail/shallow/pr10594.rkt
@@ -1,0 +1,21 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+#lang scheme/load
+
+(module T typed/racket/shallow
+
+  (define-struct: [a] thing ([get : a]))
+
+  (: thing->string ((thing String) -> String))
+  (define (thing->string x)
+    (string-append "foo" (thing-get x)))
+
+  (provide (all-defined-out)))
+
+(module U scheme
+
+  (require 'T)
+
+  (thing->string (make-thing 5)))
+
+(require 'U)

--- a/typed-racket-test/fail/shallow/pr11686.rkt
+++ b/typed-racket-test/fail/shallow/pr11686.rkt
@@ -1,0 +1,31 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang racket/load
+
+(module T typed/racket/shallow
+
+  (struct: [X] doll ([contents : X]))
+
+  (define-type RussianDoll
+    (Rec RD (U 'center (doll RD))))
+
+  (: f (RussianDoll -> RussianDoll))
+  (define (f rd)
+    (let ((v (doll-contents (assert rd doll?))))
+      (assert v doll?)))
+
+  (: md (All (x) (x -> (doll x))))
+  (define md doll)
+
+  (provide (all-defined-out)))
+
+(module U racket
+ (require 'T)
+ (f (md 3)))
+
+(require 'U)
+
+
+
+

--- a/typed-racket-test/fail/shallow/pr13274.rkt
+++ b/typed-racket-test/fail/shallow/pr13274.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"arity mismatch")
+#lang racket/base
+
+(module f-t typed/racket/shallow
+  (: flomap-transform (case-> (Integer Integer -> Integer)
+                              (Integer Integer Integer Integer Integer Integer -> Integer)))
+  (define flomap-transform
+    (case-lambda
+      [(fm t)                             fm]
+      [(fm t x-start y-start x-end y-end) fm]))
+  (provide flomap-transform))
+
+(require 'f-t)
+
+(flomap-transform 2 3 4) ; only accepts 2 or 6 arguments

--- a/typed-racket-test/fail/shallow/pr13446.rkt
+++ b/typed-racket-test/fail/shallow/pr13446.rkt
@@ -1,0 +1,12 @@
+#;
+(exn-pred exn:fail:contract? #rx"string-length")
+#lang racket/load
+
+(module a typed/racket/shallow
+  (provide p)
+  (: p (Parameterof String Index))
+  (define p (make-parameter 0 string-length)))
+
+(require 'a)
+(p 0)
+

--- a/typed-racket-test/fail/shallow/pr13662.rkt
+++ b/typed-racket-test/fail/shallow/pr13662.rkt
@@ -1,0 +1,20 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+#lang racket/load
+
+(module typed typed/racket/shallow
+  (provide b g)
+
+  (: b (Boxof (All (a) (a -> a))))
+  (define b ((inst box (All (a) (a -> a))) (lambda (a) a)))
+  
+  (: g (Integer -> Integer))
+  (define (g x)
+    ((unbox b) x)))
+
+(module untyped racket
+  (require 'typed)
+  (set-box! b (lambda (x) "hello"))
+  (g 5))
+
+(require 'untyped)

--- a/typed-racket-test/fail/shallow/pr13664.rkt
+++ b/typed-racket-test/fail/shallow/pr13664.rkt
@@ -1,0 +1,20 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+#lang racket/load
+
+(module untyped racket
+  (provide f)
+  (define (f g)
+    (g "foo")))
+
+
+(module typed typed/racket/shallow
+  (require/typed 'untyped
+    [f (Procedure -> Any)])
+
+  (: g (Byte -> Natural))
+  (define (g x) (add1 x))
+
+  (f g))
+
+(require 'typed)

--- a/typed-racket-test/fail/shallow/pr13665.rkt
+++ b/typed-racket-test/fail/shallow/pr13665.rkt
@@ -1,0 +1,22 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang racket/load
+
+(module typed typed/racket/shallow
+  (provide g)
+
+  (define-type Foo (Rec a (U (List Any) (Boxof a))))
+
+
+  (: f (Byte -> Natural))
+  (define (f x) (add1 x))
+  (: g (Foo -> Void))
+  (define (g b) 
+    (when (box? b)
+      (set-box! b (list f)))))
+
+(require 'typed)
+(define b (box (list #f)))
+(g b)
+(displayln ((first (unbox b)) "foo"))

--- a/typed-racket-test/fail/shallow/pr13815.rkt
+++ b/typed-racket-test/fail/shallow/pr13815.rkt
@@ -1,0 +1,6 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+#lang typed/racket/shallow
+(require/typed racket/base [list (All (a) Float)])
+(* 3.3 list)
+

--- a/typed-racket-test/fail/shallow/pr14173.rkt
+++ b/typed-racket-test/fail/shallow/pr14173.rkt
@@ -1,0 +1,13 @@
+#;
+(exn-pred exn:fail:contract? #rx"add1")
+#lang racket
+
+(module t typed/racket/shallow
+  (provide f g)
+
+  (define f (ann (case-lambda [() (add1 "hello")] [(x) x]) (Number -> Number)))
+  (define g (ann f Any)))
+
+(require 't)
+(f 1)
+(g)

--- a/typed-racket-test/fail/shallow/predicate-box.rkt
+++ b/typed-racket-test/fail/shallow/predicate-box.rkt
@@ -1,0 +1,6 @@
+#;
+(exn-pred #rx"could not be converted")
+#lang typed/racket/shallow
+
+(define-predicate boxof-integer? (Boxof Integer))
+

--- a/typed-racket-test/fail/shallow/refinements-quicksort.rkt
+++ b/typed-racket-test/fail/shallow/refinements-quicksort.rkt
@@ -1,0 +1,141 @@
+#;
+(exn-pred exn:fail:contract? #rx"typed/racket/shallow:.*#:with-refinements")
+
+#lang typed/racket/base/shallow #:with-refinements
+
+(: safe-vector-ref
+   (All (A) (-> ([v : (Vectorof A)]
+                 [n : Integer])
+                #:pre (v n) (<= 0 n (- (vector-length v) 1))
+                A)))
+(define safe-vector-ref vector-ref)
+
+(: safe-vector-set!
+   (All (A) (-> ([v : (Vectorof A)]
+                 [n : Natural]
+                 [a : A])
+                #:pre (v n) (< n (vector-length v))
+                Void)))
+(define safe-vector-set! vector-set!)
+
+
+(: quicksort! (-> (Vectorof Real) Void))
+(define (quicksort! A)
+  (quicksort-helper! A 0 (- (vector-length A) 1)))
+
+(: quicksort-helper! (-> ([A : (Vectorof Real)]
+                   [lo : Natural]
+                   [hi : Integer])
+                  #:pre (A lo hi)
+                  (and (<= lo (vector-length A))
+                       (< hi (vector-length A)))
+                  Void))
+(define (quicksort-helper! A lo hi)
+  (when (< lo hi)
+    (define pivot (partition! A lo hi))
+    (quicksort-helper! A lo (- pivot 1))
+    (quicksort-helper! A (+ pivot 1) hi)))
+
+
+(: swap! (-> ([A : (Vectorof Real)]
+              [i : Natural]
+              [j : Natural])
+             #:pre (A i j)
+             (and (< i (vector-length A))
+                  (< j (vector-length A)))
+             Void))
+(define (swap! A i j)
+  (define tmp (safe-vector-ref A i))
+  (safe-vector-set! A i (safe-vector-ref A j))
+  (safe-vector-set! A j tmp)) 
+
+
+
+(: partition! (-> ([A : (Vectorof Real)]
+                   [lo : Natural]
+                   [hi : Natural])
+                  #:pre (A lo hi)
+                  (< lo hi (vector-length A))
+                  (Refine [pivot : Natural]
+                          (<= lo pivot hi))))
+(define (partition! A lo hi)
+  (define pivot (safe-vector-ref A lo))
+  (let outer-loop!
+    ([i : (Refine [n : Natural] (< lo n))
+        (+ 1 lo)]
+     [j : (Refine [n : Natural] (and (<= n hi)
+                                     (<= lo n))) hi])
+    (let i-loop!
+      ([i : (Refine [n : Natural] (< lo n))
+          i])
+      (cond
+        [(and (<= i j)
+              (< (safe-vector-ref A i) pivot))
+         (i-loop! (+ i 1))]
+        [else
+         (let j-loop!
+           ([j : (Refine [n : Natural] (and (<= n hi)
+                                            (<= lo n))) j])
+           (cond
+             [(and (>= (safe-vector-ref A j) pivot)
+                   (>= j i))
+              (j-loop! (- j 1))]
+             [(> i j) (swap! A lo j)
+                      j]
+             [else
+              (swap! A i j)
+              (outer-loop! i j)]))]))))
+
+
+(: random-reals (-> Integer (Listof Real)))
+(define (random-reals n)
+  (build-list n (λ _ (ann (random 10000) Real))))
+
+(for ([_ (in-range 10000)])
+  (for ([size (in-range 23)])
+    (define l (random-reals size))
+    (define v (list->vector l))
+    (quicksort! v)
+    (define l* (vector->list v))
+    (unless (equal? (sort l <) l*)
+      (error "bad sort!: \n  expected: ~a\n  got: ~a\n\n"
+             l l*))))
+
+(define v : (Vectorof Real) (vector 0 5 9 12 3 0 4 6 3))
+(quicksort! v)
+v
+
+
+
+(: misc-inf-loop (-> (Refine [n : Natural] (<= n 11))
+                     (Listof (Refine [n : Natural] (<= n 11)))))
+(define (misc-inf-loop x)
+  (cond
+    [(or (= x 1) (= x 6)) (list x)]
+    [else (list)]))
+
+
+(ann (add1 1) (Refine [n : Integer] (= n 2)))
+(ann (sub1 5) (Refine [n : Integer] (= n 4)))
+(ann (random 5) (Refine [n : Integer] (<= 0 n 4)))
+(ann (random 1 5) (Refine [n : Integer] (<= 1 n 4)))
+(ann (add1 (random 5)) (Refine [n : Integer] (<= 1 n 6)))
+(ann (modulo 1 5) (Refine [n : Integer] (<= 0 n 4)))
+
+(: foo (-> Integer (Refine [n : Integer] (= n 42))))
+(define (foo x)
+  (if (equal? x 42)
+      x
+      42))
+
+(: bar (-> Integer (Refine [n : Integer] (= n 42))))
+(define (bar x)
+  (if (eqv? x 42)
+      x
+      42))
+
+(: baz (-> Integer (Refine [n : Integer] (= n 42))))
+(define (baz x)
+  (if (eq? x 42)
+      x
+      42))

--- a/typed-racket-test/fail/shallow/sandbox.rkt
+++ b/typed-racket-test/fail/shallow/sandbox.rkt
@@ -1,0 +1,40 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+#lang racket/base
+
+;; This test checks that TR optimizations are disabled within a
+;; sandboxed context
+
+(require racket/sandbox)
+
+(environment-variables-set!	(current-environment-variables)
+                            (string->bytes/locale "PLT_TR_NO_OPTIMIZE")
+                            #f)
+
+(define (make-sandbox-code-inspector)
+  (make-inspector (current-code-inspector)))
+
+(parameterize ([sandbox-memory-limit #f]
+               [sandbox-eval-limits #f]
+               [sandbox-make-code-inspector make-sandbox-code-inspector])
+  (let ([eval (make-evaluator 'racket/base
+                              '(module untyped racket/base
+                                 (provide extract-field
+                                          (struct-out int-wrapper))
+
+                                 (require syntax/location)
+                                 (require syntax/modresolve)
+
+                                 (struct int-wrapper (value))
+
+                                 (module typed typed/racket/shallow
+                                   (provide extract-integer)
+                                   (define (extract-integer [p : (Pair Integer Integer)])
+                                     (cdr p)))
+
+                                 (require 'typed)
+
+                                 (define extract-field
+                                   (eval 'extract-integer (module->namespace (quote-module-path typed)))))
+                              '(require (submod "." untyped)))])
+    (eval '(extract-field (int-wrapper 42)))))

--- a/typed-racket-test/fail/shallow/sandboxed-unsafe-ops.rkt
+++ b/typed-racket-test/fail/shallow/sandboxed-unsafe-ops.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred #rx"access disallowed by")
+#lang racket/base
+
+;; This test checks that TR's unsafe libraries are not accessible
+;; from a sandboxed context
+
+(require racket/sandbox)
+
+;; this doesn't need a memory limit
+(parameterize ([sandbox-memory-limit #f]
+               [sandbox-eval-limits #f])
+  (define eval (make-evaluator 'typed/racket/shallow))
+  (eval '(require typed/racket/unsafe))
+
+  ;; should fail
+  (eval '(unsafe-require/typed racket/base [values 3])))

--- a/typed-racket-test/fail/shallow/sealing-contract-1.rkt
+++ b/typed-racket-test/fail/shallow/sealing-contract-1.rkt
@@ -1,0 +1,24 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+#lang racket/base
+
+(module u racket
+  ;; drops cls on the floor, doesn't match spec
+  (define (mixin cls)
+    (class object% (super-new)))
+
+  (provide mixin))
+
+(module t typed/racket/shallow
+  ;; expects a mixin that adds n
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r [n (-> Integer Integer)])))])
+
+  (mixin (class object%
+           (super-new)
+           (define/public (m x) x))))
+
+(require 't)

--- a/typed-racket-test/fail/shallow/sealing-contract-2.rkt
+++ b/typed-racket-test/fail/shallow/sealing-contract-2.rkt
@@ -1,0 +1,26 @@
+#;
+(exn-pred #rx"superclass already contains")
+#lang racket/base
+
+(module u racket
+  ;; adds m instead of n like the spec says
+  (define (mixin cls)
+    (class cls
+      (super-new)
+      (define/public (m x) x)))
+
+  (provide mixin))
+
+(module t typed/racket/shallow
+  ;; expects a mixin that adds n
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r [n (-> Integer Integer)])))])
+
+  (mixin (class object%
+           (super-new)
+           (define/public (m x) x))))
+
+(require 't)

--- a/typed-racket-test/fail/shallow/sealing-contract-3.rkt
+++ b/typed-racket-test/fail/shallow/sealing-contract-3.rkt
@@ -1,0 +1,26 @@
+#;
+(exn-pred #rx"superclass already contains field")
+#lang racket/base
+
+(module u racket
+  ;; adds f instead of g like the spec says
+  (define (mixin cls)
+    (class cls
+      (super-new)
+      (field [f 0])))
+
+  (provide mixin))
+
+(module t typed/racket/shallow
+  ;; expects a mixin that adds g
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r (field [g Integer]))))])
+
+  (mixin (class object%
+           (super-new)
+           (field [f 1]))))
+
+(require 't)

--- a/typed-racket-test/fail/shallow/sealing-contract-4.rkt
+++ b/typed-racket-test/fail/shallow/sealing-contract-4.rkt
@@ -1,0 +1,35 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+#lang racket/base
+
+(module u racket
+  (define state #f)
+
+  ;; don't allow smuggling with mutation either
+  (define (mixin cls)
+    (define result
+      (if (not state)
+          (class cls
+            (super-new)
+            (define/public (n x) x))
+          ;; should subclass from cls, not state since otherwise
+          ;; we lose the `m` method
+          (class state (super-new))))
+    (set! state cls)
+    result)
+
+  (provide mixin))
+
+(module t typed/racket/shallow
+  (require/typed (submod ".." u)
+                 [mixin
+                  (All (r #:row)
+                   (-> (Class #:row-var r)
+                       (Class #:row-var r [n (-> Integer Integer)])))])
+
+  (mixin (class object% (super-new)))
+  (mixin (class object%
+           (super-new)
+           (define/public (m x) x))))
+
+(require 't)

--- a/typed-racket-test/fail/shallow/shallow-deep-id-2.rkt
+++ b/typed-racket-test/fail/shallow/shallow-deep-id-2.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:syntax? #rx"required a flat contract")
+
+#lang typed/racket/base/deep
+
+;; cannot send syntax shallow -> deep,
+;; (see succeed/shallow/pass for tests 0 and 1)
+
+(module shallow typed/racket/base/shallow
+  (provide xxx)
+  (: xxx (Syntaxof Any))
+  (define xxx
+    #`#,(vector 0)))
+
+(require 'shallow)
+xxx
+

--- a/typed-racket-test/fail/shallow/struct.rkt
+++ b/typed-racket-test/fail/shallow/struct.rkt
@@ -1,0 +1,19 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang racket/base
+
+(module t typed/racket/shallow
+  (struct A ((x : Integer) (y : (Listof Integer)) (z : (-> Integer Integer))))
+  (: f (-> (Listof A) Integer))
+  (define (f x)
+    (define mya (car x))
+    (A-x mya))
+
+  (provide (struct-out A) f))
+
+(require 't)
+
+(define a (A 'NaN '() add1))
+
+(f (list a))

--- a/typed-racket-test/fail/shallow/submodule-list-0.rkt
+++ b/typed-racket-test/fail/shallow/submodule-list-0.rkt
@@ -1,0 +1,13 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(module u racket/base
+  (define x* (list "OOPS"))
+  (provide x*))
+
+(require/typed 'u
+  (x* (Listof Integer)))
+
+(+ (car x*) 1)

--- a/typed-racket-test/fail/shallow/submodule-list-1.rkt
+++ b/typed-racket-test/fail/shallow/submodule-list-1.rkt
@@ -1,0 +1,12 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(module u racket/base
+  (define x* "OOPS")
+  (provide x*))
+
+(require/typed 'u
+  (x* (Listof Integer)))
+

--- a/typed-racket-test/fail/shallow/submodule-opaque-0.rkt
+++ b/typed-racket-test/fail/shallow/submodule-opaque-0.rkt
@@ -1,0 +1,12 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(module u racket/base
+  (define x* "not function")
+  (provide x*))
+
+(require/typed 'u
+  (#:opaque X? x*))
+

--- a/typed-racket-test/fail/shallow/submodule-struct-0.rkt
+++ b/typed-racket-test/fail/shallow/submodule-struct-0.rkt
@@ -1,0 +1,15 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/shallow
+
+(module u racket/base
+  (struct posn [x y])
+  (define origin (posn 0 #false))
+  (provide origin (struct-out posn)))
+
+(require/typed 'u
+  (#:struct posn ((x : Real) (y : Real)))
+  (origin posn))
+
+(+ (posn-x origin) (posn-y origin))

--- a/typed-racket-test/fail/shallow/submodule-struct-1.rkt
+++ b/typed-racket-test/fail/shallow/submodule-struct-1.rkt
@@ -1,0 +1,17 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/shallow
+
+;; Send a non-struct value across,
+;; expect shape-check error
+
+(module u racket/base
+  (struct posn [x y])
+  (define origin 'not-posn)
+  (provide origin (struct-out posn)))
+
+(require/typed 'u
+  (#:struct posn ((x : Real) (y : Real)))
+  (origin posn))
+

--- a/typed-racket-test/fail/shallow/values.rkt
+++ b/typed-racket-test/fail/shallow/values.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred exn:fail:contract? #rx"shape-check")
+
+#lang typed/racket/base/shallow
+
+(module u racket/base
+  (provide f)
+  (define (f x)
+    (values x x)))
+
+(require/typed 'u
+  (f (-> Natural (Values (Boxof Symbol) Natural))))
+
+(define-values [a b] (f 2))
+
+(unbox a)

--- a/typed-racket-test/fail/shallow/with-type1.rkt
+++ b/typed-racket-test/fail/shallow/with-type1.rkt
@@ -1,0 +1,8 @@
+#;
+(exn-pred exn:fail:contract?)
+#lang scheme
+(require typed/racket/shallow)
+
+((with-type #:result (Number -> Number)
+   (lambda: ([x : Number]) (add1 x)))
+ #f)

--- a/typed-racket-test/fail/shallow/with-type2.rkt
+++ b/typed-racket-test/fail/shallow/with-type2.rkt
@@ -1,0 +1,11 @@
+#;
+(exn-pred exn:fail:contract?)
+#lang scheme
+
+(require typed/racket/shallow)
+
+(let ([x 'hello])
+  (with-type
+   #:result String
+   #:freevars ([x String])
+   (string-append x ", world")))

--- a/typed-racket-test/info.rkt
+++ b/typed-racket-test/info.rkt
@@ -45,6 +45,7 @@
   '("succeed"
     "external"
     "fail"
+    "shallow" "t-succeed" "t-fail"
     "xfail"
     "racketcs-eval-server.rkt"
     "optimizer" ;; FIXME: should be improved by stamourv

--- a/typed-racket-test/succeed/optional/accessors.rkt
+++ b/typed-racket-test/succeed/optional/accessors.rkt
@@ -1,0 +1,259 @@
+#lang typed/racket/optional
+
+;; Test a variety of accessors for failures
+
+(module untyped racket
+  (define pair0 (cons "A" "B"))
+  (define mpair0 (mcons "A" "B"))
+  (define list0 (list "A" "B" "C"))
+  (define vector0 (vector "A" "B"))
+  (define box0 (box "A"))
+  (define hash0 (make-hash (list (cons 'A "A"))))
+  (define set0 (set "A"))
+  (define (function0 x) "not symbol")
+  (struct mystruct (ref))
+  (define mystruct0 (mystruct "not symbol"))
+  (define class0
+    (class object%
+      (super-new)
+      (field (field0 "not symbol"))
+      (define/public (method0 x) "not symbol")
+      (define/public (method1 x) "not symbol")
+      (define/public (method2 x) this)
+      (define/public (method3 x) "not symbol")))
+  (define object0 (new class0))
+  (provide pair0 mpair0 list0 vector0 box0 hash0 set0 function0
+           (struct-out mystruct) mystruct0 class0 object0))
+
+(module opt typed/racket/optional
+  (: function1 (-> String String))
+  (define (function1 x) "B")
+  (define-type Class1
+   (Class
+     (field (field0 String))
+     (method0 (-> String String))
+     (method1 (-> String String))
+     (method2 (-> String (Instance Class1)))
+     (method3 (-> String String))))
+  (: class1 Class1)
+  (define class1
+    (class object%
+      (super-new)
+      (field (field0 "not symbol"))
+      (define/public (method0 x) "not symbol")
+      (define/public (method1 x) "not symbol")
+      (define/public (method2 x) this)
+      (define/public (method3 x) "not symbol")))
+  (define object1 (new class1))
+  (provide function1 class1 object1))
+
+(define-type Class0
+  (Class (field (field0 Symbol))
+         (method0 (-> Symbol Symbol))
+         (method1 (-> Symbol Symbol))
+         (method2 (-> Symbol (Instance Class0)))
+         (method3 (-> Symbol Symbol))))
+
+(define-type Class1
+  (Class (field (field0 Symbol))
+         (method0 (-> Symbol Symbol))
+         (method1 (-> Symbol Symbol))
+         (method2 (-> Symbol (Instance Class1)))
+         (method3 (-> Symbol Symbol))))
+
+(require typed/rackunit typed/racket/random)
+(require/typed 'untyped
+  (pair0 (Pairof Symbol Symbol))
+  (mpair0 (MPairof Symbol Symbol))
+  (list0 (Listof Symbol))
+  (vector0 (Vectorof Symbol))
+  (box0 (Boxof Symbol))
+  (hash0 (HashTable Symbol Symbol))
+  (set0 (Setof Symbol))
+  (function0 (-> Symbol Symbol))
+  (#:struct mystruct ((ref : Symbol)))
+  (mystruct0 mystruct)
+  (class0 Class0)
+  (object0 (Instance Class0)))
+
+(require/typed 'opt
+  (function1 (-> Symbol Symbol))
+  (class1 Class1)
+  (object1 (Instance Class1)))
+
+;; -----------------------------------------------------------------------------
+;; pair
+
+(check-not-exn
+  (lambda ()
+    (car pair0)))
+
+(check-not-exn
+  (lambda ()
+    (cdr pair0)))
+
+;; -----------------------------------------------------------------------------
+;; mpair
+
+(check-not-exn
+  (lambda ()
+    (mcar mpair0)))
+
+(check-not-exn
+  (lambda ()
+    (mcdr mpair0)))
+
+;; -----------------------------------------------------------------------------
+;; list
+
+(check-not-exn
+  (lambda ()
+    (car list0)))
+
+(check-not-exn
+  (lambda ()
+    (cadr list0)))
+
+(check-not-exn
+  (lambda ()
+    (third list0)))
+
+;; -----------------------------------------------------------------------------
+;; vector
+
+(check-not-exn
+  (lambda ()
+    (vector-ref vector0 0)))
+
+; no type: vector*-ref
+
+;; -----------------------------------------------------------------------------
+;; box
+
+(check-not-exn
+  (lambda ()
+    (unbox box0)))
+
+; no type: unbox*
+
+;; -----------------------------------------------------------------------------
+;; hash
+
+(check-not-exn
+  (lambda ()
+    (hash-ref hash0 'A)))
+
+(check-not-exn
+  (lambda ()
+    (hash-ref! hash0 'A (lambda () 'B))))
+
+;; -----------------------------------------------------------------------------
+;; sequence
+
+(check-not-exn
+  (lambda ()
+    (sequence-ref list0 0)))
+
+(check-not-exn
+  (lambda ()
+    (sequence-ref vector0 0)))
+
+(check-not-exn
+  (lambda ()
+    (random-ref list0)))
+
+(check-not-exn
+  (lambda ()
+    (random-ref vector0)))
+
+; no type: (sequence-ref hash0 'A)
+; no type: (random-ref hash0)
+
+;; -----------------------------------------------------------------------------
+;; no type: stream-first stream-ref
+
+;; -----------------------------------------------------------------------------
+;; no type: dict-ref
+
+;; -----------------------------------------------------------------------------
+;; set
+
+(check-not-exn
+  (lambda ()
+    (set-first list0)))
+
+(check-not-exn
+  (lambda ()
+    (set-first set0)))
+
+; no type: (set-first hash0)
+
+;; -----------------------------------------------------------------------------
+;; procedure
+
+(check-not-exn
+  (lambda ()
+    (function0 'A)))
+
+(check-not-exn
+  (lambda ()
+    (apply function0 (list 'A))))
+
+(check-not-exn
+  (lambda ()
+    (function1 'A)))
+
+(check-not-exn
+  (lambda ()
+    (apply function1 (list 'A))))
+
+; no type: keyword-apply
+
+;; -----------------------------------------------------------------------------
+;; struct
+
+(check-not-exn
+  (lambda ()
+    (mystruct-ref mystruct0)))
+
+;; -----------------------------------------------------------------------------
+;; class / object
+
+;; --- bad output
+
+(check-not-exn
+  (lambda ()
+    (send object0 method0 'A)))
+
+(check-not-exn
+  (lambda ()
+    (send* object0 (method0 'A) (method1 'A))))
+
+(check-not-exn
+  (lambda ()
+    (send+ object0 (method2 'A) (method3 'A))))
+
+(check-not-exn
+  (lambda ()
+    (get-field field0 object0)))
+
+;; --- bad input
+
+(check-not-exn
+  (lambda ()
+    (send object1 method0 'A)))
+
+(check-not-exn
+  (lambda ()
+    (send* object1 (method0 'A) (method1 'A))))
+
+(check-not-exn
+  (lambda ()
+    (send+ object1 (method2 'A) (method3 'A))))
+
+(check-not-exn
+  (lambda ()
+    (get-field field0 object1)))
+
+; no type: send/apply send/keyword-apply dynamic-send with-method(expansion) dynamic-get-field class-field-accessor send-generic
+

--- a/typed-racket-test/succeed/optional/app-hetero.rkt
+++ b/typed-racket-test/succeed/optional/app-hetero.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+(require rackunit)
+
+;; Test applications of `vector-ref` and `vector`, because these identifiers
+;;  have special typing rules
+
+(module u racket/base
+  (provide f)
+  (define (f b)
+    ((vector-ref b 0) 2)))
+
+(module t typed/racket/base/optional
+  (provide test1 test0)
+  (require/typed (submod ".." u)
+    (f (-> (Vector (-> String String)) Integer)))
+
+  (: q (-> String String))
+  (define (q n)
+    (string-append n n))
+
+  (define (test0)
+    (f (vector q)))
+
+  (define b (vector q))
+  (define (test1)
+    (f b)))
+(require 't)
+
+(check-exn #rx"string-append"
+  test0)
+
+(check-exn #rx"string-append"
+  test1)

--- a/typed-racket-test/succeed/optional/async-channel-contract.rkt
+++ b/typed-racket-test/succeed/optional/async-channel-contract.rkt
@@ -1,0 +1,20 @@
+#lang racket/load
+
+;; Test typed-untyped interaction with channels
+
+(module typed typed/racket/optional
+  (require typed/racket/async-channel)
+  (: ch (Async-Channelof (Boxof Integer)))
+  (define ch (make-async-channel))
+  (: putter (-> Thread))
+  (define (putter)
+    (thread (λ () (async-channel-put ch (box 3)))))
+  (provide putter ch))
+
+(require 'typed racket/async-channel rackunit)
+(putter)
+
+(check-not-exn
+  (lambda ()
+    (set-box! (async-channel-get ch) "not an integer")))
+

--- a/typed-racket-test/succeed/optional/bad-vector-ref.rkt
+++ b/typed-racket-test/succeed/optional/bad-vector-ref.rkt
@@ -1,0 +1,30 @@
+#lang racket/base
+
+;; Test applications of `vector-ref` that should fail due to mis-matched
+;;  values and type constructors
+
+(module t typed/racket/optional
+  (: f (-> (Vectorof Natural) Natural))
+  (define (f x)
+    (+ (vector-ref x 0)
+       (vector-ref x 1)))
+  (: g (-> (Vectorof (Vectorof Natural)) Natural))
+  (define (g x)
+    (define v (vector-ref x 0))
+    (+ (vector-ref (vector-ref x 0) 0) (vector-ref v 1)))
+  (: h (-> (Vector Natural Symbol) Natural))
+  (define (h x)
+    (vector-ref x 0))
+
+  (provide f g h))
+
+(require 't racket/contract rackunit)
+
+(check-exn #rx"\\+: contract violation"
+  (λ () (f (vector 4 'A 4 4))))
+
+(check-exn #rx"vector-ref: contract violation"
+  (λ () (g (vector 3))))
+
+(check-not-exn
+  (λ () (h (vector 1 'two 3))))

--- a/typed-racket-test/succeed/optional/cast-mod.rkt
+++ b/typed-racket-test/succeed/optional/cast-mod.rkt
@@ -1,0 +1,115 @@
+#lang typed/racket/base/optional
+
+(require typed/rackunit)
+
+(check-equal? (cast 2 Number) 2)
+(check-equal? (cast 2 Integer) 2)
+(check-equal? (cast (list 2 4) (Listof Byte)) (list 2 4))
+(check-pred vector? (cast (vector 2 4) (Vectorof Byte)))
+
+(check-equal? ((cast (lambda (x) 7) (String -> Number)) "seven") 7)
+
+(: pos-fx-sub1 : Positive-Fixnum -> Nonnegative-Fixnum)
+(define (pos-fx-sub1 x)
+  (sub1 x))
+
+(check-equal? ((cast pos-fx-sub1 (Number -> Number)) 5) 4)
+
+(check-not-exn
+           (λ () ((cast pos-fx-sub1 (Number -> Number)) 0.5) 4))
+
+(check-exn exn:fail:contract?
+           (λ () ((cast pos-fx-sub1 (String -> String)) "hello")))
+
+(check-exn exn:fail:contract?
+           (λ () ((cast pos-fx-sub1 (Any -> Any)) "hello")))
+
+(let ()
+  (: v : Boolean)
+  (define v #f)
+  (: f : Boolean -> Boolean)
+  (define (f x)
+    (set! v x)
+    x)
+  (test-case "cast on mutator functions"
+   (check-equal? v #f)
+   (check-equal? ((cast f (Boolean -> Boolean)) #t) #t)
+   (check-equal? v #t)
+   (check-not-exn
+              (λ () ((cast f (String -> String)) "hello")))
+   (check-equal? v "hello")))
+
+(let () "cast on mutable boxes" ;; TODO should be test-case
+  (: b1 : (Boxof Integer))
+  (define b1 (box 42))
+  (define b2 (cast b1 (Boxof String)))
+  (define b3 (ann b1 BoxTop))
+  (define b4 (cast b3 (Boxof (U Integer String))))
+  (check-equal? (unbox b1) 42)
+  (check-equal? (unbox b4) 42)
+  (check-not-exn (λ () (set-box! b2 "hi")))
+  (check-not-exn (lambda () (unbox b1)))
+  (check-not-exn (λ () (set-box! b4 "hello")))
+  (check-not-exn (lambda () (unbox b1))))
+
+(let () "cast on mutable vectors" ;; TODO test-case
+  (: v1 : (Vectorof Integer))
+  (define v1 (vector 42))
+  (define v2 (cast v1 (Vectorof String)))
+  (define v3 (ann v1 VectorTop))
+  (define v4 (cast v3 (Vectorof (U Integer String))))
+  (check-equal? (vector-ref v1 0) 42)
+  (check-equal? (vector-ref v4 0) 42)
+  (check-not-exn (λ () (vector-set! v2 0 "hi")))
+  (check-not-exn (lambda () (vector-ref v1 0)))
+  (check-not-exn (λ () (vector-set! v4 0 "hello")))
+  (check-not-exn (lambda () (vector-ref v1 0))))
+
+;; Struct definitions need to be at the module level for some reason.
+(struct (X) s ([i : X]) #:mutable #:transparent)
+(let () "cast on mutable structs" ;; TODO test-case
+  (: s1 : (s Integer))
+  (define s1 (s 42))
+  (define s2 (cast s1 (s String)))
+  (define s3 (ann s1 Any))
+  (define s4 (cast s3 (s (U Integer String))))
+  (check-equal? (s-i s1) 42)
+  (check-equal? (s-i s4) 42)
+  (check-not-exn (λ () (set-s-i! s2 "hi")))
+  (check-not-exn (lambda () (s-i s1)))
+  (check-not-exn (λ () (set-s-i! s4 "hello")))
+  (check-not-exn (lambda () (s-i s1))))
+
+(test-case "cast on intersections involving recursive types"
+  (define-type T
+    (Rec T (U String (Listof T))))
+  (: f : (Listof T) -> Any)
+  (define (f x)
+    (if (andmap list? x)
+        (cast x Any)
+        #f))
+  (check-equal? (f (list "a" "b" "c")) #f)
+  (check-equal? (f (list (list "a") (list "b") (list "c")))
+                (list (list "a") (list "b") (list "c"))))
+
+(test-case "cast in dead code"
+  (check-equal? (if #true 1 (cast 2 Integer))
+                1)
+  (check-equal? (if #false (cast 1 Integer) 2)
+                2)
+  (check-equal? (if #true 1 (list (cast 2 Integer) (cast 3 Integer)))
+                1)
+  (check-equal? (if #true 1 `#&,(cast 2 Integer))
+                1)
+  (check-equal? (if #true 1 `#(,(cast 2 Integer) ,(cast 3 Integer)))
+                1)
+  (check-equal? (if #true 1 `#hash([,(cast 2 Integer) . ,(cast 3 Integer)]))
+                1)
+  (check-equal? (if #true 1 `#s(struct ,(cast 2 Integer) ,(cast 3 Integer)))
+                1)
+  (check-not-false ;; check that this doesn't have an internal error
+   (λ () (begin
+           (error "hi")
+           (cast (string->number "42") Integer))))
+  )
+

--- a/typed-racket-test/succeed/optional/cast-mod2.rkt
+++ b/typed-racket-test/succeed/optional/cast-mod2.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/optional
+
+(require typed/rackunit)
+
+(check-not-exn
+  (lambda ()
+    (cast (lambda () 3) (-> String))))
+
+(check-not-exn
+  (lambda ()
+    ((cast (lambda () 3) (-> String)))))
+

--- a/typed-racket-test/succeed/optional/cast.rkt
+++ b/typed-racket-test/succeed/optional/cast.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/optional
+
+(require/typed racket/base
+  [object-name (-> (U (Listof Real) Regexp)
+                   (U String Bytes Symbol))])
+(object-name #rx"a regexp")
+(object-name (cast '(A B C) (Listof Real)))
+

--- a/typed-racket-test/succeed/optional/check-expect.rkt
+++ b/typed-racket-test/succeed/optional/check-expect.rkt
@@ -1,0 +1,6 @@
+#lang typed/racket/optional
+
+(require typed/test-engine/scheme-tests)
+(check-expect 4 4)
+
+(test)

--- a/typed-racket-test/succeed/optional/check-within.rkt
+++ b/typed-racket-test/succeed/optional/check-within.rkt
@@ -1,0 +1,17 @@
+
+#lang typed/racket/optional
+
+(require scheme/math typed/test-engine/scheme-tests)
+
+(define-struct: circle ({radius : Number}))
+(: circle-area (circle -> Number))
+
+(check-within (+ 1 2.14) pi .1)
+(check-range 2 1 3)
+(check-member-of 'a 'b 'c 'd 'a 'z)
+(check-error (error "fail") "fail")
+
+(define (circle-area c)
+ (* pi (circle-radius c) (circle-radius c)))
+
+(test)

--- a/typed-racket-test/succeed/optional/contract-conversion-error.rkt
+++ b/typed-racket-test/succeed/optional/contract-conversion-error.rkt
@@ -1,0 +1,7 @@
+#lang racket/load
+
+;; two cases of arity 1, fine for optional
+
+(module a typed/racket/optional (define v values) (provide v))
+(require 'a)
+v

--- a/typed-racket-test/succeed/optional/control-test-3.rkt
+++ b/typed-racket-test/succeed/optional/control-test-3.rkt
@@ -1,0 +1,22 @@
+#lang racket/load
+
+(module untyped racket
+  (provide call-f)
+
+  (define (call-f f)
+    (call-with-continuation-prompt
+     (λ () (f 0))
+     (default-continuation-prompt-tag)
+     (λ (x) (x "string")))))
+
+(module typed typed/racket/optional
+  (require/typed 'untyped
+                 [call-f ((Integer -> Integer) -> Integer)])
+
+  (call-f
+   (λ: ([x : Integer])
+     (abort-current-continuation
+      (default-continuation-prompt-tag)
+      (λ (x) x)))))
+
+(require 'typed)

--- a/typed-racket-test/succeed/optional/control-test-6.rkt
+++ b/typed-racket-test/succeed/optional/control-test-6.rkt
@@ -1,0 +1,22 @@
+#lang racket/load
+
+(module typed typed/racket/optional
+  (provide f)
+
+  (: f (-> Void))
+  (define (f)
+    (abort-current-continuation
+     (default-continuation-prompt-tag)
+     (λ: ([x : Number]) (+ 1 x)))))
+
+(module untyped racket
+  (require 'typed)
+
+  (call-with-continuation-prompt
+   (λ () (f))
+   (default-continuation-prompt-tag)
+   ;; behavioral values are not allowed to pass
+   ;; through the Any contract to here
+   (λ (f) (f 3))))
+
+(require 'untyped)

--- a/typed-racket-test/succeed/optional/deep-optional-id.rkt
+++ b/typed-racket-test/succeed/optional/deep-optional-id.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/optional
+
+(module deep typed/racket/base
+  (provide xxx)
+  (define xxx '$$$)
+  xxx)
+
+(require 'deep)
+xxx
+
+(define (f y)
+  xxx)

--- a/typed-racket-test/succeed/optional/define-syntax.rkt
+++ b/typed-racket-test/succeed/optional/define-syntax.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/optional
+
+;; Test that a simple macro works in locally-defensive code
+
+(define-syntax-rule (yo lo)
+  (+ lo lo))
+
+(: f (-> Integer Integer))
+(define (f x)
+  (yo (yo x)))
+
+(f 42)

--- a/typed-racket-test/succeed/optional/define-typed-untyped-identifier-syntax-properties.rkt
+++ b/typed-racket-test/succeed/optional/define-typed-untyped-identifier-syntax-properties.rkt
@@ -1,0 +1,84 @@
+#lang racket
+
+;; https://github.com/racket/typed-racket/issues/315
+
+(module t/u racket
+  (provide typed/untyped
+           (rename-out [typed/untyped-typed original-typed-req-stx]
+                       [typed/untyped-untyped original-untyped-req-stx]))
+  
+  (require typed/untyped-utils
+           racket/require-syntax
+           (for-syntax syntax/strip-context))
+  
+  (define-require-syntax (typed/untyped-typed stx)
+    (syntax-case stx ()
+      [(_ m s) (replace-context stx #'(submod m s typed))]))
+  
+  (define-require-syntax (typed/untyped-untyped stx)
+    (syntax-case stx ()
+      [(_ m s) (replace-context stx #'(submod m s untyped))]))
+  
+  (define-typed/untyped-identifier typed/untyped
+    typed/untyped-typed
+    typed/untyped-untyped))
+
+(module m racket
+  (module typed typed/racket
+    (provide test-value typed-test-value)
+    (define test-value : Symbol 'is-typed)
+    (define typed-test-value : Symbol 'present))
+  (module untyped typed/racket/no-check
+    (provide test-value untyped-test-value)
+    (define test-value : Symbol 'is-untyped)
+    (define untyped-test-value : Symbol 'present)))
+
+(module test-typed-1 typed/racket/optional
+  (require (submod ".." t/u))
+  (require typed/rackunit)
+  (require (original-typed-req-stx ".." m))
+  (check-equal? test-value 'is-typed)
+  (check-equal? typed-test-value 'present))
+
+(module test-typed-2 typed/racket/optional
+  (require (submod ".." t/u))
+  (require typed/rackunit)
+  (require/typed (typed/untyped ".." m)
+    ;; gets the untyped id
+    (test-value Symbol)
+    (untyped-test-value Symbol))
+  (check-equal? test-value 'is-untyped)
+  (check-equal? untyped-test-value 'present))
+
+(module test-typed-3 typed/racket/optional
+  (require (submod ".." t/u))
+  (require typed/rackunit)
+  (define-syntax renamer (make-rename-transformer #'original-typed-req-stx))
+  (require (renamer ".." m))
+  (check-equal? test-value 'is-typed)
+  (check-equal? typed-test-value 'present))
+
+(module test-untyped-1 racket
+  (require (submod ".." t/u))
+  (require rackunit)
+  (require (original-untyped-req-stx ".." m))
+  (check-equal? test-value 'is-untyped)
+  (check-equal? untyped-test-value 'present))
+
+(module test-untyped-2 racket
+  (require (submod ".." t/u))
+  (require rackunit)
+  (require (typed/untyped ".." m))
+  (check-equal? test-value 'is-untyped)
+  (check-equal? untyped-test-value 'present))
+
+(module test-untyped-3 racket
+  (require (submod ".." t/u))
+  (require rackunit)
+  (define-syntax renamer (make-rename-transformer #'original-untyped-req-stx))
+  (require (renamer ".." m))
+  (check-equal? test-value 'is-untyped)
+  (check-equal? untyped-test-value 'present))
+
+(require 'test-typed-1 'test-typed-2 'test-typed-3
+         'test-untyped-1 'test-untyped-2 'test-untyped-3)

--- a/typed-racket-test/succeed/optional/dotted-identity2.rkt
+++ b/typed-racket-test/succeed/optional/dotted-identity2.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/optional
+
+(: f (All (a ...) ((a ... a -> Integer) -> (a ... a -> Integer))))
+(define (f x) x)
+
+(: g (All (b ...) ( -> (b ... b -> Integer))))
+(define (g) (lambda xs 0))
+
+(f (g))

--- a/typed-racket-test/succeed/optional/empty-fun.rkt
+++ b/typed-racket-test/succeed/optional/empty-fun.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+
+(module t typed/racket/optional
+  (: f (case->))
+  (define (f x) 0)
+  (provide f))
+
+(require 't rackunit)
+(check-not-exn (lambda () (f (box 0))))
+

--- a/typed-racket-test/succeed/optional/ephemerons.rkt
+++ b/typed-racket-test/succeed/optional/ephemerons.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/optional
+
+(define key (gensym))
+
+(: eph-one (Ephemeronof Integer))
+(define eph-one (make-ephemeron key 1))
+
+(ephemeron? eph-one)
+
+(ephemeron-value eph-one)
+
+(: get-number ((Ephemeronof Number) -> Number))
+(define (get-number e)
+ (or (ephemeron-value e) 0))
+
+(get-number eph-one)

--- a/typed-racket-test/succeed/optional/even-odd-recursive-type.rkt
+++ b/typed-racket-test/succeed/optional/even-odd-recursive-type.rkt
@@ -1,0 +1,75 @@
+#lang racket
+
+(require rackunit)
+
+(module num-even/odd typed/racket/optional
+  (define-type Even (U Null (Pairof Number Odd)))
+  (define-type Odd (Pairof Number Even))
+
+  (: even-lst Even)
+  (define even-lst '(1 2 3 4))
+
+  (: odd-lst Odd)
+  (define odd-lst '(1 2 3)))
+
+(module poly-even/odd typed/racket/optional
+  (define-type (Even A) (U Null (Pairof A (Odd A))))
+  (define-type (Odd A) (Pairof A (Even A)))
+
+  (: even-lst (Even Integer))
+  (define even-lst '(1 2 3 4))
+
+  (: odd-lst (Odd Integer))
+  (define odd-lst '(1 2 3))
+
+  (: even->odd (All (A) (A (Even A) -> (Odd A))))
+  (define (even->odd elem lst)
+    (cons elem lst))
+
+  (provide even->odd Even Odd even-lst odd-lst))
+
+;; make sure it works in a let
+(module let-even/odd typed/racket/optional
+  (let ()
+    (define-type (Even A) (U Null (Pairof A (Odd A))))
+    (define-type (Odd B) (Pairof B (Even B)))
+
+    (: even-lst (Even Integer))
+    (define even-lst '(1 2 3 4))
+
+    (: odd-lst (Odd Integer))
+    (define odd-lst '(1 2 3))
+
+    (cons 3 even-lst)))
+
+(module even/odd* typed/racket/optional
+  ;; weird variant that alternates types between
+  ;; Even and Odd
+  (define-type (Even A B) (U Null (Pairof A (Odd A B))))
+  (define-type (Odd A B) (Pairof B (Even A B)))
+
+  (: even-lst (Even Integer String))
+  (define even-lst '(1 "b" 3 "a"))
+
+  (: odd-lst (Odd Integer String))
+  (define odd-lst '("b" 2 "a"))
+
+  ;; specialized for more interesting contract
+  (: even->odd (String (Even Integer String) -> (Odd Integer String)))
+  (define (even->odd elem lst) (cons elem lst))
+
+  (provide even-lst odd-lst even->odd))
+
+(require (prefix-in a: 'num-even/odd))
+(require (prefix-in b: 'poly-even/odd))
+(require (prefix-in c: 'let-even/odd))
+(require (prefix-in d: 'even/odd*))
+
+;; make sure contract generation on even/odd* worked
+(cons 3 d:odd-lst)
+(check-equal? (d:even->odd "c" d:even-lst) '("c" 1 "b" 3 "a"))
+(check-not-exn (λ () (d:even->odd 1 d:even-lst)))
+
+(b:even->odd "c" b:even-lst)
+(check-not-exn (λ () (b:even->odd "c" b:odd-lst)))
+

--- a/typed-racket-test/succeed/optional/exn-any-mutation.rkt
+++ b/typed-racket-test/succeed/optional/exn-any-mutation.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+(module untyped racket/base
+  (provide f)
+  (define (f x) x))
+(module typed typed/racket/optional
+  (require typed/rackunit)
+  (struct (X) s ([i : X]) #:mutable #:transparent)
+  (require/typed (submod ".." untyped)
+                 [f (-> Any (s (U Integer String)))])
+  (: s1 : (s Integer))
+  (define s1 (s 42))
+  (define s2 (ann s1 Any))
+  (define s3 (f s2))
+  (check-equal? (s-i s1) 42)
+  (check-equal? (s-i s3) 42)
+  (check-not-exn (λ () (set-s-i! s3 "hi")))
+  (check-not-exn (lambda () (s-i s1)))
+  )
+(require 'typed)

--- a/typed-racket-test/succeed/optional/find.rkt
+++ b/typed-racket-test/succeed/optional/find.rkt
@@ -1,0 +1,15 @@
+#lang typed/racket/base/optional
+
+(module a racket/base
+  (provide fake-int* checker)
+  (define fake-int* '(NaN xxx))
+  (define (checker x)
+    #true))
+
+(require/typed 'a
+  (fake-int* (Listof Integer))
+  (checker (-> Integer Boolean)))
+
+(define x : (U #f Integer)
+  (findf checker fake-int*))
+

--- a/typed-racket-test/succeed/optional/flonum.rkt
+++ b/typed-racket-test/succeed/optional/flonum.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+
+(module t typed/racket/base/optional
+  ;; Test case-> type
+  (require racket/flonum)
+  (provide flprobability?)
+  (: flprobability? (case-> (Flonum -> Boolean) (Flonum Any -> Boolean)))
+  (define (flprobability? p [log? #f])
+    (cond [log?  (and (p . fl>= . -inf.0) (p . fl<= . 0.0))]
+          [else  (and (p . fl>= . 0.0) (p . fl<= . 1.0))])))
+
+(require 't rackunit)
+
+(check-not-exn
+  (lambda () (flprobability? 0.5)))
+
+(check-exn #rx"fl>=: contract violation"
+  (lambda () (flprobability? "seven")))

--- a/typed-racket-test/succeed/optional/fold.rkt
+++ b/typed-racket-test/succeed/optional/fold.rkt
@@ -1,0 +1,13 @@
+#lang typed/racket/base/optional
+
+(module a racket/base
+  (provide f)
+  (define (f acc i)
+    'not-int))
+
+(require/typed 'a
+  (f (-> Integer Integer Integer)))
+
+(define x : (U #f Integer)
+  (foldl f 0 '(0 1 2)))
+

--- a/typed-racket-test/succeed/optional/in-cycle.rkt
+++ b/typed-racket-test/succeed/optional/in-cycle.rkt
@@ -1,0 +1,30 @@
+#lang typed/racket/optional
+
+;; Plot error:
+;;
+;;    /Users/ben/code/racket/fork/racket/share/pkgs/plot-lib/plot/private/plot3d/isosurface.rkt:130:23: Type Checker: No function domains matched in function application:
+;;    Domains: Any (Sequenceof (Parameterof Plot-Pen-Style) Any)
+;;             Any (Sequenceof (Parameterof Plot-Pen-Style))
+;;             Any Integer
+;;    Arguments: Any (Sequenceof Plot-Pen-Style)
+;;      in: (in-cycle* line-styles)
+;;
+;; Try to reproduce ... failure so far (2019-08-22), but
+;; - error goes away if remove `rts` provides from the #%type-decl
+;; - error STAYS if remove only the unhygienic lookups
+;; so the problem is related to the new exports for the "contract + type" hack,
+;;  and maybe by improving that we'll get a better fix
+;;
+;; Ok now we are simplified; the issue is a defined variable vs a for-loop variable
+
+(: in-cycle* (All (A) (-> (Sequenceof A) (Sequenceof A))))
+(define (in-cycle* s)
+  (define n (sequence-length s))
+  (if (zero? n) empty-sequence (in-cycle s)))
+
+(define xxx : String "hello")
+
+(: f (-> (Listof Symbol) Void))
+(define (f line-styles)
+  (for ([xxx  (in-cycle* line-styles)])
+    (void)))

--- a/typed-racket-test/succeed/optional/keyword-mand-opt.rkt
+++ b/typed-racket-test/succeed/optional/keyword-mand-opt.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/base/optional
+
+(module u racket/base
+  (define (f0 x #:y y)
+    (void))
+  (provide f0))
+
+(require/typed 'u
+  (f0 (->* [Symbol] [#:y Symbol] Void)))
+
+(void f0)

--- a/typed-racket-test/succeed/optional/ll-lambda.rkt
+++ b/typed-racket-test/succeed/optional/ll-lambda.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+
+;; Test tc-app lambda special case for ((lambda ...) ...)
+
+(module a typed/racket/deep
+  (define-values [a b]
+     ((lambda (x) (values x (list 'A 'A))) 42)))
+
+(module r racket/base
+  (provide f)
+  (define (f x) (values x '(A A))))
+
+(module b typed/racket/optional
+  (define-values [x0 x1]
+     ((lambda (x) (values x (list 'A 'A))) 42))
+
+  (require/typed
+    (submod ".." r)
+    (f (-> Integer (Values Integer (Listof Symbol)))))
+
+  (define-values [x2 x3]
+     ((lambda (x) (f x)) 42))
+
+  (define-values [x4 x5]
+     (f 42))
+  )
+
+(require 'a 'b)

--- a/typed-racket-test/succeed/optional/macro.rkt
+++ b/typed-racket-test/succeed/optional/macro.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(module a typed/racket/base/optional
+  (provide f)
+  (define-syntax-rule (f x)
+    (car (car x))))
+
+(require 'a)
+(f '((a) b c))

--- a/typed-racket-test/succeed/optional/make-predicate-top-level.rkt
+++ b/typed-racket-test/succeed/optional/make-predicate-top-level.rkt
@@ -1,0 +1,9 @@
+#lang racket/load
+
+(require typed/racket/optional)
+
+(: f (Any -> Boolean : Number))
+(define f (make-predicate Number))
+
+(: g (Listof Number))
+(define g (filter f '(1 2 3 4 "5")))

--- a/typed-racket-test/succeed/optional/module-client.rkt
+++ b/typed-racket-test/succeed/optional/module-client.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket/base/optional
+
+;; Test:
+;; 1. enclosing module is locally-defensive
+;; 2. contains a Racket submodule
+;; 3. import a value with the right constructor & the wrong type
+;; 4. send the value back to untyped code, get low-level error from untyped
+
+(require "module-server.rkt" ) ;; import a typed function
+
+(: h (-> Real Real))
+(define (h n)
+  (* n n))
+
+(f 3 h)
+
+
+(module u racket/base
+  (provide xs)
+  (define xs '(A B C)))
+(require/typed 'u
+  (xs (Listof Natural)))
+
+(with-handlers ((exn:fail:contract? (lambda (_) #true)))
+  (filter zero? xs))

--- a/typed-racket-test/succeed/optional/module-plus.rkt
+++ b/typed-racket-test/succeed/optional/module-plus.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base/optional
+
+;; Make sure defender runs in module+
+
+(module u racket/base
+  (define b
+    (box "hello"))
+  (provide b))
+
+(require/typed 'u (b (Boxof Integer)))
+
+(module+ test
+  (require typed/rackunit)
+
+  (check-not-exn
+    (lambda () (unbox b))))

--- a/typed-racket-test/succeed/optional/module-server.rkt
+++ b/typed-racket-test/succeed/optional/module-server.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/base/optional
+
+;; Not a test, just provides a locally-defensive function
+
+(provide f filter)
+
+(: f (-> Real (-> Real Real) Real))
+(define (f r g)
+  (g (g r)))

--- a/typed-racket-test/succeed/optional/module-star.rkt
+++ b/typed-racket-test/succeed/optional/module-star.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base/optional
+
+;; Make sure defender runs in module*
+
+(module u racket/base
+  (define b
+    (box "hello"))
+  (provide b))
+
+(require/typed 'u (b (Boxof Integer)))
+
+(module* test #f
+  (require typed/rackunit)
+
+  (check-not-exn
+    (lambda () (unbox b))))

--- a/typed-racket-test/succeed/optional/no-bound-fl.rkt
+++ b/typed-racket-test/succeed/optional/no-bound-fl.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/optional
+
+(: fold-left (All (a b ...) ((a b ... -> a) a (Listof b) ... -> a)))
+(define (fold-left f a . bss)
+  (if (ormap null? bss)
+      a
+      (apply fold-left
+             f
+             (apply f a (map car bss))
+             (map cdr bss))))
+

--- a/typed-racket-test/succeed/optional/nothing.rkt
+++ b/typed-racket-test/succeed/optional/nothing.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/optional
+
+;; type `Nothing` should get no check, like everything else
+
+(module a racket/base
+  (provide f)
+  (define (f) 42))
+
+(require/typed 'a
+  (f (-> Nothing)))
+
+(f)

--- a/typed-racket-test/succeed/optional/object-typed.rkt
+++ b/typed-racket-test/succeed/optional/object-typed.rkt
@@ -1,0 +1,37 @@
+#lang racket
+
+(module t typed/racket/optional
+  (define-type C0% (Class (init-field (s String)) (f (-> Integer Integer))))
+  (: c0% C0%)
+  (define c0%
+    (class object%
+      (super-new)
+      (init-field s)
+      (define/public (f x) (+ 4 4))))
+
+  (define-type C1% (Class (init-field (s String)) (f (->* [Integer] [#:y Integer] Integer))))
+  (: c1% C1%)
+  (define c1%
+    (class object%
+      (super-new)
+      (init-field s)
+      (define/public (f x #:y [y 0]) (+ 4 4))))
+  (provide c0% c1%))
+
+(require 't rackunit)
+
+(define o0 (new c0% (s "hello")))
+(check-not-exn
+  (lambda () (send o0 f 'NaN)))
+(check-not-exn
+  (lambda () (new c0% (s 'NotString))))
+
+(define o1 (new c1% (s "hello")))
+(check-not-exn
+  (lambda () (send o1 f 'NaN #:y 1)))
+(check-not-exn
+  (lambda () (send o1 f 0 #:y 'NaN)))
+(check-not-exn
+  (lambda () (send o1 f 0)))
+(check-not-exn
+  (lambda () (send o1 f 0 #:y 1)))

--- a/typed-racket-test/succeed/optional/object-untyped.rkt
+++ b/typed-racket-test/succeed/optional/object-untyped.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket/optional
+
+;; Copied from TR -test/fail/ directory
+
+(module u racket
+  (define c%
+    (class object%
+      (super-new)
+      (define/public (f x) '(+ x 1))))
+  (provide c%))
+
+(define-type C% (Class (f (-> Integer Integer))))
+
+(require typed/rackunit)
+(require/typed (submod "." u)
+  (c% C%))
+
+(: g (-> (Vector (Instance C%)) Integer))
+(define (g vo)
+  (define o (vector-ref vo 0))
+  (send o f 2))
+
+(check-not-exn
+  (lambda () (g (vector (new c%)))))
+

--- a/typed-racket-test/succeed/optional/opaque-object.rkt
+++ b/typed-racket-test/succeed/optional/opaque-object.rkt
@@ -1,0 +1,23 @@
+#lang racket/base
+
+;; Shallow does not make opaque contracts
+
+(require racket/class)
+
+(module a typed/racket/optional
+  (provide o)
+  (: o (Object))
+  (define o
+    (new
+      (class object%
+        (super-new)
+        (field [x 0])
+        (define/public (m) (void))))))
+
+(module b racket
+  (require (submod ".." a))
+  (set-field! x o "wrong type")
+  (get-field x o)
+  (send o m))
+
+(require 'b)

--- a/typed-racket-test/succeed/optional/optional-deep-id-0.rkt
+++ b/typed-racket-test/succeed/optional/optional-deep-id-0.rkt
@@ -1,0 +1,15 @@
+#lang typed/racket/base
+
+;; basic optional -> deep, is ok
+
+(module opt typed/racket/base/optional
+  (provide xxx)
+  (define xxx '$$$)
+  xxx)
+
+(require 'opt)
+xxx
+
+(define (f y)
+  xxx)
+

--- a/typed-racket-test/succeed/optional/optional-deep-id-1.rkt
+++ b/typed-racket-test/succeed/optional/optional-deep-id-1.rkt
@@ -1,0 +1,40 @@
+#lang racket/base
+
+;; deep should protect itself from optional
+
+(module uuu racket/base
+  (provide bad-list)
+  (define bad-list '(X X)))
+
+(module sss typed/racket/optional
+
+  (require/typed (submod ".." uuu)
+    (bad-list (Listof (List Symbol))))
+
+  (provide f)
+
+  (: f (-> (-> (List Symbol) Symbol) (Listof Symbol)))
+  (define (f x)
+    (map x bad-list)))
+
+(module ttt typed/racket
+  (require (submod ".." sss))
+
+  (: g (-> (List Symbol) Symbol))
+  (define (g n)
+    (car n))
+
+  (define (go1)
+    (f g))
+
+  (define (go2)
+    ;; second function, to be sure all occurrences of `f` get a contract
+    (f g))
+
+  (provide go1 go2))
+
+(require 'ttt rackunit)
+
+(check-exn exn:fail:contract? go1)
+(check-exn exn:fail:contract? go2)
+

--- a/typed-racket-test/succeed/optional/optional-provide.rkt
+++ b/typed-racket-test/succeed/optional/optional-provide.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+
+;; Test providing value to untyped
+
+(module a typed/racket/base/optional
+        (provide f)
+        (define (f (x : (Boxof Integer)))
+          (unbox x)))
+
+(require 'a rackunit)
+(check-exn exn:fail:contract?
+  (lambda () (f 0)))

--- a/typed-racket-test/succeed/optional/optional-shallow-id-0.rkt
+++ b/typed-racket-test/succeed/optional/optional-shallow-id-0.rkt
@@ -1,0 +1,15 @@
+#lang typed/racket/base/shallow
+
+;; basic optional -> shallow
+
+(module opt typed/racket/base/optional
+  (provide xxx)
+  (define xxx '$$$)
+  xxx)
+
+(require 'opt)
+xxx
+
+(define (f y)
+  xxx)
+

--- a/typed-racket-test/succeed/optional/optional-shallow-id-1.rkt
+++ b/typed-racket-test/succeed/optional/optional-shallow-id-1.rkt
@@ -1,0 +1,40 @@
+#lang racket/base
+
+;; shallow should protect itself from optional
+
+(module uuu racket/base
+  (provide bad-list)
+  (define bad-list '(X X)))
+
+(module sss typed/racket/optional
+
+  (require/typed (submod ".." uuu)
+    (bad-list (Listof (List Symbol))))
+
+  (provide f)
+
+  (: f (-> (-> (List Symbol) Symbol) (Listof Symbol)))
+  (define (f x)
+    (map x bad-list)))
+
+(module ttt typed/racket/shallow
+  (require (submod ".." sss))
+
+  (: g (-> (List Symbol) Symbol))
+  (define (g n)
+    (car n))
+
+  (define (go1)
+    (f g))
+
+  (define (go2)
+    ;; second function, to be sure all occurrences of `f` get a contract
+    (f g))
+
+  (provide go1 go2))
+
+(require 'ttt rackunit)
+
+(check-exn #rx"shape-check" go1)
+(check-exn #rx"shape-check" go2)
+

--- a/typed-racket-test/succeed/optional/optional-shallow-id-2.rkt
+++ b/typed-racket-test/succeed/optional/optional-shallow-id-2.rkt
@@ -1,0 +1,20 @@
+#lang typed/racket/base/shallow
+
+;; basic optional -> shallow
+
+(module uuu racket/base
+  (provide bad-sym)
+  (define bad-sym #f))
+
+(module opt typed/racket/base/optional
+  (provide get-sym)
+  (require/typed (submod ".." uuu)
+    (bad-sym Symbol))
+  (: get-sym (-> Symbol))
+  (define (get-sym)
+    bad-sym))
+
+(require 'opt typed/rackunit)
+
+(check-exn #rx"shape-check" (lambda () (ann (get-sym) Symbol)))
+

--- a/typed-racket-test/succeed/optional/optional-shallow-id-3.rkt
+++ b/typed-racket-test/succeed/optional/optional-shallow-id-3.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/shallow
+
+(module uuu racket/base
+  (provide bad-sym)
+  (define bad-sym #f))
+
+(module opt typed/racket/base/optional
+  (require/typed/provide (submod ".." uuu)
+    (bad-sym Symbol)))
+
+(require 'opt)
+bad-sym

--- a/typed-racket-test/succeed/optional/optional-syntax.rkt
+++ b/typed-racket-test/succeed/optional/optional-syntax.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(module a typed/racket/base/shallow
+  (provide f)
+  (define-syntax-rule (f x)
+    (car (car x))))
+
+(require 'a)
+(f '((a) b c))

--- a/typed-racket-test/succeed/optional/poly-bad-3.rkt
+++ b/typed-racket-test/succeed/optional/poly-bad-3.rkt
@@ -1,0 +1,13 @@
+#lang typed/racket/base/optional
+
+(require/typed racket/base
+  (cdr (All (A) (U (Boxof A) (Pairof A A) (-> (Pairof String String) Symbol)))))
+
+(let ((v : (U (Boxof String) (Pairof String String) (-> (Pairof String String) Symbol))
+       (inst cdr String)))
+  (if (box? v)
+    #f
+    (if (pair? v)
+      #f
+      (v (cons "a" "aaa")))))
+

--- a/typed-racket-test/succeed/optional/poly-ref.rkt
+++ b/typed-racket-test/succeed/optional/poly-ref.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/base/optional
+
+;; Test that type variables do not have a run-time check
+;;  (no need for a check, because a context cannot make assumptions about the value)
+
+(: f (All (A) (-> (Vectorof A) A)))
+(define (f x)
+  (vector-ref x 0))
+
+(f (vector 1 2 3))
+(f '#(four five six))

--- a/typed-racket-test/succeed/optional/poly-require-typed.rkt
+++ b/typed-racket-test/succeed/optional/poly-require-typed.rkt
@@ -1,0 +1,17 @@
+#lang racket/base
+
+;; Test require/typed with a polymorphic type
+
+(module util racket/base
+  (provide random-from)
+  (require racket/list)
+
+  (define (random-from xs)
+    (first (shuffle xs))))
+
+(module client typed/racket/base/optional
+  (require/typed (submod ".." util)
+    (random-from (All (A) (-> (Listof A) A))))
+
+  (random-from '(1 2 3)))
+(require 'client)

--- a/typed-racket-test/succeed/optional/pr10350.rkt
+++ b/typed-racket-test/succeed/optional/pr10350.rkt
@@ -1,0 +1,14 @@
+#lang typed/racket/optional
+(require/typed
+ scheme/base
+ [values (All (T) ((Any -> Boolean) -> (Any -> Boolean : T)))])
+
+(: number->string? (Any -> Boolean : (Number -> String)))
+(define (number->string? x)
+  (((inst values (Number -> String)) procedure?) x))
+
+(: f (Number -> String))
+(define f
+  (if (number->string? +) + number->string))
+
+(ann (f 3) String)

--- a/typed-racket-test/succeed/optional/pr12913.rkt
+++ b/typed-racket-test/succeed/optional/pr12913.rkt
@@ -1,0 +1,10 @@
+#lang racket
+
+;; Test that `define-type` works at the top-level
+
+(define ns (make-base-namespace))
+(eval '(require typed/racket/optional) ns)
+(eval '(define-type Foo (U String Symbol)) ns)
+(eval '(: x Foo) ns)
+(eval '(define x 'x) ns)
+

--- a/typed-racket-test/succeed/optional/pr13747.rkt
+++ b/typed-racket-test/succeed/optional/pr13747.rkt
@@ -1,0 +1,13 @@
+#lang racket
+
+;; Test that `require/typed` works at the top-level
+
+(require racket/sandbox)
+
+(define evaluator
+  (call-with-trusted-sandbox-configuration
+   (λ () (make-evaluator 'typed/racket/optional))))
+
+(evaluator '(require/typed racket/base [values (Integer -> Integer)]))
+(evaluator '(values 1))
+

--- a/typed-racket-test/succeed/optional/pr226-variation-2.rkt
+++ b/typed-racket-test/succeed/optional/pr226-variation-2.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket/optional
+
+;; Chaperoned struct predicates must be wrapped in a contract.
+;; (Even though `struct-predicate-procedure?` will return
+;;  true for these values)
+
+(module untyped racket
+  (struct s ())
+  (define s?? (chaperone-procedure s? (lambda (x) (x) x)))
+  ;; provide enough names to trick #:struct
+  (provide s struct:s (rename-out [s?? s?])))
+
+(require/typed 'untyped
+  [#:struct s ()])
+
+(define (fail-if-called)
+  (error 'pr226 "Untyped code invoked a higher-order value passed as 'Any'"))
+
+(require typed/rackunit)
+(check-exn #rx"Untyped code invoked a higher-order value"
+  (lambda () (s? fail-if-called)))

--- a/typed-racket-test/succeed/optional/pr226-variation-3.rkt
+++ b/typed-racket-test/succeed/optional/pr226-variation-3.rkt
@@ -1,0 +1,23 @@
+#lang typed/racket/optional
+
+(module untyped racket
+  (struct s ())
+  (define (s?? x)
+    (when (box? x)
+      (set-box! x (void)))
+    #t)
+  (provide s struct:s (rename-out [s?? s?])))
+
+(require/typed 'untyped
+  [#:struct s ()])
+
+(: suitcase (Boxof '$$$))
+(define suitcase (box '$$$))
+
+(with-handlers ([exn:fail:contract? (lambda (x) (void))])
+  (s? suitcase)
+  (void))
+
+(require typed/rackunit)
+(check-not-exn
+  (lambda () (unbox suitcase)))

--- a/typed-racket-test/succeed/optional/prefab-field-provide.rkt
+++ b/typed-racket-test/succeed/optional/prefab-field-provide.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+
+(module m typed/racket/base/optional
+
+  (struct foo ([x : Integer]) #:prefab)
+  (define f (foo 42))
+  (struct bar ([y : Integer]) #:prefab #:mutable)
+  (define b (bar 43))
+  (provide f foo-x b bar-y set-bar-y!))
+
+(module n racket/base
+  (require (submod ".." m) rackunit)
+  (set-bar-y! b 44)
+  (check-not-exn (lambda () (set-bar-y! b "44"))))
+
+(require (submod 'n))

--- a/typed-racket-test/succeed/optional/prefab.rkt
+++ b/typed-racket-test/succeed/optional/prefab.rkt
@@ -1,0 +1,472 @@
+#lang typed/racket/optional
+
+;; Test prefab struct declarations
+
+(require typed/rackunit)
+(provide (all-defined-out))
+
+(struct foo ([x : Symbol]) #:prefab)
+(struct bar foo ([y : String] [z : String]) #:prefab)
+(define-struct foo* ([x : Symbol]) #:prefab)
+(define-struct (bar* foo*) ([y : String] [z : String]) #:prefab)
+
+(: a-bar (Prefab (bar foo 1) Symbol String String)) 
+(define a-bar (bar 'foo "bar1" "bar2"))
+
+(ann (foo-x (foo 'foo)) Symbol)
+(ann (bar-y (bar 'foo "bar1" "bar2")) String)
+(ann (foo-x #s(foo "hi")) String)
+(ann (foo-x #s((bar foo 1) #t 42 "!")) True)
+(ann (bar-y #s((bar foo 1) #t 42 "!")) Number)
+(ann (bar-z #s((bar foo 1) #t 42 "!")) String)
+
+(foo*-x (make-foo* 'foo))
+(bar*-y (make-bar* 'foo "bar1" "bar2"))
+
+;; prefab keys may be normalized or not
+(: a-bar-2 (Prefab (bar 2 foo 1 (0 #f) #()) Symbol String String))
+(define a-bar-2 (bar 'foo "bar1" "bar2"))
+
+;; prefab subtyping is computed via the key and field length
+(: a-bar-3 (Prefab foo Symbol))
+(define a-bar-3 (bar 'foo "bar1" "bar2"))
+
+
+(: read-some-unknown-foo1 (-> (PrefabTop foo 1) Any))
+(define (read-some-unknown-foo1 f)
+  (foo-x f))
+
+(: read-some-unknown-foo2 (-> (Prefab foo Any) Any))
+(define (read-some-unknown-foo2 f)
+  (foo-x f))
+
+
+(ann read-some-unknown-foo1 (-> (Prefab foo Any) Any))
+
+(ann read-some-unknown-foo2 (-> (PrefabTop foo 1) Any))
+ 
+
+(: read-some-unknown-foo3 (-> Any Any))
+(define (read-some-unknown-foo3 x)
+  (if (foo? x)
+      (read-some-unknown-foo1 x)
+      42))
+
+
+(: read-some-unknown-foo4 (-> Any Any))
+(define (read-some-unknown-foo4 x)
+  (if (bar? x)
+      (read-some-unknown-foo1 x)
+      42))
+
+(define-predicate foo/sym1? foo)
+(: read-known-foo1 (-> Any Symbol))
+(define (read-known-foo1 f)
+  (if (foo/sym1? f)
+      (foo-x f)
+      'other))
+
+(: foo/sym2? (-> Any Boolean : foo))
+(define (foo/sym2? x)
+  (and (foo? x) (symbol? (foo-x x))))
+
+(: read-known-foo2 (-> Any Symbol))
+(define (read-known-foo2 f)
+  (if (foo/sym2? f)
+      (foo-x f)
+      'other))
+
+(: bar/str-str? (-> Any Boolean : bar))
+(define (bar/str-str? x)
+  (and (foo? x)
+       (symbol? (foo-x x))
+       (bar? x)
+       (string? (bar-y x))
+       (string? (bar-z x))))
+
+(: foo/sym-or-num? (-> Any Boolean : (Prefab foo (U Symbol Number))))
+(define (foo/sym-or-num? x)
+  (and (foo? x) (or (symbol? (foo-x x))
+                    (number? (foo-x x)))))
+
+(: foo/sym-or-str? (-> Any Boolean : (Prefab foo (U Symbol String))))
+(define (foo/sym-or-str? x)
+  (and (foo? x) (or (symbol? (foo-x x))
+                    (string? (foo-x x)))))
+
+(: foo/num-or-str? (-> Any Boolean : (Prefab foo (U Number String))))
+(define (foo/num-or-str? x)
+  (and (foo? x) (or (number? (foo-x x))
+                    (string? (foo-x x)))))
+
+(: read-known-foo3 (-> Any Symbol))
+(define (read-known-foo3 f)
+  (if (and (foo/sym-or-num? f)
+           (foo/sym-or-str? f)
+           (foo/num-or-str? f))
+      (+ 'dead "code")
+      'other))
+
+(: empty-intersection-check1 (-> Any Any))
+(define (empty-intersection-check1 x)
+  (cond
+    [(and (foo? x) (foo*? x)) (+ 1 "2")]
+    [else 42]))
+
+(: empty-intersection-check2 (-> Any Any))
+(define (empty-intersection-check2 x)
+  (cond
+    [(and (foo? x) (bar*? x)) (+ 1 "2")]
+    [else 42]))
+
+;; Mutable prefab structs
+
+(struct baz ([x : String]) #:mutable #:prefab)
+(define-struct baz* ([x : String]) #:mutable #:prefab)
+
+(define a-baz (baz "baz"))
+(set-baz-x! a-baz "baz2")
+(baz-x a-baz)
+
+(define a-baz* (make-baz* "baz"))
+(set-baz*-x! a-baz* "baz2")
+(baz*-x a-baz*)
+
+
+(: set-some-baz-x! (All (A) (-> (Prefab (baz #(0)) A) A Void)))
+(define (set-some-baz-x! b val)
+  (set-baz-x! b val)) 
+
+
+(: read-some-baz-x (All (A) (-> (Prefab (baz #(0)) A) A)))
+(define (read-some-baz-x b)
+  (baz-x b))
+
+
+(: read-some-unknown-baz-x1 (-> (PrefabTop (baz #(0)) 1) Any))
+(define (read-some-unknown-baz-x1 b)
+  (baz-x b))
+
+
+(: read-some-unknown-baz-x2 (-> Any Any))
+(define (read-some-unknown-baz-x2 b)
+  (if (baz? b)
+      (baz-x b)
+      42))
+
+
+;; Polymorphic prefab structs
+
+(struct (X) poly ([x : X]) #:prefab)
+(define-struct (X) poly* ([x : X]) #:prefab)
+
+(poly-x (poly "foo"))
+(poly-x (poly 3))
+(poly-x #s(poly "foo"))
+
+(poly*-x (make-poly* "foo"))
+(poly*-x (make-poly* 3))
+(poly*-x #s(poly* "foo"))
+
+;; Test match (indirectly tests unsafe-struct-ref)
+(match (foo 'x) [(foo s) s])
+(match (foo* 'x) [(foo* s) s])
+
+(struct point ([x : Number] [y : Number])
+  #:prefab)
+
+;; although point prefabs with strings can be
+;; created, the constructor `point` should enforce
+;; the fields we asked it to enforce
+(assert-typecheck-fail
+ (point "1" "2")) 
+
+;; the point predicate does not tell us
+;; what values are in the point
+(: maybe-point-x (-> Any Void))
+(define (maybe-point-x p)
+  (when (point? p)
+    (assert-typecheck-fail (ann (point-x p) Number))
+    (void)))
+
+
+(struct initials ([first : Symbol] [last : Symbol])
+  #:prefab
+  #:mutable)
+
+
+;; although initials prefabs with strings can be
+;; created, the constructor `initials` should enforce
+;; the fields we asked it to enforce
+(assert-typecheck-fail
+ (initials "1" "2"))
+
+
+;; the initials predicate does not tell us
+;; what values are in the field
+(: maybe-initials-first (-> Any Symbol))
+(define (maybe-initials-first i)
+  (cond
+    [(initials? i)
+     (assert-typecheck-fail
+      (initials-first i)
+      #:result 'default)]
+    [else 'also-okay]))  
+
+;; we cannot write to a mutable prefab when
+;; we do not know what type it's fields have
+;; (and the predicate does not tell us that)
+(: maybe-set-initials-first! (-> Any Void))
+(define (maybe-set-initials-first! i)
+  (when (initials? i)
+    (assert-typecheck-fail
+     (set-initials-first! i (error "any-value")))))
+
+;; should fail because the number of fields for initials is
+;; incorrect (i.e. the initials we defined above has 2 fields
+;; but this PrefabTop says its for initials with 3 fields)
+(: set-some-initials-first! (-> (PrefabTop (initials #(0 1)) 3) Void))
+(define (set-some-initials-first! i)
+  (assert-typecheck-fail
+   (set-initials-first! i (error "any-value"))))
+
+
+
+(struct (A B) tuple ([fst : A] [snd : B]) #:prefab)
+
+(define-predicate is-tuple? (tuple Any Any))
+(define-predicate is-num-tuple? (tuple Number Number))
+
+(define good-point (tuple 1 2))
+(define bad-point1 (tuple "1" 2))
+(define bad-point2 (tuple 1 "2"))
+
+(unless (is-tuple? (if (zero? (random 1)) good-point "other value"))
+  (error "is-tuple? broken!"))
+
+(unless (is-num-tuple? (if (zero? (random 1)) good-point "other value"))
+  (error "is-tuple? broken!"))
+
+(when (is-num-tuple? (if (zero? (random 1)) bad-point1 good-point))
+  (error "is-num-tuple? broken!"))
+
+(when (is-num-tuple? (if (zero? (random 1)) bad-point2 good-point))
+  (error "is-num-tuple? broken!"))
+
+
+(struct num-num ([n1 : Number] [n2 : Number]) #:prefab)
+(struct num-num-str-str-str num-num ([s1 : String] [s2 : String] [s3 : String]) #:prefab)
+
+
+(num-num 1 2)
+(assert-typecheck-fail
+ (num-num 1 "2"))
+(assert-typecheck-fail
+ (num-num "1" 2))
+(num-num-str-str-str 1 2 "1" "2" "3")
+(assert-typecheck-fail
+ (num-num-str-str-str 1 2 1 "2" "3"))
+(assert-typecheck-fail
+ (num-num-str-str-str 1 2 "1" 2 "3"))
+(assert-typecheck-fail
+ (num-num-str-str-str 1 2 "1" "2" 3))
+(unless (equal? 1 (ann (num-num-n1 (num-num-str-str-str 1 2 "3" "4" "5")) Number))
+  (error "oh no! didn't get 1!"))
+(unless (equal? 1 (ann (num-num-n1 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) Number))
+  (error "oh no! didn't get 1!"))
+(unless (equal? 2 (ann (num-num-n2 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) Number))
+  (error "oh no! didn't get 2!"))
+(unless (equal? 2 (ann (num-num-n2 (num-num-str-str-str 1 2 "3" "4" "5")) Number))
+  (error "oh no! didn't get 2!"))
+(unless (equal? "3" (ann (num-num-str-str-str-s1 (num-num-str-str-str 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"3\""))
+(unless (equal? "3" (ann (num-num-str-str-str-s1 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"3\""))
+(unless (equal? "4" (ann (num-num-str-str-str-s2 (num-num-str-str-str 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"4\""))
+(unless (equal? "4" (ann (num-num-str-str-str-s2 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"4\""))
+(unless (equal? "5" (ann (num-num-str-str-str-s3 (num-num-str-str-str 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"5\""))
+(unless (equal? "5" (ann (num-num-str-str-str-s3 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"5\""))
+
+
+
+(unless (equal?
+         (let ([val : (PrefabTop (num-num-str-str-str num-num 2) 5)
+                    #s((num-num-str-str-str num-num 2) "one" "two" 'three 'four 'five)])
+           (ann (cond
+                  [(not (num-num? val)) (+ "dead" 'code)]
+                  [(not (num-num-str-str-str? val)) (+ "dead" 'code)]
+                  [(string? (num-num-n1 val)) (num-num-n1 val)]  
+                  [(string? (num-num-n2 val)) (num-num-n2 val)]
+                  [(symbol? (num-num-str-str-str-s1 val)) (symbol->string (num-num-str-str-str-s1 val))]
+                  [(symbol? (num-num-str-str-str-s2 val)) (symbol->string (num-num-str-str-str-s2 val))]
+                  [(symbol? (num-num-str-str-str-s3 val)) (symbol->string (num-num-str-str-str-s3 val))]
+                  [else "missed"])
+                String))
+         "one")
+  (error "accessors broken num-num-str-str-str 1")) 
+
+(unless (equal?
+         (let ([val : Any #s((num-num-str-str-str num-num 2) "one" "two" 'three 'four 'five)])
+           (ann (cond
+                  [(not (num-num-str-str-str? val)) "nope"]
+                  [(string? (num-num-n1 val)) (num-num-n1 val)] 
+                  [(string? (num-num-n2 val)) (num-num-n2 val)]
+                  [(symbol? (num-num-str-str-str-s1 val)) (symbol->string (num-num-str-str-str-s1 val))]
+                  [(symbol? (num-num-str-str-str-s2 val)) (symbol->string (num-num-str-str-str-s2 val))]
+                  [(symbol? (num-num-str-str-str-s3 val)) (symbol->string (num-num-str-str-str-s3 val))]
+                  [else "missed"])
+                String))
+         "one")
+  (error "accessors broken num-num-str-str-str 2"))
+ 
+(unless (equal?
+         (match (ann #s((num-num-str-str-str num-num 2) "one" "two" three four five) Any)
+           [(num-num-str-str-str fld1 fld2 fld3 fld4 fld5)
+            (list fld1 fld2 fld3 fld4 fld5)])
+         (list "one" "two" 'three 'four 'five))
+  (error "prefab pattern matching broken! num-num-str-str-str"))
+
+
+
+(struct sym-sym ([n1 : Symbol] [n2 : Symbol]) #:prefab #:mutable)
+(struct sym-sym-str-str-str sym-sym ([s1 : String] [s2 : String] [s3 : String]) #:prefab)
+
+
+(sym-sym 'one 'two)
+(sym-sym-str-str-str 'one 'two "1" "2" "3")
+(unless (equal? 'one (ann (sym-sym-n1 (sym-sym-str-str-str 'one 'two "3" "4" "5")) Symbol))
+  (error "oh no! didn't get 'one!"))
+(unless (equal? 'two (ann (sym-sym-n2 (sym-sym-str-str-str 'one 'two "3" "4" "5")) Symbol))
+  (error "oh no! didn't get 'two!"))
+(unless (equal? "3" (ann (sym-sym-str-str-str-s1 (sym-sym-str-str-str 'one 'two "3" "4" "5")) String))
+  (error "oh no! didn't get \"3\""))
+(unless (equal? "4" (ann (sym-sym-str-str-str-s2 (sym-sym-str-str-str 'one 'two "3" "4" "5")) String))
+  (error "oh no! didn't get \"4\""))
+(unless (equal? "5" (ann (sym-sym-str-str-str-s3 (sym-sym-str-str-str 'one 'two "3" "4" "5")) String))
+  (error "oh no! didn't get \"5\""))
+
+(unless
+    (equal?
+     (let ([val : Any (read (open-input-string "#s((sym-sym-str-str-str sym-sym 2 #(0 1)) \"one\" \"two\" 'three 'four 'five)"))])
+       (ann (cond
+              [(not (sym-sym-str-str-str? val)) "nope"]
+              [else
+               (let ([fld1 (sym-sym-n1 val)]
+                     [fld2 (sym-sym-n2 val)]
+                     [fld3 (sym-sym-str-str-str-s1 val)]
+                     [fld4 (sym-sym-str-str-str-s2 val)]
+                     [fld5 (sym-sym-str-str-str-s3 val)])
+                 (cond
+                   [(string? fld1) fld1]
+                   [(string? fld2) fld2]
+                   [(symbol? fld3) (symbol->string fld3)]
+                   [(symbol? fld4) (symbol->string fld4)]
+                   [(symbol? fld5) (symbol->string fld5)]
+                   [else "missed"]))])
+            String))
+     "one")
+  (error "accessors broken sym-sym-str-str-str"))
+
+(match (ann (read (open-input-string "#s((sym-sym-str-str-str sym-sym 2 #(0 1)) \"one\" \"two\" three four five)"))
+            Any)
+  [(sym-sym-str-str-str fld1 fld2 fld3 fld4 fld5)
+   (unless (equal? (list fld1 fld2 fld3 fld4 fld5)
+                   (list "one" "two" 'three 'four 'five))
+     (error 'sym-sym-str-str-str "prefab pattern matching broken! got: ~a\n"
+            (list fld1 fld2 fld3 fld4 fld5)))]
+  [val (error "prefab pattern matching broken! sym-sym-str-str-str did not match ~a\n"
+              val)])
+
+
+(struct num-num-sym-sym-sym num-num ([s1 : Symbol] [s2 : Symbol] [s3 : Symbol]) #:prefab #:mutable)
+
+(num-num-sym-sym-sym 1 2 'three 'four 'five)
+(unless (equal? 1 (ann (num-num-n1 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Number))
+  (error "oh no! didn't get 1e!"))
+(unless (equal? 2 (ann (num-num-n2 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Number))
+  (error "oh no! didn't get 2!"))
+(unless (equal? 'three (ann (num-num-sym-sym-sym-s1 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Symbol))
+  (error "oh no! didn't get \"3\""))
+(unless (equal? 'four (ann (num-num-sym-sym-sym-s2 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Symbol))
+  (error "oh no! didn't get \"4\""))
+(unless (equal? 'five (ann (num-num-sym-sym-sym-s3 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Symbol))
+  (error "oh no! didn't get \"5\""))
+
+
+(unless
+    (equal?
+     (let ([val : Any (read (open-input-string "#s((num-num-sym-sym-sym #(0 1 2) num-num 2) \"one\" \"two\" 3 4 5)"))])
+       (ann (cond
+              [(not (num-num-sym-sym-sym? val)) "nope"]
+              [else
+               (let ([fld1 (num-num-n1 val)] 
+                     [fld2 (num-num-n2 val)]
+                     [fld3 (num-num-sym-sym-sym-s1 val)]
+                     [fld4 (num-num-sym-sym-sym-s2 val)]
+                     [fld5 (num-num-sym-sym-sym-s3 val)])
+                 (cond
+                   [(string? fld1) fld1]
+                   [(string? fld2) fld2]
+                   [(number? fld3) (number->string fld3)]
+                   [(number? fld4) (number->string fld4)]
+                   [(number? fld5) (number->string fld5)]
+                   [else "missed"]))])
+            String))
+     "one")
+  (error "accessors broken num-num-sym-sym-sym"))
+
+(struct str-str ([s1 : String] [s2 : String]) #:prefab #:mutable)
+(struct str-str-num-num-num str-str ([n1 : Number] [n2 : Number] [n3 : Number]) #:prefab #:mutable)
+
+
+(unless
+    (equal?
+     (let ([val : Any (read (open-input-string
+                             "#s((str-str-num-num-num #(0 1 2) str-str 2 #(0 1)) one two three four five)"))])
+       (ann (cond
+              [(not (str-str-num-num-num? val)) "nope"]
+              [else
+               (let ([fld1 (str-str-s1 val)]
+                     [fld2 (str-str-s2 val)]
+                     [fld3 (str-str-num-num-num-n1 val)]
+                     [fld4 (str-str-num-num-num-n2 val)]
+                     [fld5 (str-str-num-num-num-n3 val)])
+                 (cond
+                   [(string? fld1) fld1]
+                   [(string? fld2) fld2]
+                   [(number? fld3) (number->string fld3)]
+                   [(number? fld4) (number->string fld4)]
+                   [(number? fld5) (number->string fld5)]
+                   [else "missed"]))])
+            String))
+     "missed")
+  (error "accessors broken num-num-sym-sym-sym"))
+
+(unless (equal?
+         (match (ann (read (open-input-string
+                             "#s((str-str-num-num-num #(0 1 2) str-str 2 #(0 1)) one two three four five)"))
+                     Any)
+           [(str-str-num-num-num fld1 fld2 fld3 fld4 fld5)
+            (list fld1 fld2 fld3 fld4 fld5)])
+         (list 'one 'two 'three 'four 'five))
+  (error "prefab pattern matching broken! str-str-num-num-num"))
+
+
+(struct vec ([x : Float] [y : Float]))
+
+
+(struct par-vec ([x : Float] [y : Float]) #:prefab)
+
+
+(: partial-dec (-> Any vec))
+(define (partial-dec x)
+  (cond
+    [(and (par-vec? x)
+          (flonum? (par-vec-x x))
+          (flonum? (par-vec-y x)))
+     (vec (par-vec-x x) (par-vec-y x))]
+    [else (error "invalid encoding")]))

--- a/typed-racket-test/succeed/optional/procedure-top.rkt
+++ b/typed-racket-test/succeed/optional/procedure-top.rkt
@@ -1,0 +1,16 @@
+#lang racket
+
+(module example typed/racket/optional
+  (: id (Procedure -> Procedure))
+  (define (id x) x)
+
+  (: f (Integer -> Integer))
+  (define (f x) (+ x 1))
+
+  (define g (id f))
+
+  (provide g))
+
+(require 'example)
+
+(g 3)

--- a/typed-racket-test/succeed/optional/promise-any.rkt
+++ b/typed-racket-test/succeed/optional/promise-any.rkt
@@ -1,0 +1,11 @@
+#lang racket
+
+(module typed typed/racket/optional
+  (: d Any)
+  (define d (delay (lambda: ([x : Integer]) (+ x 1))))
+  (provide d))
+
+(require 'typed)
+
+((force d) 6)
+

--- a/typed-racket-test/succeed/optional/prompt-tag.rkt
+++ b/typed-racket-test/succeed/optional/prompt-tag.rkt
@@ -1,0 +1,32 @@
+#lang typed/racket/optional
+
+(: pt (Prompt-Tagof String (Integer -> Integer)))
+(define pt (make-continuation-prompt-tag))
+
+;; Test abort
+(call-with-continuation-prompt
+ (λ () (string-append "foo" (abort-current-continuation pt 5)))
+ pt
+ (λ: ([x : Integer]) x))
+
+(: pt2 (Prompt-Tagof Integer ((Integer -> Integer) -> Integer)))
+(define pt2 (make-continuation-prompt-tag))
+
+;; Test call/comp & abort
+(call-with-continuation-prompt
+ (λ () (+ 1 ((inst call-with-composable-continuation
+                   Integer ((Integer -> Integer) -> Integer) Integer)
+             (λ: ([k : (Integer -> Integer)])
+               (abort-current-continuation pt2 k))
+             pt2)))
+ pt2
+ (λ: ([f : (Integer -> Integer)]) (f 5)))
+
+;; Test the default handler
+(: pt3 (Prompt-Tagof Integer ((-> Integer) -> Integer)))
+(define pt3 (make-continuation-prompt-tag))
+
+(+ 2
+   (call-with-continuation-prompt
+    (λ () (+ 1 (abort-current-continuation pt3 (λ () 5))))
+    pt3))

--- a/typed-racket-test/succeed/optional/provide-struct.rkt
+++ b/typed-racket-test/succeed/optional/provide-struct.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+;; Test providing a struct (and its types)
+
+(module t typed/racket/base/optional
+
+  (provide (struct-out foo) wepa)
+
+  (struct foo ((a : Natural)))
+
+  (define (wepa (f : foo))
+    (+ 1 (foo-a f))))
+
+(require 't rackunit)
+
+(check-pred values (foo 1))
+(check-pred values (foo 'a))
+
+(check-exn #rx"\\+: contract violation"
+  (λ () (wepa (foo 'a))))
+
+(check-equal?
+  (foo-a (foo 'a))
+  'a)

--- a/typed-racket-test/succeed/optional/sequenceof-integer.rkt
+++ b/typed-racket-test/succeed/optional/sequenceof-integer.rkt
@@ -1,0 +1,29 @@
+#lang racket/base
+
+(module typed typed/racket/base/optional
+  (provide foo)
+  (: foo (-> (U Integer (Sequenceof Integer)) String))
+  (define (foo x)
+    (if (integer? x)
+        (format "I got an integer: ~a" x)
+        (error "I did not get an integer: ~a" x))))
+
+(module other-typed typed/racket/base/optional
+  (provide bar)
+  (require (submod ".." typed))
+  (define (bar) (foo 0)))
+
+(module contract-test typed/racket/base/optional
+  (define b* : (Sequenceof (Boxof Integer)) (list (box 0)))
+  (provide b*))
+
+(require 'typed
+         'other-typed
+         'contract-test
+         rackunit)
+(check-equal? (foo 0) "I got an integer: 0")
+(check-equal? (bar) "I got an integer: 0")
+(check-not-exn
+  (λ () (set-box! (car b*) 'NaN)))
+(check-not-exn ;; untyped context
+  (λ () (unbox (car b*))))

--- a/typed-racket-test/succeed/optional/shallow-optional-id.rkt
+++ b/typed-racket-test/succeed/optional/shallow-optional-id.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/optional
+
+(module shallow typed/racket/base/shallow
+  (provide xxx)
+  (define xxx '$$$)
+  xxx)
+
+(require 'shallow)
+xxx
+
+(define (f y)
+  xxx)

--- a/typed-racket-test/succeed/optional/struct-match-0.rkt
+++ b/typed-racket-test/succeed/optional/struct-match-0.rkt
@@ -1,0 +1,15 @@
+#lang racket/base
+
+(module s typed/racket/base/optional
+  (require racket/match)
+
+  (struct posn ([x : Real] [y : Real]))
+
+  (: f (-> posn Void))
+  (define (f p)
+    (match p
+     ((posn x y) (void (+ x y)))
+     (_ (void)))))
+
+(require 's)
+

--- a/typed-racket-test/succeed/optional/struct-match-1.rkt
+++ b/typed-racket-test/succeed/optional/struct-match-1.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+
+(module t typed/racket/base
+  (struct posn ([x : Real] [y : Real]))
+  (provide (struct-out posn)))
+
+(module s typed/racket/base/optional
+  (require racket/match
+           (submod ".." t))
+  (: f (-> posn Void))
+  (define (f p)
+    (match p
+     ((posn x y) (void (+ x y)))
+     (_ (void)))))
+
+(require 's)

--- a/typed-racket-test/succeed/optional/submodule-list-0.rkt
+++ b/typed-racket-test/succeed/optional/submodule-list-0.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/optional
+
+;; Test importing a list
+
+(module u racket/base
+  (define x* (list 1))
+  (provide x*))
+
+(require/typed 'u
+  (x* (Listof Integer)))
+
+(+ (car x*) 1)

--- a/typed-racket-test/succeed/optional/submodule-list-1.rkt
+++ b/typed-racket-test/succeed/optional/submodule-list-1.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/optional
+
+;; Test importing a list with incorrect type
+
+(module u racket/base
+  (define x* (list "NaN"))
+  (provide x*))
+
+(require/typed 'u
+  (x* (Listof Integer)))
+
+(ann (append x* (list 1 2 3)) (Listof Integer))

--- a/typed-racket-test/succeed/optional/submodule-opaque-0.rkt
+++ b/typed-racket-test/succeed/optional/submodule-opaque-0.rkt
@@ -1,0 +1,17 @@
+#lang typed/racket/optional
+
+;; Test opaque import
+
+(module u racket/base
+  (struct posn [x y])
+  (define origin (posn 0 0))
+  (provide origin (struct-out posn)))
+
+(require/typed 'u
+  (#:opaque Posn posn?)
+  (origin Posn)
+  (posn (-> Integer Integer Posn))
+  (posn-x (-> Posn Integer)))
+
+(+ (posn-x origin) (posn-x (posn 4 0)))
+

--- a/typed-racket-test/succeed/optional/submodule-optional.rkt
+++ b/typed-racket-test/succeed/optional/submodule-optional.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base/optional
+
+;; optional submodules in optional code
+
+(module t typed/racket/base/optional
+  (: f (-> Real (-> Real Real) Real))
+  (define (f r g)
+    (g (g r)))
+  (provide f))
+(require 't)
+
+(: h (-> Real Real))
+(define (h n)
+  (* n n))
+
+(f 3 h)

--- a/typed-racket-test/succeed/optional/submodule-struct-0.rkt
+++ b/typed-racket-test/succeed/optional/submodule-struct-0.rkt
@@ -1,0 +1,14 @@
+#lang typed/racket/optional
+
+;; Test importing a struct
+
+(module u racket/base
+  (struct posn [x y])
+  (define origin (posn 0 0))
+  (provide origin (struct-out posn)))
+
+(require/typed 'u
+  (#:struct posn ((x : Real) (y : Real)))
+  (origin posn))
+
+(+ (posn-x origin) (posn-y origin))

--- a/typed-racket-test/succeed/optional/submodule-struct-1.rkt
+++ b/typed-racket-test/succeed/optional/submodule-struct-1.rkt
@@ -1,0 +1,15 @@
+#lang typed/racket/optional
+
+(module u racket/base
+  (struct posn [x y])
+  (define origin (posn 0 0))
+  (provide origin (struct-out posn)))
+
+(require/typed 'u
+  (#:struct posn ((x : Symbol) (y : Symbol)))
+  (origin posn))
+(require typed/rackunit)
+
+(check-not-exn
+  (lambda () (posn-x origin)))
+

--- a/typed-racket-test/succeed/optional/submodule.rkt
+++ b/typed-racket-test/succeed/optional/submodule.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/optional
+
+;; Test importing a flat value
+
+(module u racket/base
+  (define x 3)
+  (provide x))
+
+(require/typed 'u
+  (x Byte))
+
+(+ x 1)

--- a/typed-racket-test/succeed/optional/subst-poly-dots.rkt
+++ b/typed-racket-test/succeed/optional/subst-poly-dots.rkt
@@ -1,0 +1,17 @@
+#lang typed/racket/optional
+
+(: f (All (A B ...) (A ... B -> (List (Boxof A) ... B))))
+(define (f . args)
+    (map (inst box A) args))
+
+(: h (-> Nothing))
+(define (h) (h))
+
+(: g (All (A B ...) (A ... B -> (Values (Boxof A) ... B))))
+(define (g . args)
+   (h))
+
+
+(ann ((inst f String Symbol Symbol) "c" "d") (List (Boxof String) (Boxof String)))
+(lambda (x)
+  (ann ((inst g String Symbol Symbol) "c" "d") (values (Boxof String) (Boxof String))))

--- a/typed-racket-test/succeed/optional/toplevel-redefinition.rkt
+++ b/typed-racket-test/succeed/optional/toplevel-redefinition.rkt
@@ -1,0 +1,9 @@
+#lang racket/load
+
+;; Test that variable redefinition works at the top-level
+
+(require typed/racket/optional)
+(: x Integer)
+(define x 3)
+(define x 5)
+

--- a/typed-racket-test/succeed/optional/typed-provide.rkt
+++ b/typed-racket-test/succeed/optional/typed-provide.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+
+;; Test providing a value to an untyped context
+
+(module a typed/racket/base
+  (provide f)
+  (define (f (x : (Boxof (Boxof Integer))))
+    (unbox (unbox x))))
+
+(module b racket/base
+  (provide bbx)
+  (define bbx (box 0)))
+
+(module c typed/racket/base/optional
+  (require (submod ".." a))
+  (require/typed (submod ".." b) (bbx (Boxof (Boxof Integer))))
+  (provide do-c bbx)
+  (define (do-c)
+    (f bbx)))
+
+(require 'a rackunit)
+(check-exn #rx"f: contract violation"
+  (lambda () (f 0)))
+
+(require 'c)
+(check-not-exn (lambda () (unbox bbx)))
+(check-exn #rx"f: contract violation"
+  do-c)

--- a/typed-racket-test/succeed/optional/typed-untyped-id.rkt
+++ b/typed-racket-test/succeed/optional/typed-untyped-id.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+(module a racket/base
+  (require racket/contract)
+  (provide
+    (contract-out [f0 (-> symbol? symbol?)]))
+  (define (f0 x) 'a))
+
+(module b typed/racket/base
+  (provide f1)
+  (define (f1 (x : Symbol)) : Symbol 'a))
+
+(module c racket/base
+  (require (submod ".." a) (submod ".." b) typed/untyped-utils)
+  (define-typed/untyped-identifier f f1 f0)
+  (provide f))
+
+(module d typed/racket/base/optional
+  ;; fail = (require (submod ".." c))
+  (require/typed (submod ".." c)
+                 (f (-> Symbol Symbol)))
+  f)
+
+(require 'd)

--- a/typed-racket-test/succeed/optional/untyped-struct-properties-with-self.rkt
+++ b/typed-racket-test/succeed/optional/untyped-struct-properties-with-self.rkt
@@ -1,0 +1,15 @@
+#lang racket
+
+(module foo racket
+  (define-values (prop:hi hi? hi-ref) (make-struct-type-property 'hi))
+  (provide prop:hi hi? hi-ref yyy)
+  (define yyy 10))
+
+(module ty-foo typed/racket/optional
+  (require/typed (submod ".." foo) [prop:hi (Struct-Property (-> Self Any))] #;[#:opaque Hi hi?]  [hi-ref (-> Any (-> Any Void))])
+  (struct bar () #:property prop:hi (λ ([self : bar])
+                                      (display (format "instance bar\n" ))))
+  (hi-ref (bar) #;(assert (bar) hi?))
+  )
+
+(require 'ty-foo)

--- a/typed-racket-test/succeed/optional/val-ctc-test.rkt
+++ b/typed-racket-test/succeed/optional/val-ctc-test.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket/base/optional
+
+;; A symbol type should generate a contract that accepts the same symbol
+
+(module uuu racket/base
+  (define FOUNDING 'FOUNDING)
+  (provide FOUNDING))
+
+(require/typed/provide 'uuu
+  (FOUNDING 'FOUNDING))

--- a/typed-racket-test/succeed/optional/with-type.rkt
+++ b/typed-racket-test/succeed/optional/with-type.rkt
@@ -1,0 +1,22 @@
+#lang scheme
+(require typed/racket/optional)
+
+(with-type #:result Number 3)
+
+(let ([x "hello"])
+  (with-type #:result String
+    #:freevars ([x String])
+    (string-append x ", world")))
+
+(define-values (a b)
+  (with-type #:result (values Number String)
+             (values 3 "foo")))
+
+(with-type ([fun (Number -> Number)]
+            [val Number])
+  (define (fun x) x)
+  (define val 17))
+
+(fun val)
+val
+

--- a/typed-racket-test/succeed/shallow/accessors.rkt
+++ b/typed-racket-test/succeed/shallow/accessors.rkt
@@ -1,0 +1,259 @@
+#lang typed/racket/shallow
+
+;; Test a variety of accessors for failures
+
+(module untyped racket
+  (define pair0 (cons "A" "B"))
+  (define mpair0 (mcons "A" "B"))
+  (define list0 (list "A" "B" "C"))
+  (define vector0 (vector "A" "B"))
+  (define box0 (box "A"))
+  (define hash0 (make-hash (list (cons 'A "A"))))
+  (define set0 (set "A"))
+  (define (function0 x) "not symbol")
+  (struct mystruct (ref))
+  (define mystruct0 (mystruct "not symbol"))
+  (define class0
+    (class object%
+      (super-new)
+      (field (field0 "not symbol"))
+      (define/public (method0 x) "not symbol")
+      (define/public (method1 x) "not symbol")
+      (define/public (method2 x) this)
+      (define/public (method3 x) "not symbol")))
+  (define object0 (new class0))
+  (provide pair0 mpair0 list0 vector0 box0 hash0 set0 function0
+           (struct-out mystruct) mystruct0 class0 object0))
+
+(module shallow typed/racket/shallow
+  (: function1 (-> String String))
+  (define (function1 x) "B")
+  (define-type Class1
+   (Class
+     (field (field0 String))
+     (method0 (-> String String))
+     (method1 (-> String String))
+     (method2 (-> String (Instance Class1)))
+     (method3 (-> String String))))
+  (: class1 Class1)
+  (define class1
+    (class object%
+      (super-new)
+      (field (field0 "not symbol"))
+      (define/public (method0 x) "not symbol")
+      (define/public (method1 x) "not symbol")
+      (define/public (method2 x) this)
+      (define/public (method3 x) "not symbol")))
+  (define object1 (new class1))
+  (provide function1 class1 object1))
+
+(define-type Class0
+  (Class (field (field0 Symbol))
+         (method0 (-> Symbol Symbol))
+         (method1 (-> Symbol Symbol))
+         (method2 (-> Symbol (Instance Class0)))
+         (method3 (-> Symbol Symbol))))
+
+(define-type Class1
+  (Class (field (field0 Symbol))
+         (method0 (-> Symbol Symbol))
+         (method1 (-> Symbol Symbol))
+         (method2 (-> Symbol (Instance Class1)))
+         (method3 (-> Symbol Symbol))))
+
+(require typed/rackunit typed/racket/random)
+(require/typed 'untyped
+  (pair0 (Pairof Symbol Symbol))
+  (mpair0 (MPairof Symbol Symbol))
+  (list0 (Listof Symbol))
+  (vector0 (Vectorof Symbol))
+  (box0 (Boxof Symbol))
+  (hash0 (HashTable Symbol Symbol))
+  (set0 (Setof Symbol))
+  (function0 (-> Symbol Symbol))
+  (#:struct mystruct ((ref : Symbol)))
+  (mystruct0 mystruct)
+  (class0 Class0)
+  (object0 (Instance Class0)))
+
+(require/typed 'shallow
+  (function1 (-> Symbol Symbol))
+  (class1 Class1)
+  (object1 (Instance Class1)))
+
+;; -----------------------------------------------------------------------------
+;; pair
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (car pair0)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (cdr pair0)))
+
+;; -----------------------------------------------------------------------------
+;; mpair
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (mcar mpair0)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (mcdr mpair0)))
+
+;; -----------------------------------------------------------------------------
+;; list
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (car list0)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (cadr list0)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (third list0)))
+
+;; -----------------------------------------------------------------------------
+;; vector
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (vector-ref vector0 0)))
+
+; no type: vector*-ref
+
+;; -----------------------------------------------------------------------------
+;; box
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (unbox box0)))
+
+; no type: unbox*
+
+;; -----------------------------------------------------------------------------
+;; hash
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (hash-ref hash0 'A)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (hash-ref! hash0 'A (lambda () 'B))))
+
+;; -----------------------------------------------------------------------------
+;; sequence
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (sequence-ref list0 0)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (sequence-ref vector0 0)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (random-ref list0)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (random-ref vector0)))
+
+; no type: (sequence-ref hash0 'A)
+; no type: (random-ref hash0)
+
+;; -----------------------------------------------------------------------------
+;; no type: stream-first stream-ref
+
+;; -----------------------------------------------------------------------------
+;; no type: dict-ref
+
+;; -----------------------------------------------------------------------------
+;; set
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (set-first list0)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (set-first set0)))
+
+; no type: (set-first hash0)
+
+;; -----------------------------------------------------------------------------
+;; procedure
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (function0 'A)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (apply function0 (list 'A))))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (function1 'A)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (apply function1 (list 'A))))
+
+; no type: keyword-apply
+
+;; -----------------------------------------------------------------------------
+;; struct
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (mystruct-ref mystruct0)))
+
+;; -----------------------------------------------------------------------------
+;; class / object
+
+;; --- bad output
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (symbol->string (send object0 method0 'A))))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (symbol->string (send* object0 (method0 'A) (method1 'A)))))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (symbol->string (send+ object0 (method2 'A) (method3 'A)))))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (get-field field0 object0)))
+
+;; --- bad input
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (send object1 method0 'A)))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (send* object1 (method0 'A) (method1 'A))))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (send+ object1 (method2 'A) (method3 'A))))
+
+(check-exn exn:fail:contract?
+  (lambda ()
+    (get-field field0 object1)))
+
+; no type: send/apply send/keyword-apply dynamic-send with-method(expansion) dynamic-get-field class-field-accessor send-generic
+

--- a/typed-racket-test/succeed/shallow/alias.rkt
+++ b/typed-racket-test/succeed/shallow/alias.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/base/shallow
+
+;; Test trusted vs. untrusted primitives
+;; - + is a trusted identifier, its result is not checked
+;; - (begin +) is not a trusted identifier --- even though it evaluates to
+;;   a function that could be trusted --- its result is checked
+
+(+ 2 2)
+((begin +) 2 2)

--- a/typed-racket-test/succeed/shallow/ann-inst.rkt
+++ b/typed-racket-test/succeed/shallow/ann-inst.rkt
@@ -1,0 +1,6 @@
+#lang typed/racket/base/shallow
+
+;; Test the `ann` and `inst` forms
+
+((ann car (All (A B) (-> (Pairof A B) A))) '(A B))
+((inst car Symbol (Listof Symbol)) '(A B))

--- a/typed-racket-test/succeed/shallow/app-hetero.rkt
+++ b/typed-racket-test/succeed/shallow/app-hetero.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+(require rackunit)
+
+;; Test applications of `vector-ref` and `vector`, because these identifiers
+;;  have special typing rules
+
+(module u racket/base
+  (provide f)
+  (define (f b)
+    ((vector-ref b 0) 2)))
+
+(module t typed/racket/base/shallow
+  (provide test1 test0)
+  (require/typed (submod ".." u)
+    (f (-> (Vector (-> String String)) Integer)))
+
+  (: q (-> String String))
+  (define (q n)
+    (string-append n n))
+
+  (define (test0)
+    (f (vector q)))
+
+  (define b (vector q))
+  (define (test1)
+    (f b)))
+(require 't)
+
+(check-exn #rx"shape-check"
+  test0)
+
+(check-exn #rx"shape-check"
+  test1)

--- a/typed-racket-test/succeed/shallow/apply-append.rkt
+++ b/typed-racket-test/succeed/shallow/apply-append.rkt
@@ -1,0 +1,4 @@
+#lang typed/racket/shallow
+
+(apply append '((1 2 3) (4 5 6)))
+(apply append (list (list 1 2 3) (list 4 5 6)))

--- a/typed-racket-test/succeed/shallow/apply-dots-list.rkt
+++ b/typed-racket-test/succeed/shallow/apply-dots-list.rkt
@@ -1,0 +1,23 @@
+#lang typed/racket/shallow
+
+(define tests (list (list (λ() 1) 1 "test 1")
+                   (list (λ() 2) 2 "test 2")))
+
+; Comment out the type signature when running untyped
+(: check-all (All (A ...) ((List (-> A) A String) ... A -> Void)))
+(define (check-all . tests)
+ (let aux ([tests tests]
+           [num-passed 0])
+   (if (null? tests)
+       (printf "~a tests passed.\n" num-passed)
+       (let ((test (car tests)))
+         (let ((actual ((car test)))
+               (expected (cadr test))
+               (msg (caddr test)))
+           (if (equal? actual expected)
+               (aux (cdr tests) (+ num-passed 1))
+               (printf "Test failed: ~a. Expected ~a, got ~a.\n"
+                       msg expected actual)))))))
+
+(apply check-all tests) ; Works in untyped, but not in typed
+(check-all (car tests) (cadr tests)) ; Works in typed or untyped

--- a/typed-racket-test/succeed/shallow/apply.rkt
+++ b/typed-racket-test/succeed/shallow/apply.rkt
@@ -1,0 +1,33 @@
+#lang typed/racket/base/shallow
+
+;; Test that `(apply f ...)`  does not check its result when `f` is a
+;;  trusted function
+
+(void (apply string-append '("one" "two" "three")))
+
+
+;; Apply works when we need protection
+
+(module u racket/base
+  (provide f0 f1 f2)
+  (define (f0) (values))
+  (define (f1) (values 'a))
+  (define (f2) (values 'a 'b)))
+
+(require/typed 'u
+  (f0 (-> (Values)))
+  (f1 (-> Symbol))
+  (f2 (-> (Values Symbol Symbol))))
+
+(define-values [] (apply f0 '()))
+
+(: a Symbol)
+(define-values [a] (apply f1 '()))
+
+(: b Symbol)
+(: c Symbol)
+(define-values [b c] (apply f2 '()))
+
+
+;; One more apply
+(call-with-values (lambda () (apply values (ann '(x x x) (Listof Symbol)))) void)

--- a/typed-racket-test/succeed/shallow/async-channel-contract.rkt
+++ b/typed-racket-test/succeed/shallow/async-channel-contract.rkt
@@ -1,0 +1,19 @@
+#lang racket/load
+
+;; Test typed-untyped interaction with channels
+
+(module typed typed/racket/shallow
+  (require typed/racket/async-channel)
+  (: ch (Async-Channelof (Boxof Integer)))
+  (define ch (make-async-channel))
+  (: putter (-> Thread))
+  (define (putter)
+    (thread (λ () (async-channel-put ch (box 3)))))
+  (provide putter ch))
+
+(require 'typed racket/async-channel rackunit)
+(putter)
+(check-not-exn
+  (lambda ()
+    (set-box! (async-channel-get ch) "not an integer")))
+

--- a/typed-racket-test/succeed/shallow/bad-typed-identifier.rkt
+++ b/typed-racket-test/succeed/shallow/bad-typed-identifier.rkt
@@ -1,0 +1,15 @@
+#lang typed/racket/base/shallow
+
+(module bad racket/base
+  (provide bad)
+  (define (bad x) 'xxx))
+
+(require/typed 'bad
+  (bad (-> Any String)))
+
+(define f (vector bad))
+(define g (vector-ref f 0)) ;; g is typed id, but cannot trust type
+
+(require typed/rackunit)
+(check-exn #rx"shape-check"
+  (lambda () (string-append (g 0) "xxx")))

--- a/typed-racket-test/succeed/shallow/bad-vector-ref.rkt
+++ b/typed-racket-test/succeed/shallow/bad-vector-ref.rkt
@@ -1,0 +1,30 @@
+#lang racket/base
+
+;; Test applications of `vector-ref` that should fail due to mis-matched
+;;  values and type constructors
+
+(module t typed/racket/shallow
+  (: f (-> (Vectorof Natural) Natural))
+  (define (f x)
+    (+ (vector-ref x 0)
+       (vector-ref x 1)))
+  (: g (-> (Vectorof (Vectorof Natural)) Natural))
+  (define (g x)
+    (define v (vector-ref x 0))
+    (+ (vector-ref (vector-ref x 0) 0) (vector-ref v 1)))
+  (: h (-> (Vector Natural Symbol) Natural))
+  (define (h x)
+    (vector-ref x 0))
+
+  (provide f g h))
+
+(require 't racket/contract rackunit)
+
+(check-exn #rx"shape-check"
+  (λ () (f (vector 4 'A 4 4))))
+
+(check-exn #rx"shape-check"
+  (λ () (g (vector 3))))
+
+(check-exn #rx"shape-check"
+  (λ () (h (vector 1 'two 3))))

--- a/typed-racket-test/succeed/shallow/caar.rkt
+++ b/typed-racket-test/succeed/shallow/caar.rkt
@@ -1,0 +1,6 @@
+#lang typed/racket/base/shallow
+
+;; Test that nested elimination forms get checked
+
+(define (f)
+  (car (car '((1)))))

--- a/typed-racket-test/succeed/shallow/call-comp.rkt
+++ b/typed-racket-test/succeed/shallow/call-comp.rkt
@@ -1,0 +1,28 @@
+#lang typed/racket/shallow
+
+(require racket/control)
+
+(: tag (Prompt-Tagof Integer (Integer -> Integer)))
+(define tag (make-continuation-prompt-tag))
+
+(call-with-continuation-prompt
+ (λ ()
+    (+ 1
+       ((inst call-with-composable-continuation Integer (Integer -> Integer)
+              Integer)
+        (lambda: ([k : (Integer -> Integer)]) (k 1))
+        tag)))
+ tag
+ (λ: ([x : Integer]) (+ 1 x)))
+
+((inst call/ec Integer Integer Integer) (lambda ([f : (Integer Integer -> Nothing)]) (f 0 1)))
+(let/cc k : (values String Symbol Boolean)
+   (values
+    (+ 5 (k "result arity matters, only first arg can be a different type" 'hahaha #t))
+    'must-be-symbol
+    #f))
+
+(: r : (All (a b ...) (-> a b ... b (values a b ... b))))
+(define (r A . bs) (let/ec break : (values a b ... b) (apply break A bs)))
+(r 0 1 2 3 4 5)
+

--- a/typed-racket-test/succeed/shallow/case-lambda-rest.rkt
+++ b/typed-racket-test/succeed/shallow/case-lambda-rest.rkt
@@ -1,0 +1,12 @@
+#lang racket/load
+
+(module a typed/racket/shallow
+  (provide foo)
+  (: foo
+     (case-> 
+       (Number String * -> Number)
+       (Number String String * -> Number)))
+  (define (foo x . args) x))
+
+(require 'a)
+(foo 3 "x")

--- a/typed-racket-test/succeed/shallow/case-lambda.rkt
+++ b/typed-racket-test/succeed/shallow/case-lambda.rkt
@@ -1,0 +1,72 @@
+#lang racket/base
+
+(module t typed/racket/base/shallow
+  (: f0 (case-> (-> Symbol Symbol)))
+  (define f0
+    (case-lambda
+      [(x) x]))
+
+  (: f1 (case-> (-> Symbol Symbol)
+                (-> String String String)))
+  (define f1
+    (case-lambda
+      [(x) x]
+      [(y z) (string-append y z)]))
+
+  (: f2 (case-> (-> String String String)
+                (-> Symbol Symbol)))
+  (define f2
+    (case-lambda
+      [(x) x]
+      [(y z) (string-append y z)]))
+  (provide f0 f1 f2))
+
+(require 't rackunit)
+
+(check-not-exn
+  (lambda () (f0 'ok)))
+
+(check-exn exn:fail:contract?
+  (lambda () (f0 42)))
+
+(check-not-exn
+  (lambda () (f1 'ok)))
+
+(check-not-exn
+  (lambda () (f1 "a" "b")))
+
+(check-exn exn:fail:contract?
+  (lambda () (f1 42)))
+
+(check-exn exn:fail:contract?
+  (lambda () (f1 "a" 'b)))
+
+(check-not-exn
+  (lambda () (f2 'ok)))
+
+(check-not-exn
+  (lambda () (f2 "a" "b")))
+
+(check-exn exn:fail:contract?
+  (lambda () (f2 42)))
+
+(check-exn exn:fail:contract?
+  (lambda () (f2 "a" 'b)))
+
+;; ---
+
+(module u racket/base
+  (define f1
+    (case-lambda
+      [(x) x]
+      [(y z) 'oops]))
+  (provide f1))
+
+(module t1 typed/racket/base/shallow
+  (require/typed (submod ".." u)
+    (f1 (case-> (-> Symbol Symbol)
+                (-> String String String))))
+  (require typed/rackunit)
+  (check-exn exn:fail:contract?
+    (lambda () (f1 "a" "b"))))
+(require 't1)

--- a/typed-racket-test/succeed/shallow/cast-mod.rkt
+++ b/typed-racket-test/succeed/shallow/cast-mod.rkt
@@ -1,0 +1,116 @@
+#lang typed/racket/base/shallow
+
+(require typed/rackunit)
+
+(check-equal? (cast 2 Number) 2)
+(check-equal? (cast 2 Integer) 2)
+(check-equal? (cast (list 2 4) (Listof Byte)) (list 2 4))
+(check-pred vector? (cast (vector 2 4) (Vectorof Byte)))
+
+(check-equal? ((cast (lambda (x) 7) (String -> Number)) "seven") 7)
+
+(: pos-fx-sub1 : Positive-Fixnum -> Nonnegative-Fixnum)
+(define (pos-fx-sub1 x)
+  (sub1 x))
+
+(check-equal? ((cast pos-fx-sub1 (Number -> Number)) 5) 4)
+
+(check-exn #rx"shape-check"
+           (λ () ((cast pos-fx-sub1 (Number -> Number)) 0.5) 4))
+
+(check-exn #rx"shape-check"
+           (λ () ((cast pos-fx-sub1 (String -> String)) "hello")))
+
+(check-exn #rx"shape-check"
+           (λ () ((cast pos-fx-sub1 (Any -> Any)) "hello")))
+
+(let ()
+  (: v : Boolean)
+  (define v #f)
+  (: f : Boolean -> Boolean)
+  (define (f x)
+    (set! v x)
+    x)
+  (test-case "cast on mutator functions"
+   (check-equal? v #f)
+   (check-equal? ((cast f (Boolean -> Boolean)) #t) #t)
+   (check-equal? v #t)
+   (check-exn #rx"shape-check"
+              (λ () ((cast f (String -> String)) "hello")))
+   (check-equal? v #t
+                 "if the previous test hadn't errored, this would be \"hello\" with type Boolean")))
+
+(let () "cast on mutable boxes" ;; TODO should be test-case
+  (: b1 : (Boxof Integer))
+  (define b1 (box 42))
+  (define b2 (cast b1 (Boxof String)))
+  (define b3 (ann b1 BoxTop))
+  (define b4 (cast b3 (Boxof (U Integer String))))
+  (check-equal? (unbox b1) 42)
+  (check-equal? (unbox b4) 42)
+  (check-not-exn (λ () (set-box! b2 "hi")))
+  (check-exn #rx"shape-check" (lambda () (unbox b1)))
+  (check-not-exn (λ () (set-box! b4 "hello")))
+  (check-exn #rx"shape-check" (lambda () (unbox b1))))
+
+(let () "cast on mutable vectors" ;; TODO test-case
+  (: v1 : (Vectorof Integer))
+  (define v1 (vector 42))
+  (define v2 (cast v1 (Vectorof String)))
+  (define v3 (ann v1 VectorTop))
+  (define v4 (cast v3 (Vectorof (U Integer String))))
+  (check-equal? (vector-ref v1 0) 42)
+  (check-equal? (vector-ref v4 0) 42)
+  (check-not-exn (λ () (vector-set! v2 0 "hi")))
+  (check-exn #rx"shape-check" (lambda () (vector-ref v1 0)))
+  (check-not-exn (λ () (vector-set! v4 0 "hello")))
+  (check-exn #rx"shape-check" (lambda () (vector-ref v1 0))))
+
+;; Struct definitions need to be at the module level for some reason.
+(struct (X) s ([i : X]) #:mutable #:transparent)
+(let () "cast on mutable structs" ;; TODO test-case
+  (: s1 : (s Integer))
+  (define s1 (s 42))
+  (define s2 (cast s1 (s String)))
+  (define s3 (ann s1 Any))
+  (define s4 (cast s3 (s (U Integer String))))
+  (check-equal? (s-i s1) 42)
+  (check-equal? (s-i s4) 42)
+  (check-not-exn (λ () (set-s-i! s2 "hi")))
+  (check-exn #rx"shape-check" (lambda () (s-i s1)))
+  (check-not-exn (λ () (set-s-i! s4 "hello")))
+  (check-exn #rx"shape-check" (lambda () (s-i s1))))
+
+(test-case "cast on intersections involving recursive types"
+  (define-type T
+    (Rec T (U String (Listof T))))
+  (: f : (Listof T) -> Any)
+  (define (f x)
+    (if (andmap list? x)
+        (cast x Any)
+        #f))
+  (check-equal? (f (list "a" "b" "c")) #f)
+  (check-equal? (f (list (list "a") (list "b") (list "c")))
+                (list (list "a") (list "b") (list "c"))))
+
+(test-case "cast in dead code"
+  (check-equal? (if #true 1 (cast 2 Integer))
+                1)
+  (check-equal? (if #false (cast 1 Integer) 2)
+                2)
+  (check-equal? (if #true 1 (list (cast 2 Integer) (cast 3 Integer)))
+                1)
+  (check-equal? (if #true 1 `#&,(cast 2 Integer))
+                1)
+  (check-equal? (if #true 1 `#(,(cast 2 Integer) ,(cast 3 Integer)))
+                1)
+  (check-equal? (if #true 1 `#hash([,(cast 2 Integer) . ,(cast 3 Integer)]))
+                1)
+  (check-equal? (if #true 1 `#s(struct ,(cast 2 Integer) ,(cast 3 Integer)))
+                1)
+  (check-not-false ;; check that this doesn't have an internal error
+   (λ () (begin
+           (error "hi")
+           (cast (string->number "42") Integer))))
+  )
+

--- a/typed-racket-test/succeed/shallow/cast-top-level.rkt
+++ b/typed-racket-test/succeed/shallow/cast-top-level.rkt
@@ -1,0 +1,87 @@
+#lang racket/load
+
+(require typed/racket/base/shallow)
+(require typed/rackunit)
+
+(cast 2 Number)
+(cast 2 Integer)
+(cast (list 2 4) (Listof Byte))
+(cast (vector 2 4) (Vectorof Byte))
+
+(check-equal? (cast 2 Number) 2)
+(check-equal? (cast 2 Integer) 2)
+(check-equal? (cast (list 2 4) (Listof Byte)) (list 2 4))
+(check-pred vector? (cast (vector 2 4) (Vectorof Byte)))
+
+(check-equal? ((cast (lambda (x) 7) (String -> Number)) "seven") 7)
+
+(: pos-fx-sub1 : Positive-Fixnum -> Nonnegative-Fixnum)
+(define (pos-fx-sub1 x)
+  (sub1 x))
+
+(check-equal? ((cast pos-fx-sub1 (Number -> Number)) 5) 4)
+
+(check-exn #rx"shape-check.*Positive-Fixnum"
+           (λ () ((cast pos-fx-sub1 (Number -> Number)) 0.5) 4))
+
+(check-exn #rx"shape-check.*Positive-Fixnum"
+           (λ () (void ((cast pos-fx-sub1 (String -> String)) "hello"))))
+
+(check-exn #rx"shape-check.*Positive-Fixnum"
+           (λ () (void ((cast pos-fx-sub1 (Any -> Any)) "hello"))))
+
+(test-case "cast on mutator functions"
+  (: v : Boolean)
+  (define v #f)
+  (: f : Boolean -> Boolean)
+  (define (f x)
+    (set! v x)
+    x)
+
+  (check-equal? v #f)
+  (check-equal? ((cast f (Boolean -> Boolean)) #t) #t)
+  (check-equal? v #t)
+  (check-exn #rx"shape-check.*Boolean"
+             (λ () ((cast f (String -> String)) "hello")))
+  (check-equal? v #t
+                "if the previous test hadn't errored, this would be \"hello\" with type Boolean"))
+
+(test-case "cast on mutable boxes"
+  (: b1 : (Boxof Integer))
+  (define b1 (box 42))
+  (define b2 (cast b1 (Boxof String)))
+  (check-equal? (unbox b1) 42)
+  (check-not-exn
+             (λ () (set-box! b2 "hi")))
+  (check-not-equal? (unbox b2) 42
+                "he previous test didn't error, so this value is \"hi\"")
+  (check-exn #rx"shape-check"
+    (lambda ()
+      (unbox b1))))
+
+(test-case "cast on mutable vectors"
+  (: v1 : (Vectorof Integer))
+  (define v1 (vector 42))
+  (define v2 (cast v1 (Vectorof String)))
+  (check-equal? (vector-ref v1 0) 42)
+  (check-not-exn
+             (λ () (vector-set! v2 0 "hi")))
+  (check-not-equal? (vector-ref v2 0) 42
+                "the previous test didn't errored, so this value is \"hi\"")
+  (check-exn #rx"shape-check"
+    (lambda () (vector-ref v1 0))))
+
+;; Struct definitions need to be at the top level for some reason.
+(struct (X) s ([i : X]) #:mutable)
+(test-case "cast on mutable structs"
+  (: s1 : (s Integer))
+  (define s1 (s 42))
+  (define s2 (cast s1 (s String)))
+  (check-equal? (s-i s1) 42)
+  (check-not-exn
+             (λ () (set-s-i! s2 "hi")))
+  (check-not-equal? (s-i s2) 42
+                "the previous test didn't error, so this value is \"hi\"")
+  (check-exn #rx"shape-check"
+    (lambda () (s-i s1))))
+

--- a/typed-racket-test/succeed/shallow/channel-contract.rkt
+++ b/typed-racket-test/succeed/shallow/channel-contract.rkt
@@ -1,0 +1,16 @@
+#lang racket/load
+
+;; Test typed-untyped interaction with channels
+
+(module typed typed/racket/shallow
+  (: ch (Channelof (Boxof Integer)))
+  (define ch (make-channel))
+  (: putter (-> Thread))
+  (define (putter)
+    (thread (λ () (channel-put ch (box 3)))))
+  (provide putter ch))
+
+(require 'typed)
+(putter)
+(set-box! (channel-get ch) "not an integer")
+

--- a/typed-racket-test/succeed/shallow/check-expect.rkt
+++ b/typed-racket-test/succeed/shallow/check-expect.rkt
@@ -1,0 +1,6 @@
+#lang typed/racket/shallow
+
+(require typed/test-engine/scheme-tests)
+(check-expect 4 4)
+
+(test)

--- a/typed-racket-test/succeed/shallow/check-within.rkt
+++ b/typed-racket-test/succeed/shallow/check-within.rkt
@@ -1,0 +1,17 @@
+
+#lang typed/racket/shallow
+
+(require scheme/math typed/test-engine/scheme-tests)
+
+(define-struct: circle ({radius : Number}))
+(: circle-area (circle -> Number))
+
+(check-within (+ 1 2.14) pi .1)
+(check-range 2 1 3)
+(check-member-of 'a 'b 'c 'd 'a 'z)
+(check-error (error "fail") "fail")
+
+(define (circle-area c)
+ (* pi (circle-radius c) (circle-radius c)))
+
+(test)

--- a/typed-racket-test/succeed/shallow/cl-bug.rkt
+++ b/typed-racket-test/succeed/shallow/cl-bug.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket/shallow
+
+(: f (case-lambda (Integer * -> Integer) (Number * -> Number)))
+(define (f . x) (+ 1 2))
+
+(: f4 (case-lambda (Integer * -> Integer) (Number * -> Number)))
+(define (f4 . x) (apply + x))

--- a/typed-racket-test/succeed/shallow/contract-conversion-error.rkt
+++ b/typed-racket-test/succeed/shallow/contract-conversion-error.rkt
@@ -1,0 +1,7 @@
+#lang racket/load
+
+;; two cases of arity 1, ok for shallow
+
+(module a typed/racket/shallow (define v values) (provide v))
+(require 'a)
+v

--- a/typed-racket-test/succeed/shallow/control-test-3.rkt
+++ b/typed-racket-test/succeed/shallow/control-test-3.rkt
@@ -1,0 +1,24 @@
+#lang racket/load
+
+(module untyped racket
+  (provide call-f)
+
+  (define (call-f f)
+    (call-with-continuation-prompt
+     (λ () (f 0))
+     (default-continuation-prompt-tag)
+     (λ (x) (x "string")))))
+
+(module typed typed/racket/shallow
+  (require/typed 'untyped
+                 [call-f ((Integer -> Integer) -> String)])
+
+  ;; shallow should check the result of call-f and error
+  (call-f
+   (λ: ([x : Integer])
+     ;; this abort should wrap with an Any wrapper
+     (abort-current-continuation
+      (default-continuation-prompt-tag)
+      (λ (x) x)))))
+
+(require 'typed)

--- a/typed-racket-test/succeed/shallow/control-test-6.rkt
+++ b/typed-racket-test/succeed/shallow/control-test-6.rkt
@@ -1,0 +1,20 @@
+#lang racket/load
+
+(module typed typed/racket/shallow
+  (provide f)
+
+  (: f (-> Void))
+  (define (f)
+    (abort-current-continuation
+     (default-continuation-prompt-tag)
+     (λ: ([x : Number]) (+ 1 x)))))
+
+(module untyped racket
+  (require 'typed)
+
+  (call-with-continuation-prompt
+   (λ () (f))
+   (default-continuation-prompt-tag)
+   (λ (f) (f 3))))
+
+(require 'untyped)

--- a/typed-racket-test/succeed/shallow/dead-code-values.rkt
+++ b/typed-racket-test/succeed/shallow/dead-code-values.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/shallow
+
+;; Test the 'values' case in defender/defender protect-codomain,
+;; ... application returns +1 results that need cod checks
+;; ... but also send the rewritten code through the optimizer
+
+(: forth-eval (-> Any Any (Values Symbol Symbol)))
+(define (forth-eval E S)
+  (match 'any
+    [(? pair? E+S)
+     ;; dead code
+     (values (car E+S) (cdr E+S))]))

--- a/typed-racket-test/succeed/shallow/deep-shallow-id-0.rkt
+++ b/typed-racket-test/succeed/shallow/deep-shallow-id-0.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/shallow
+
+(module deep typed/racket/base
+  (provide xxx)
+  (define xxx '$$$)
+  xxx)
+
+(require 'deep)
+xxx
+
+(define (f y)
+  xxx)

--- a/typed-racket-test/succeed/shallow/deep-shallow-id-1.rkt
+++ b/typed-racket-test/succeed/shallow/deep-shallow-id-1.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket/base/shallow
+
+(module deep typed/racket/base
+  (provide v->v)
+  (: v->v (-> (Vectorof Real) (Vectorof Symbol)))
+  (define (v->v vr)
+    (define n1 (vector-ref vr 0))
+    (define s1 (string->symbol (number->string n1)))
+    (vector 'a s1)))
+
+(require 'deep typed/rackunit)
+
+(check-exn #rx"v->v: contract violation"
+  (lambda () (v->v (cast (vector "X") (Vectorof Real)))))
+
+(check-exn #rx"v->v: contract violation"
+  (lambda ()
+    (vector-set!
+      (cast (v->v (vector 1)) (Vectorof String))
+      0 "X")))
+

--- a/typed-racket-test/succeed/shallow/deep-with-type.rkt
+++ b/typed-racket-test/succeed/shallow/deep-with-type.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base
+
+;; neither id should be bound in t/r lang
+
+(require syntax/macro-testing typed/rackunit)
+
+(check-exn #rx"unbound identifier"
+  (lambda () (convert-compile-time-error with-type-shallow)))
+
+(check-exn #rx"unbound identifier"
+  (lambda () (convert-compile-time-error with-type-optional)))
+

--- a/typed-racket-test/succeed/shallow/define-syntax.rkt
+++ b/typed-racket-test/succeed/shallow/define-syntax.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/shallow
+
+;; Test that a simple macro works in locally-defensive code
+
+(define-syntax-rule (yo lo)
+  (+ lo lo))
+
+(: f (-> Integer Integer))
+(define (f x)
+  (yo (yo x)))
+
+(f 42)

--- a/typed-racket-test/succeed/shallow/define-typed-untyped-identifier-syntax-properties.rkt
+++ b/typed-racket-test/succeed/shallow/define-typed-untyped-identifier-syntax-properties.rkt
@@ -1,0 +1,84 @@
+#lang racket
+
+;; https://github.com/racket/typed-racket/issues/315
+
+(module t/u racket
+  (provide typed/untyped
+           (rename-out [typed/untyped-typed original-typed-req-stx]
+                       [typed/untyped-untyped original-untyped-req-stx]))
+  
+  (require typed/untyped-utils
+           racket/require-syntax
+           (for-syntax syntax/strip-context))
+  
+  (define-require-syntax (typed/untyped-typed stx)
+    (syntax-case stx ()
+      [(_ m s) (replace-context stx #'(submod m s typed))]))
+  
+  (define-require-syntax (typed/untyped-untyped stx)
+    (syntax-case stx ()
+      [(_ m s) (replace-context stx #'(submod m s untyped))]))
+  
+  (define-typed/untyped-identifier typed/untyped
+    typed/untyped-typed
+    typed/untyped-untyped))
+
+(module m racket
+  (module typed typed/racket
+    (provide test-value typed-test-value)
+    (define test-value : Symbol 'is-typed)
+    (define typed-test-value : Symbol 'present))
+  (module untyped typed/racket/no-check
+    (provide test-value untyped-test-value)
+    (define test-value : Symbol 'is-untyped)
+    (define untyped-test-value : Symbol 'present)))
+
+(module test-typed-1 typed/racket/shallow
+  (require (submod ".." t/u))
+  (require typed/rackunit)
+  (require (original-typed-req-stx ".." m))
+  (check-equal? test-value 'is-typed)
+  (check-equal? typed-test-value 'present))
+
+(module test-typed-2 typed/racket/shallow
+  (require (submod ".." t/u))
+  (require typed/rackunit)
+  (require/typed (typed/untyped ".." m)
+    ;; shallow gets the untyped id
+    (test-value Symbol)
+    (untyped-test-value Symbol))
+  (check-equal? test-value 'is-untyped)
+  (check-equal? untyped-test-value 'present))
+
+(module test-typed-3 typed/racket/shallow
+  (require (submod ".." t/u))
+  (require typed/rackunit)
+  (define-syntax renamer (make-rename-transformer #'original-typed-req-stx))
+  (require (renamer ".." m))
+  (check-equal? test-value 'is-typed)
+  (check-equal? typed-test-value 'present))
+
+(module test-untyped-1 racket
+  (require (submod ".." t/u))
+  (require rackunit)
+  (require (original-untyped-req-stx ".." m))
+  (check-equal? test-value 'is-untyped)
+  (check-equal? untyped-test-value 'present))
+
+(module test-untyped-2 racket
+  (require (submod ".." t/u))
+  (require rackunit)
+  (require (typed/untyped ".." m))
+  (check-equal? test-value 'is-untyped)
+  (check-equal? untyped-test-value 'present))
+
+(module test-untyped-3 racket
+  (require (submod ".." t/u))
+  (require rackunit)
+  (define-syntax renamer (make-rename-transformer #'original-untyped-req-stx))
+  (require (renamer ".." m))
+  (check-equal? test-value 'is-untyped)
+  (check-equal? untyped-test-value 'present))
+
+(require 'test-typed-1 'test-typed-2 'test-typed-3
+         'test-untyped-1 'test-untyped-2 'test-untyped-3)

--- a/typed-racket-test/succeed/shallow/distinguish-source.rkt
+++ b/typed-racket-test/succeed/shallow/distinguish-source.rkt
@@ -1,0 +1,29 @@
+#lang racket/base
+
+;; Test 3 kinds of typed functions:
+;; - a function defined by TR
+;; - a function imported through `require/typed`
+;; - a (safe) function from the standard library
+
+(module u racket/base
+  (provide f)
+  (define (f x)
+    x))
+
+(module t typed/racket/base/shallow
+  (require/typed (submod ".." u)
+    (f (-> (Listof String) (Listof Natural))))
+
+  (: g (-> Natural Boolean))
+  (define (g x)
+    (= x 4))
+
+  (define (test)
+    (filter g (f '("a" "bb" "ccc"))))
+
+  (provide test))
+(require 't rackunit)
+
+(check-exn (λ (e) (or (regexp-match? #rx"expected: Natural" (exn-message e))
+                      (regexp-match? #rx"shape-check" (exn-message e))))
+  test)

--- a/typed-racket-test/succeed/shallow/do.rkt
+++ b/typed-racket-test/succeed/shallow/do.rkt
@@ -1,0 +1,17 @@
+#lang typed/racket/shallow
+
+(define-type-alias Nb Number)
+
+(let: ([x : Nb 3]) x)
+
+(let ([x '(1 3 5 7 9)])
+  (let: doloop : Nb
+	([x : (Listof Nb) x]
+	 [sum : Number 0])
+	(if (null? x) sum
+	    (doloop (cdr x) (+ sum (car x))))))
+
+(let ((x '(1 3 5 7 9)))
+  (do: : Nb ((x : (Listof Nb) x (cdr x))
+	     (sum : Number 0 (+ sum (car x))))
+       ((null? x) sum)))

--- a/typed-racket-test/succeed/shallow/dotted-identity.rkt
+++ b/typed-racket-test/succeed/shallow/dotted-identity.rkt
@@ -1,0 +1,18 @@
+#lang typed/racket/shallow
+
+(: f (All (a ...) ((a ... a -> Integer) -> (a ... a -> Integer))))
+(define (f x) x)
+
+(: y (Integer Integer -> Integer))
+(define (y a b) (+ a b))
+
+#{(f y) :: (Integer Integer -> Integer)}
+
+(: z (Integer * -> Integer))
+(define (z . xs) (apply + xs))
+
+((f z) 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18)
+
+(f z)
+
+#{(f z) :: (Integer * -> Integer)}

--- a/typed-racket-test/succeed/shallow/dotted-identity2.rkt
+++ b/typed-racket-test/succeed/shallow/dotted-identity2.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/shallow
+
+;; I don't believe the below should work, but it points out where that internal error is coming from.
+
+(: f (All (a ...) ((a ... a -> Integer) -> (a ... a -> Integer))))
+(define (f x) x)
+
+(: g (All (b ...) ( -> (b ... b -> Integer))))
+(define (g) (lambda xs 0))
+
+(f (g))

--- a/typed-racket-test/succeed/shallow/dungeon-main.rkt
+++ b/typed-racket-test/succeed/shallow/dungeon-main.rkt
@@ -1,0 +1,384 @@
+#lang typed/racket/shallow
+
+;; File should compile without unbound identifier errors
+;;
+;; Example of a bad error:
+;;   g486: undefined;
+;;    cannot reference an identifier before its definition
+;;     module: "/Users/ben/code/racket/fork/extra-pkgs/typed-racket/typed-racket-test/shallow/pass/dungeon-main.rkt"
+;;     internal name: g486.1
+
+;; -----------------------------------------------------------------------------
+
+(require
+  typed/racket/class
+  racket/match
+)
+
+(require/typed racket/set
+  (set-intersect (All (A) (-> (Listof A) (Listof A) (Listof A))))
+)
+
+(define-type CCTable (HashTable Char (U Door% Cell%)))
+(define-type Cell%
+  (Class
+    (init-field
+     (items (Listof Any) #:optional)
+     (occupant (U #f (Instance Cell%)) #:optional))
+    (free? (-> Boolean))
+    (open (-> Void))
+    (show (-> Char))
+    (close (-> Void))))
+(define-type Door% Cell%)
+(define-type Pos (Vector Index Index))
+(define-type Grid (Vectorof (Vectorof (Instance Cell%))))
+(define-type Poss->Cells (Listof (Pairof Pos Cell%)))
+(define-type Direction (->* (Pos) (Index) Pos))
+(define-type Cache (HashTable Pos Boolean))
+(define-type ExtPoints (Listof (Pairof Pos Room)))
+(struct room
+  ((height : Index)
+   (width : Index)
+   (poss->cells : Poss->Cells) ; maps positions to cell constructors
+   ;;            (so that we can construct the room later when we commit to it)
+   (free-cells : (Listof Pos))   ; where monsters or treasure could go
+   (extension-points : (Listof Pos)))) ; where a corridor could sprout
+(define-type Room room)
+
+
+
+(: dict-set (-> Poss->Cells Pos Cell% Poss->Cells))
+(define (dict-set pc p c)
+  (define ok : (Boxof Boolean) (box #f))
+  (for/list : Poss->Cells
+            ([x (in-list pc)])
+    (if (and (not (unbox ok)) (equal? (car x) p))
+      (begin (set-box! ok #t) (cons p c))
+      x)))
+
+(: array-set! (-> Grid Pos (Instance Cell%) Void))
+(define (array-set! g p v)
+  (vector-set! (vector-ref g (vector-ref p 0)) (vector-ref p 1) v))
+
+(: build-array (-> Pos (-> Pos (Instance Cell%)) Grid))
+(define (build-array p f)
+  (for/vector : Grid
+    ([x (in-range (vector-ref p 0))])
+   (for/vector : (Vectorof (Instance Cell%))
+                ([y (in-range (vector-ref p 1))])
+    (f (vector (assert x index?) (assert y index?))))))
+  ;(build-array p f)))
+
+;; a Grid is a math/array Mutable-Array of cell%
+;; (mutability is required for dungeon generation)
+
+;; parses a list of strings into a grid, based on the printed representation
+;; of each cell
+(: parse-grid (-> (Listof String) Grid))
+(define (parse-grid los)
+  (for/vector : Grid
+              ; #:shape (vector (length los)
+              ;                (apply max (map string-length los)))
+              ;#:fill (new void-cell%)
+              ([s (in-list los)])
+            (for/vector : (Vectorof (Instance Cell%))
+               ([c (in-string s)]) ;: (Instance Cell%)
+     (new (char->cell% c)))))
+
+(: show-grid (-> Grid String))
+(define (show-grid g)
+  (with-output-to-string
+    (lambda ()
+      (for ([r (in-vector g)])
+        (for ([c (in-vector r)])
+          (display (send c show)))
+        (newline)))))
+
+(: grid-height (-> Grid Index))
+(define (grid-height g)
+  (vector-length g))
+  ;(match-define (vector rows cols) (array-shape g))
+  ;rows)
+
+(: grid-width (-> Grid Index))
+(define (grid-width g)
+  (vector-length (vector-ref g 0)))
+  ;(match-define (vector rows cols) (array-shape g))
+  ;cols)
+
+(: within-grid? (-> Grid Pos Boolean))
+(define (within-grid? g pos)
+  (and (<= 0 (vector-ref pos 0) (sub1 (grid-height g)))
+       (<= 0 (vector-ref pos 1) (sub1 (grid-width  g)))))
+
+(: grid-ref (-> Grid Pos (U #f (Instance Cell%))))
+(define (grid-ref g pos)
+  (and (within-grid? g pos)
+       (vector-ref (vector-ref g (vector-ref pos 0)) (vector-ref pos 1))))
+
+(: left (->* (Pos) (Index) Pos))
+(define (left pos [n 1])
+  (vector (vector-ref pos 0)
+          (assert (- (vector-ref pos 1) n) index?)))
+
+(: right (->* (Pos) (Index) Pos))
+(define (right pos [n 1])
+  (vector (vector-ref pos 0)
+          (assert (+ (vector-ref pos 1) n) index?)))
+
+(: up (->* (Pos) (Index) Pos))
+(define (up pos [n 1])
+  (vector (assert (- (vector-ref pos 0) n) index?)
+          (vector-ref pos 1)))
+
+(: down (->* (Pos) (Index) Pos))
+(define (down pos [n 1])
+  (vector (assert (+ (vector-ref pos 0) n) index?)
+          (vector-ref pos 1)))
+
+(define orig : (Listof Natural) '(2 10 24 3 0 2 10 45 2 2 2 2 49 3 1 5 1 0 0 2 1 0 2 1 0 0 2 2 5 0 0 0 3 0 1 2 0 3 0 0 2 2 0 2 2 0 0 3 0 0 2 0 3 1 0 2 0 0 1 1 0 2 0 0 3 0 0 1 2 0 3 1 0 2 0 0 0 1 3 1 1 0 1 2 0 3 2 0 1 2 0 1 1 0 2 2 0 1 1 0 2 2 0 0 0 2 1 0 0 0 0 3 4 0 0 2 1 0 2 1 0 3 1 0 1 0 0 1 0 0 1 2 0 1 0 0 2 2 0 2 2 0 3 1 0 1 0 0 1 1 0 2 1 0 3 2 0 3 0 0 2 2 0 0 0 3 4 2 0 3 0 0 3 1 0 0 3 0 4 0 0 2 0 0 2 2 0 2 1 0 0 0 3 6 1 0 3 0 0 0 2 1 3 0 0 3 1 0 1 1 0 2 0 0 3 2 0 2 1 0 1 2 0 0 3 0 2 2 0 2 2 0 2 2 0 1 1 0 3 1 0 2 1 0 1 2 0 0 2 0 3 1 0 1 1 0 2 2 0 2 2 0 1 5 3 3 2 1))
+(define r* : (Boxof (Listof Natural)) (box orig))
+
+(: reset! (-> Void))
+(define (reset!)
+  (set-box! r* orig))
+
+(: random (-> Integer Natural))
+(define (random n)
+  (begin0 (car (unbox r*)) (set-box! r* (cdr (unbox r*)))))
+
+(: article (->* (Boolean Boolean) (#:an? Boolean) String))
+(define (article capitalize? specific?
+                 #:an? [an? #f])
+  (if specific?
+      (if capitalize? "The" "the")
+      (if an?
+          (if capitalize? "An" "an")
+          (if capitalize? "A"  "a"))))
+
+(: random-between (-> Integer Integer Integer))
+(define (random-between min max) ;; TODO replace with 6.4's `random`
+  (+ min (random (- max min))))
+
+(: d6 (-> Integer))
+(define (d6)
+  (random-between 1 7))
+
+(: d20 (-> Integer))
+(define (d20)
+  (random-between 1 21))
+
+(: random-from (All (A) (-> (Listof A) A)))
+(define (random-from l)
+  (first (shuffle l)))
+
+(: shuffle (All (A) (-> (Listof A) (Listof A))))
+(define (shuffle l)
+  (reverse l))
+
+;; =============================================================================
+;; ---
+(define enqueue-message! void)
+(: dict-ref (-> CCTable Char Cell%))
+(define (dict-ref tbl c)
+  (or (hash-ref tbl c #f) (raise-user-error 'dict-ref)))
+(: dict-set! (-> CCTable Char Cell% Void))
+(define (dict-set! cc k v)
+  (hash-set! cc k v))
+
+;; =============================================================================
+
+;; maps printed representations to cell classes
+;; for map parsing
+(: chars->cell%s CCTable)
+(define chars->cell%s
+  (make-hash))
+
+(: register-cell-type! (-> Cell% Char Void))
+(define (register-cell-type! c% char)
+  (dict-set! chars->cell%s char c%))
+
+(: char->cell% (-> Char Cell%))
+(define (char->cell% char)
+  (dict-ref chars->cell%s char))
+
+(: cell% Cell%)
+(define cell% ; some kind of obstacle by default
+  (class object%
+    (init-field [items    '()]
+                [occupant #f]) ; player, monster, etc.
+    (define/public (free?)
+      #f)
+    (define/public (show)
+      #\*) ; for debugging
+    (define/public (open)
+      (enqueue-message! "Can't open that."))
+    (define/public (close)
+      (enqueue-message! "Can't close that."))
+    (super-new)))
+(register-cell-type! cell% #\*)
+
+(: empty-cell% Cell%)
+(define empty-cell%
+  (class cell%
+    (inherit-field occupant)
+    (define/override (free?)
+      (not occupant))
+    (define/override (show)
+      (if occupant
+          (send (or occupant (raise-user-error 'show)) show)
+          #\space))
+    (super-new)))
+(register-cell-type! empty-cell% #\space)
+
+(: void-cell% Cell%)
+(define void-cell%
+  (class cell%
+    (define/override (show) #\.) ; for testing only
+    (super-new)))
+(register-cell-type! void-cell% #\.)
+
+(: wall% Cell%)
+(define wall%
+  (class cell%
+    (define/override (show) #\X) ; for testing only
+    (super-new)))
+(register-cell-type! wall% #\X)
+
+(define double-bar? #t)
+(define-syntax-rule (define-wall name single-bar double-bar)
+  (begin (define name : Cell%
+           (class wall%
+             (define/override (show) (if double-bar? double-bar single-bar))
+             (super-new)))
+         ;; parse either kind
+         (register-cell-type! name single-bar)
+         (register-cell-type! name double-bar)
+         (provide name)))
+(define-wall pillar%           #\+     #\#)
+(define-wall vertical-wall%    #\u2502 #\u2551)
+(define-wall horizontal-wall%  #\u2500 #\u2550)
+(define-wall four-corner-wall% #\u253c #\u256c)
+(define-wall north-east-wall%  #\u2510 #\u2557)
+(define-wall north-west-wall%  #\u250c #\u2554)
+(define-wall south-east-wall%  #\u2518 #\u255d)
+(define-wall south-west-wall%  #\u2514 #\u255a)
+(define-wall north-tee-wall%   #\u252c #\u2566)
+(define-wall south-tee-wall%   #\u2534 #\u2569)
+(define-wall east-tee-wall%    #\u2524 #\u2563)
+(define-wall west-tee-wall%    #\u251c #\u2560)
+
+(: door% Door%)
+(define door%
+  (class cell%
+    ;(init-field [open? #f])
+    (inherit-field occupant)
+    (define/override (free?)
+      (and #;open? (not occupant)))
+    (define/override (open)
+      (if #t ;open?
+          (enqueue-message! "The door is already open.")
+          (void) #;(set! open? #t)))
+    (define/override (close)
+      (if #t ;open?
+          (void) #;(set! open? #f)
+          (enqueue-message! "The door is already closed.")))
+    (super-new)))
+(: vertical-door% Door%)
+(define vertical-door%
+  (class door%
+    (inherit-field #;open? occupant)
+    (define/override (show)
+      (if #t ;open?
+          (if occupant (send (or occupant (raise-user-error 'vdoor)) show) #\_)
+          #\|))
+    (super-new)))
+(register-cell-type! vertical-door% #\|)
+(register-cell-type! (class vertical-door% (super-new #;[open? #t])) #\_)
+(: horizontal-door% Door%)
+(define horizontal-door%
+  (class door%
+    (inherit-field #;open? occupant)
+    (define/override (show)
+      (if #t ;open?
+          (if occupant (send (or occupant (raise-user-error 'hdoor)) show) #\')
+          #\-))
+    (super-new)))
+(register-cell-type! horizontal-door% #\-)
+(register-cell-type! (class horizontal-door% (super-new #;[open? #t])) #\')
+;; ---
+
+;; -----------------------------------------------------------------------------
+
+(define N 1)
+
+(: wall-cache Cache)
+(define wall-cache (make-hash))
+
+(: free-cache Cache)
+(define free-cache (make-hash))
+(define animate-generation? #f) ; to see intermediate steps
+(define ITERS : Index 10)
+(define dungeon-height : Index 18) ; to be easy to display in 80x24, with other stuff
+(define dungeon-width  : Index 60)
+
+;; -----------------------------------------------------------------------------
+
+(: try-add-rectangle (-> Grid Pos Index Index Direction (U #f Room)))
+(define (try-add-rectangle grid pos height width direction)
+  ;; height and width include a wall of one cell wide on each side
+  (match-define (vector x y) pos)
+  (define min-x (match direction
+                  [(== down) x]
+                  ;; expanding north, we have to move the top of the room
+                  ;; up so the bottom reaches the starting point
+                  [(== up) (+ (- x height) 1)]
+                  ;; have the entrance be at a random position on the
+                  ;; entrance-side wall
+                  [else    (sub1 (- x (random (- height 2))))]))
+  (define min-y (match direction
+                  ;; same idea as for x
+                  [(== right) y]
+                  [(== left)  (+ (- y width) 1)]
+                  [else       (sub1 (- y (random (- width 2))))]))
+  (define max-x (+ min-x height))
+  (define max-y (+ min-y width))
+  (define-values (success? poss->cells free-cells extension-points)
+    (for*/fold : (Values Boolean Poss->Cells (Listof Pos) (Listof Pos))
+               ([success?         : Boolean #t]
+                [poss->cells      : Poss->Cells '()]
+                [free-cells       : (Listof Pos) '()]
+                [extension-points : (Listof Pos) '()])
+        ([x : Integer (in-range min-x max-x)]
+         [y : Integer (in-range min-y max-y)])
+      ;#:break (not success?)
+      (cond
+       [(not success?)
+        (values success? poss->cells free-cells extension-points)]
+       [success?
+        (define c (and (index? x) (index? y) (grid-ref grid (vector x y))))
+        (cond [(and c ; not out of bounds
+                    (or (is-a? c void-cell%) ; unused yet
+                        (is-a? c wall%)))    ; neighboring room, can abut
+               (define p : Pos (vector (assert x index?) (assert y index?)))
+               ;; tentatively add stuff
+               (define x-wall? (or (= x min-x) (= x (sub1 max-x))))
+               (define y-wall? (or (= y min-y) (= y (sub1 max-y))))
+               (if (or x-wall? y-wall?)
+                   ;; add a wall
+                   (values #t ; still succeeding
+                           (dict-set poss->cells p wall%)
+                           free-cells
+                           (if (and x-wall? y-wall?)
+                               ;; don't extend from corners
+                               extension-points
+                               (cons p extension-points)))
+                   (values #t
+                           (dict-set poss->cells p empty-cell%)
+                           (cons p free-cells)
+                           extension-points))]
+              [else ; hit something, give up
+               (values #f '() '() '() )])])))
+  (and success?
+       (room height width poss->cells free-cells extension-points)))
+

--- a/typed-racket-test/succeed/shallow/empty-case-arrow.rkt
+++ b/typed-racket-test/succeed/shallow/empty-case-arrow.rkt
@@ -1,0 +1,3 @@
+#lang typed/racket/shallow
+(: f (case->))
+(define (f x) 0)

--- a/typed-racket-test/succeed/shallow/empty-fun.rkt
+++ b/typed-racket-test/succeed/shallow/empty-fun.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+
+(module t typed/racket/shallow
+  (: f (case->))
+  (define (f x) 0)
+  (provide f))
+
+(require 't rackunit)
+(check-exn exn:fail:contract? (lambda () (f (box 0))))
+

--- a/typed-racket-test/succeed/shallow/empty-or.rkt
+++ b/typed-racket-test/succeed/shallow/empty-or.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket/shallow
+
+(require scheme/bool scheme/list typed/test-engine/scheme-tests)
+
+(define-type-alias Atom (U Number #f))
+
+(: mrg ([Listof Atom] [Listof Atom] -> [Listof Number]))
+;; add corresponding numbers, drop false, stop at end of shortest list
+
+(check-expect (mrg (list 1 false 2) (list 3 4 5 false 10)) (list 4 4 7))
+
+(define (mrg l k)
+ (cond
+   [(or (empty? l) (empty? k))
+    empty]
+   [(and (not (car l)) (not (car k)))
+    (cons 0 (mrg (rest l) (rest k)))]
+   [(not (car l))
+    (cons (car k) (mrg (rest l) (rest k)))]
+   [(not (car k))
+    (cons (car l) (mrg (rest l) (rest k)))]
+   [else
+    (cons (+ (car l) (car k)) (mrg (rest l) (rest k)))]))
+
+(test)

--- a/typed-racket-test/succeed/shallow/ephemerons.rkt
+++ b/typed-racket-test/succeed/shallow/ephemerons.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/shallow
+
+(define key (gensym))
+
+(: eph-one (Ephemeronof Integer))
+(define eph-one (make-ephemeron key 1))
+
+(ephemeron? eph-one)
+
+(ephemeron-value eph-one)
+
+(: get-number ((Ephemeronof Number) -> Number))
+(define (get-number e)
+ (or (ephemeron-value e) 0))
+
+(get-number eph-one)

--- a/typed-racket-test/succeed/shallow/even-odd-recursive-contract.rkt
+++ b/typed-racket-test/succeed/shallow/even-odd-recursive-contract.rkt
@@ -1,0 +1,26 @@
+#lang racket/load
+
+;; Test mutually recursive type alias contract generation
+;; with polymorphism
+
+(module untyped racket
+  (define (even->odd elem lst) (cons 3 lst))
+  (provide even->odd))
+
+(module poly-even/odd typed/racket/shallow
+  (define-type (Even A) (U Null (Pairof A (Odd A))))
+  (define-type (Odd A) (Pairof A (Even A)))
+
+  (: even-lst (Even Integer))
+  (define even-lst '(1 2 3 4))
+
+  (: odd-lst (Odd Integer))
+  (define odd-lst '(1 2 3))
+
+  (require/typed 'untyped
+                 [even->odd (All (A) (A (Even A) -> (Odd A)))])
+
+  (even->odd 3 even-lst) )
+
+(require 'poly-even/odd)
+

--- a/typed-racket-test/succeed/shallow/even-odd-recursive-type.rkt
+++ b/typed-racket-test/succeed/shallow/even-odd-recursive-type.rkt
@@ -1,0 +1,75 @@
+#lang racket
+
+(require rackunit)
+
+(module num-even/odd typed/racket/shallow
+  (define-type Even (U Null (Pairof Number Odd)))
+  (define-type Odd (Pairof Number Even))
+
+  (: even-lst Even)
+  (define even-lst '(1 2 3 4))
+
+  (: odd-lst Odd)
+  (define odd-lst '(1 2 3)))
+
+(module poly-even/odd typed/racket/shallow
+  (define-type (Even A) (U Null (Pairof A (Odd A))))
+  (define-type (Odd A) (Pairof A (Even A)))
+
+  (: even-lst (Even Integer))
+  (define even-lst '(1 2 3 4))
+
+  (: odd-lst (Odd Integer))
+  (define odd-lst '(1 2 3))
+
+  (: even->odd (All (A) (A (Even A) -> (Odd A))))
+  (define (even->odd elem lst)
+    (cons elem lst))
+
+  (provide even->odd Even Odd even-lst odd-lst))
+
+;; make sure it works in a let
+(module let-even/odd typed/racket/shallow
+  (let ()
+    (define-type (Even A) (U Null (Pairof A (Odd A))))
+    (define-type (Odd B) (Pairof B (Even B)))
+
+    (: even-lst (Even Integer))
+    (define even-lst '(1 2 3 4))
+
+    (: odd-lst (Odd Integer))
+    (define odd-lst '(1 2 3))
+
+    (cons 3 even-lst)))
+
+(module even/odd* typed/racket/shallow
+  ;; weird variant that alternates types between
+  ;; Even and Odd
+  (define-type (Even A B) (U Null (Pairof A (Odd A B))))
+  (define-type (Odd A B) (Pairof B (Even A B)))
+
+  (: even-lst (Even Integer String))
+  (define even-lst '(1 "b" 3 "a"))
+
+  (: odd-lst (Odd Integer String))
+  (define odd-lst '("b" 2 "a"))
+
+  ;; specialized for more interesting contract
+  (: even->odd (String (Even Integer String) -> (Odd Integer String)))
+  (define (even->odd elem lst) (cons elem lst))
+
+  (provide even-lst odd-lst even->odd))
+
+(require (prefix-in a: 'num-even/odd))
+(require (prefix-in b: 'poly-even/odd))
+(require (prefix-in c: 'let-even/odd))
+(require (prefix-in d: 'even/odd*))
+
+;; make sure contract generation on even/odd* worked
+(cons 3 d:odd-lst)
+(check-equal? (d:even->odd "c" d:even-lst) '("c" 1 "b" 3 "a"))
+(check-exn exn:fail:contract? (λ () (d:even->odd 1 d:even-lst)))
+
+(b:even->odd "c" b:even-lst)
+(check-not-exn (λ () (b:even->odd "c" b:odd-lst)))
+

--- a/typed-racket-test/succeed/shallow/exn-any-mutation.rkt
+++ b/typed-racket-test/succeed/shallow/exn-any-mutation.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+(module untyped racket/base
+  (provide f)
+  (define (f x) x))
+(module typed typed/racket/shallow
+  (require typed/rackunit)
+  (struct (X) s ([i : X]) #:mutable #:transparent)
+  (require/typed (submod ".." untyped)
+                 [f (-> Any (s (U Integer String)))])
+  (: s1 : (s Integer))
+  (define s1 (s 42))
+  (define s2 (ann s1 Any))
+  (define s3 (f s2))
+  (check-equal? (s-i s1) 42)
+  (check-equal? (s-i s3) 42)
+  (check-not-exn (λ () (set-s-i! s3 "hi")))
+  (check-exn exn:fail:contract? (lambda () (s-i s1)))
+  )
+(require 'typed)

--- a/typed-racket-test/succeed/shallow/factorial.rkt
+++ b/typed-racket-test/succeed/shallow/factorial.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket/shallow
+
+;; Test factorial function, and the `for/product` combinator
+
+(: factorial (-> Natural Natural))
+(define (factorial x)
+  (for/product : Natural ([i : Natural (in-range x)])
+    (+ i 1)))
+
+(factorial 6)

--- a/typed-racket-test/succeed/shallow/flonum.rkt
+++ b/typed-racket-test/succeed/shallow/flonum.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+
+(module t typed/racket/base/shallow
+  ;; Test case-> type
+  (require racket/flonum)
+  (provide flprobability?)
+  (: flprobability? (case-> (Flonum -> Boolean) (Flonum Any -> Boolean)))
+  (define (flprobability? p [log? #f])
+    (cond [log?  (and (p . fl>= . -inf.0) (p . fl<= . 0.0))]
+          [else  (and (p . fl>= . 0.0) (p . fl<= . 1.0))])))
+
+(require 't rackunit)
+
+(check-not-exn
+  (lambda () (flprobability? 0.5)))
+
+(check-exn #rx"shape-check"
+  (lambda () (flprobability? "seven")))

--- a/typed-racket-test/succeed/shallow/fold-left-inst.rkt
+++ b/typed-racket-test/succeed/shallow/fold-left-inst.rkt
@@ -1,0 +1,19 @@
+#lang typed/racket/shallow
+
+(: fold-left (All (c a b ...) ((c a b ... b -> c) c (Listof a) (Listof b) ... b -> c)))
+(define (fold-left f c as . bss)
+  (if (or (null? as)
+          (ormap null? bss))
+      c
+      (apply (inst fold-left c a b ... b) f
+             (apply f c (car as) (map car bss))
+             (cdr as) (map cdr bss))))
+
+(: fold-right (All (c a b ...) ((c a b ... b -> c) c (Listof a) (Listof b) ... b -> c)))
+(define (fold-right f c as . bss)
+  (if (or (null? as)
+          (ormap null? bss))
+      c
+      (apply f
+             (apply (inst fold-left c a b ... b) f c (cdr as) (map cdr bss))
+             (car as) (map car bss))))

--- a/typed-racket-test/succeed/shallow/fold-left.rkt
+++ b/typed-racket-test/succeed/shallow/fold-left.rkt
@@ -1,0 +1,41 @@
+#lang typed/racket/shallow
+
+(: fold-left (All (c a b ...) ((c a b ... b -> c) c (Listof a) (Listof b) ... b -> c)))
+(define (fold-left f c as . bss)
+  (if (or (null? as)
+          (ormap null? bss))
+      c
+      (apply fold-left f
+             (apply f c (car as) (map car bss))
+             (cdr as) (map cdr bss))))
+
+(: fold-right (All (c a b ...) ((c a b ... b -> c) c (Listof a) (Listof b) ... b -> c)))
+(define (fold-right f c as . bss)
+  (if (or (null? as)
+          (ormap null? bss))
+      c
+      (apply f
+             (apply fold-right f c (cdr as) (map cdr bss))
+             (car as) (map car bss))))
+
+;; Matthias -- tell me why this returns 4.
+((plambda: (x ...) [xs : x ... x]
+    (apply fold-left
+           (lambda: ([a : Integer] [b : Integer] . [xs : x ... x])
+             (+ a b))
+           3
+           (list 1 2 3)
+           (map list xs)))
+ 3 4 5)
+
+((plambda: (x ...) [xs : x ... x]
+    (apply fold-right
+           (lambda: ([a : Integer] [b : Integer] . [xs : x ... x])
+             (+ a b))
+           3
+           (list 1 2 3)
+           (map list xs)))
+ 3 4 5)
+
+(fold-left  (lambda: ([a : (Listof Integer)] [c : Integer]) (cons c a)) null (list 3 4 5 6))
+(fold-right (lambda: ([a : (Listof Integer)] [c : Integer]) (cons c a)) null (list 3 4 5 6))

--- a/typed-racket-test/succeed/shallow/gh-issue-336.rkt
+++ b/typed-racket-test/succeed/shallow/gh-issue-336.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/shallow
+
+;; Test for github issue #336
+
+(: foo (∀ (A ... B ...) (→ (List (→ A ... B) ...)
+                           Any)))
+(define (foo f)
+  (apply conjoin f))

--- a/typed-racket-test/succeed/shallow/hello.rkt
+++ b/typed-racket-test/succeed/shallow/hello.rkt
@@ -1,0 +1,5 @@
+#lang typed/racket/shallow
+
+;; No-brainer test
+
+"hello world"

--- a/typed-racket-test/succeed/shallow/in-cycle.rkt
+++ b/typed-racket-test/succeed/shallow/in-cycle.rkt
@@ -1,0 +1,30 @@
+#lang typed/racket/shallow
+
+;; Plot error:
+;;
+;;    /Users/ben/code/racket/fork/racket/share/pkgs/plot-lib/plot/private/plot3d/isosurface.rkt:130:23: Type Checker: No function domains matched in function application:
+;;    Domains: Any (Sequenceof (Parameterof Plot-Pen-Style) Any)
+;;             Any (Sequenceof (Parameterof Plot-Pen-Style))
+;;             Any Integer
+;;    Arguments: Any (Sequenceof Plot-Pen-Style)
+;;      in: (in-cycle* line-styles)
+;;
+;; Try to reproduce ... failure so far (2019-08-22), but
+;; - error goes away if remove `rts` provides from the #%type-decl
+;; - error STAYS if remove only the unhygienic lookups
+;; so the problem is related to the new exports for the "contract + type" hack,
+;;  and maybe by improving that we'll get a better fix
+;;
+;; Ok now we are simplified; the issue is a defined variable vs a for-loop variable
+
+(: in-cycle* (All (A) (-> (Sequenceof A) (Sequenceof A))))
+(define (in-cycle* s)
+  (define n (sequence-length s))
+  (if (zero? n) empty-sequence (in-cycle s)))
+
+(define xxx : String "hello")
+
+(: f (-> (Listof Symbol) Void))
+(define (f line-styles)
+  (for ([xxx  (in-cycle* line-styles)])
+    (void)))

--- a/typed-racket-test/succeed/shallow/intersection1.rkt
+++ b/typed-racket-test/succeed/shallow/intersection1.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+
+
+(module a typed/racket/shallow
+  (provide num-id)
+  (: num-id (∀ (A) (-> (∩ Number A) (∩ Number A))))
+  (define (num-id x) x))
+
+(require 'a)
+
+(let ()
+  (num-id 42)
+  (void))
+
+(with-handlers ([exn:fail:contract?
+                 (λ (ex) (void))])
+  (num-id "42"))
+
+

--- a/typed-racket-test/succeed/shallow/issue-598.rkt
+++ b/typed-racket-test/succeed/shallow/issue-598.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket/base/shallow
+
+(module u racket/base
+  (define (f b)
+    (set-box! b "hello"))
+  (provide f))
+
+(define-type Maybe-Box (U #f (Boxof Integer)))
+
+(require/typed 'u (f (-> Maybe-Box Void)))
+
+(define b : Maybe-Box (box 4))
+
+(module+ test
+  (require typed/rackunit)
+
+  (check-not-exn
+    (λ () (f b)))
+
+  (check-exn exn:fail:contract?
+    (lambda () (if (box? b) (unbox b) (error 'deadcode)))))

--- a/typed-racket-test/succeed/shallow/issue-625.rkt
+++ b/typed-racket-test/succeed/shallow/issue-625.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+
+;; Hash contracts with non-flat keys should give a good error messages
+;;  when applied to hashes that are not `hash-equal?`
+
+(module t typed/racket/base/shallow
+  (provide give-me-a-hash)
+  (: give-me-a-hash (-> (HashTable (Vectorof Symbol) Symbol) Symbol))
+  (define (give-me-a-hash x)
+    'thanks))
+
+(require 't rackunit)
+
+(check-not-exn
+  (λ () (give-me-a-hash (hasheqv))))
+
+(check-not-exn
+  (λ () (give-me-a-hash (hasheq))))
+
+(check-not-exn
+  (λ () (give-me-a-hash (hash))))

--- a/typed-racket-test/succeed/shallow/keyword-opt-mand.rkt
+++ b/typed-racket-test/succeed/shallow/keyword-opt-mand.rkt
@@ -1,0 +1,14 @@
+#lang typed/racket/base/shallow
+
+;; No error when function accepts optional kws
+;;  and type says mandatory
+
+(module u racket/base
+  (define (f1 x #:y [y #f])
+    (void))
+  (provide f1))
+
+(require/typed 'u
+  (f1 (-> Symbol #:y Symbol Void)))
+
+(void f1)

--- a/typed-racket-test/succeed/shallow/lambda-allvar.rkt
+++ b/typed-racket-test/succeed/shallow/lambda-allvar.rkt
@@ -1,0 +1,14 @@
+#lang typed/racket/base/shallow
+
+;; From the `math` library, something like this appears after macro expansion
+;;  and shallow was refusing to defend because had 'Error' type.
+;;
+;; Missing a type annotation?
+;; If not, maybe TR is over-specializing.
+
+(: fff (All (A) (-> A Void)))
+(define (fff ba)
+  (define ggg
+    (lambda ((v : A)) (void)))
+  (void))
+

--- a/typed-racket-test/succeed/shallow/lambda-subtype.rkt
+++ b/typed-racket-test/succeed/shallow/lambda-subtype.rkt
@@ -1,0 +1,35 @@
+#lang typed/racket/base/shallow
+
+;; shallow domain checks must be based off the function's formals --- not
+;;  on the type assigned to the whole expression
+;;
+;; because the function body might assume (-> T0 T1)
+;; and the "whole" type might be (-> T2 T1) where T2 <: T0
+;; and if that happens, the shallow check could incorrectly error on some
+;; T0 inputs
+;;
+;; discovered in the quadT & synth benchmarks
+
+;; ---
+
+(define-type Quad Symbol)
+(define-type LineQuad Symbol)
+(define-type Wrap-Proc-Type (((Listof Quad)) (Float) . ->* . (Listof LineQuad)))
+
+(: quadT-fun Wrap-Proc-Type)
+(define (quadT-fun q* [n #f])
+  (if n
+    (list (string->symbol (number->string n)))
+    q*))
+
+(quadT-fun '())
+
+;; ---
+
+(define-type Array (Vectorof Real))
+
+(: synth-array-append* (-> (Listof Array) (Listof Array) Array))
+(define (synth-array-append* aa bb [k 0])
+  (vector k))
+
+(synth-array-append* '() '())

--- a/typed-racket-test/succeed/shallow/lambda.rkt
+++ b/typed-racket-test/succeed/shallow/lambda.rkt
@@ -1,0 +1,148 @@
+#lang typed/racket/base/shallow
+
+;; Test functions args, positional optional keyword rest
+
+;; -----------------------------------------------------------------------------
+;; --- positional
+
+(: f0 (-> Natural))
+(define (f0)
+  4)
+
+(lambda () 0)
+
+
+(: f1 (-> Natural Natural))
+(define (f1 x)
+  (+ x 1))
+
+(lambda ((x : Natural))
+  (+ x 1))
+
+
+(: f2 (-> (Listof Natural) (Vectorof Natural) Natural))
+(define (f2 a b)
+  (+ (length a) (vector-length b)))
+
+(lambda ((a : (Listof Natural)) (b : (Vectorof Natural)))
+  (+ (length a) (vector-length b)))
+
+;; -----------------------------------------------------------------------------
+;; --- optional
+
+(: f3 (->* [(Listof Natural)] [(U #f Symbol)] Natural))
+(define (f3 a [b #f])
+  (+ (length a) (if b (string-length (symbol->string b)) 1)))
+
+(lambda ((a : (Listof Natural)) (b : (U #f Symbol) #f))
+  (+ (length a) (if b (string-length (symbol->string b)) 1)))
+
+(: f4 (->* [] [Integer (U #f Symbol)] Natural))
+(define (f4 [a -1] [b #f])
+  (+ (abs a) (if b (string-length (symbol->string b)) 1)))
+
+(lambda ([a : Integer -1] [b : (U #f Symbol) #f])
+  (+ (abs a) (if b (string-length (symbol->string b)) 1)))
+
+;; -----------------------------------------------------------------------------
+;; --- keyword
+
+(: f5 (-> #:a Symbol #:b (Listof Symbol) String))
+(define (f5 #:a a #:b b)
+  (if (null? b) "hello" "world"))
+
+(lambda (#:a (a : Symbol) #:b (b : (Listof Symbol)))
+  (if (null? b) "hello" "world"))
+
+(: f6 (->* [] [#:a Symbol #:b (Listof Symbol)] String))
+(define (f6 #:a [a 'a] #:b [b '(b b b)])
+  (if (= 3 (length b)) "one" "two"))
+
+(lambda (#:a [a : Symbol 'a] #:b [b : (Listof Symbol) '(b b b)])
+  (if (= 3 (length b)) "one" "two"))
+
+;; -----------------------------------------------------------------------------
+;; --- rest
+
+(: f7 (->* [] [] #:rest String String))
+(define (f7 . xs)
+  (if (null? xs)
+    "asdf"
+    (string-append (car xs) (cadr xs))))
+
+(f7)
+(f7 "a" "b")
+
+(ann
+  (lambda xs
+    (string-append (car xs) (cadr xs)))
+  (->* [] [] #:rest String String))
+
+;; -----------------------------------------------------------------------------
+;; --- misc
+
+(: choose-randomly (->* [ (Listof Symbol) Natural] [ #:random (U #f String)] String))
+(define (choose-randomly probabilities speed #:random (q #false))
+  (cond
+   [(string? q)
+    "string"]
+   [(not q)
+    "false"]
+   [else
+    "oh no something else"]))
+
+(choose-randomly '() 0 #:random "yes")
+(choose-randomly '() 0 #:random #false)
+(choose-randomly '() 0) ; this will error if keyword-arg functions are protected
+
+(define-type State Natural)
+(define-type Payoff Natural)
+(define-type Transition* (Listof Symbol))
+
+(struct automaton ({current : State}
+                   {original : State}
+                   {payoff : Payoff}
+                   {table : Transition*}) #:transparent)
+
+(: make-random-automaton (-> Natural automaton))
+(define (make-random-automaton n)
+  (automaton n n n '()))
+
+;; -----------------------------------------------------------------------------
+;; --- kcfa
+
+(struct Exp ())
+
+(struct Call Exp ([a : Any] [b : Any] [c : Any]))
+
+(define (new-label)
+  'aaa)
+
+(: make-call (-> Exp Exp * Exp))
+(define (make-call fun . args)
+  (Call (new-label) fun args))
+
+;; -----------------------------------------------------------------------------
+;; --- polydots
+
+;; Do NOT want to see "error shape-check expected Nothing"
+((plambda: (x ...) [xs : x ... x] xs) 3 4 5)
+
+;; -----------------------------------------------------------------------------
+;; --- poly
+
+(: shuffle-vector
+   (All (X) (-> (Vectorof X) (Vectorof X) (cons (Vectorof X) (Vectorof X)))))
+(define (shuffle-vector b a)
+  ;; copy b into a
+  (for ([x (in-vector b)][i (in-naturals)])
+    (vector-set! a i x))
+  ;; now shuffle a 
+  (for ([x (in-vector b)] [i (in-naturals)])
+    (define j (random (add1 i)))
+    (unless (= j i) (vector-set! a i (vector-ref a j)))
+    (vector-set! a j x))
+  (cons a b))
+
+(shuffle-vector (vector 1 2 3) (vector 4 5 6))
+

--- a/typed-racket-test/succeed/shallow/lifting-top-level.rkt
+++ b/typed-racket-test/succeed/shallow/lifting-top-level.rkt
@@ -1,0 +1,18 @@
+#lang racket/load
+
+;; Test to make sure lifting is okay at the top-level for TR
+;;
+;; Would be best as a unit test, but the local expansion done in
+;; tests is different from the local expansion done for #%top-interaction
+
+(require typed/racket/shallow)
+
+(define-syntax (m stx)
+  (syntax-local-lift-expression #'(string-append "foo" "bar")))
+(m)
+
+(define-syntax (n* stx)
+  (syntax-local-lift-expression #'(string-append "foo" "bar")))
+(define-syntax (m* stx)
+  (syntax-local-lift-expression #'(n*)))
+(m*)

--- a/typed-racket-test/succeed/shallow/list-dots.rkt
+++ b/typed-racket-test/succeed/shallow/list-dots.rkt
@@ -1,0 +1,35 @@
+#lang typed/racket/shallow
+
+;; tests for the new iteration of ...
+
+(: f (All (a ...) ((List a ...) -> (List a ... a))))
+(define (f x) x)
+
+(: g (All (a ...) (a ... -> (List a ...))))
+(define (g . x) x)
+
+(g 7 7 7)
+
+(: h (All (a ...) (a ... -> (Listof Any))))
+(define (h . x) x)
+
+(: h2 (All (a ...) ((Pair String a) ... -> (Listof (Pair String Any)))))
+(define (h2 . x) x)
+
+(: h3 (All (a ...) ((Pair String a) ... -> (Listof Any))))
+(define (h3 . x) x)
+
+(: h4 (All (a ...) (a ... -> Number)))
+(define (h4 . x) (length x))
+
+(: i (All (a ...) (List a ...) (a ... -> Number) -> Number))
+(define (i xs f) (apply f xs))
+
+(: i2 (All (a ...) (List a ...) (Any * -> Number) -> Number))
+(define (i2 xs f) (apply f xs))
+
+(: i3 (All (a ...) (List a ...) (List a ...) ((Pairof a a) ... -> Number) -> Number))
+(define (i3 xs ys f) (apply f (map cons xs ys)))
+
+(: i4 (All (a ...) (List a ...) (Listof Number) ((Pairof a Number) ... -> Number) -> Number))
+(define (i4 xs ys f) (apply f (map cons xs ys)))

--- a/typed-racket-test/succeed/shallow/list-ref.rkt
+++ b/typed-racket-test/succeed/shallow/list-ref.rkt
@@ -1,0 +1,23 @@
+#lang typed/racket/shallow
+
+;; Test `list-ref` applications
+
+(: f (-> (Listof Natural) Natural))
+(define (f x)
+  (+ (car x)
+     (first x)))
+
+(f (list 4 4 4 4))
+
+(: g (-> (Listof (Listof Natural)) Natural))
+(define (g x)
+  (define l (list-ref x (+ 0 0)))
+  (+ (car l) (third l)))
+
+(g '((1 2 2 3 4)))
+
+(: h (-> (Pairof Natural Natural) Natural))
+(define (h x)
+  (+ (car x) (cdr x)))
+
+(h '(1 . 2))

--- a/typed-racket-test/succeed/shallow/literal-regexp-gh-issue-539.rkt
+++ b/typed-racket-test/succeed/shallow/literal-regexp-gh-issue-539.rkt
@@ -1,0 +1,128 @@
+#lang typed/racket/shallow
+
+;; The precise type for a regexp should be the regexp itself:
+(ann #rx"abc" #rx"abc")
+(ann #px"abc" #px"abc")
+(ann #rx"abc" '#rx"abc")
+(ann #px"abc" '#px"abc")
+;; The precise type for a byte-regexp should be the regexp itself:
+(ann #rx#"abc" #rx#"abc")
+(ann #px#"abc" #px#"abc")
+(ann #rx#"abc" '#rx#"abc")
+(ann #px#"abc" '#px#"abc")
+;; Up-casting as Regexp should still work:
+(ann #rx"abc" Regexp)
+(ann (ann #rx"abc" #rx"abc") Regexp)
+(ann (ann #rx"abc" '#rx"abc") Regexp)
+(ann #px"abc" Regexp)
+(ann (ann #px"abc" #px"abc") Regexp)
+(ann (ann #px"abc" '#px"abc") Regexp)
+(ann #px"abc" PRegexp)
+(ann (ann #px"abc" #px"abc") PRegexp)
+(ann (ann #px"abc" '#px"abc") PRegexp)
+;; Up-casting as Byte-Regexp should still work:
+(ann #rx#"abc" Byte-Regexp)
+(ann (ann #rx#"abc" #rx#"abc") Byte-Regexp)
+(ann (ann #rx#"abc" '#rx#"abc") Byte-Regexp)
+(ann #px#"abc" Byte-Regexp)
+(ann (ann #px#"abc" #px#"abc") Byte-Regexp)
+(ann (ann #px#"abc" '#px#"abc") Byte-Regexp)
+(ann #px#"abc" Byte-PRegexp)
+(ann (ann #px#"abc" #px#"abc") Byte-PRegexp)
+(ann (ann #px#"abc" '#px#"abc") Byte-PRegexp)
+
+;; Check that the inferred type is still implicitly widened to (P)Regexp by
+;; default, for backwards compatibility (previously, all regexps had the type
+;; Regexp):
+;; * Check that when passed as a #:∀ type, the inferred type is Regexp
+(ann (let #:∀ (R) ([r : R #rx"abc"])
+       (λ ([x : R]) r))
+     (→ Regexp Regexp))
+(ann (let #:∀ (R) ([r : R #px"abc"])
+       (λ ([x : R]) r))
+     (→ PRegexp PRegexp))
+;; * Check that loops which rely on the first iteration having the wider
+;;   (P)Regexp type still work:
+(let loop : Void ([r #rx"abc"])
+  (if (equal? r #rx"abc")
+      (loop #rx"xyz")
+      (void)))
+(let loop : Void ([r #px"abc"])
+  (if (equal? r #px"abc")
+      (loop #px"xyz")
+      (void)))
+
+;; Check that the inferred type is still implicitly widened to Byte-(P)Regexp by
+;; default, for backwards compatibility (previously, all regexps had the type
+;; Regexp):
+;; * Check that when passed as a #:∀ type, the inferred type is Byte-Regexp
+(ann (let #:∀ (R) ([r : R #rx#"abc"])
+       (λ ([x : R]) r))
+     (→ Byte-Regexp Byte-Regexp))
+(ann (let #:∀ (R) ([r : R #px#"abc"])
+       (λ ([x : R]) r))
+     (→ Byte-Regexp Byte-Regexp))
+;; * Check that loops which rely on the first iteration having the wider
+;;   Byte-(P)Regexp type still work:
+(let loop : Void ([r #rx#"abc"])
+  (if (equal? r #rx#"abc")
+      (loop #rx#"xyz")
+      (void)))
+(let loop : Void ([r #px#"abc"])
+  (if (equal? r #px#"abc")
+      (loop #px#"xyz")
+      (void)))
+
+(define v (vector #rx"abc" #px"abc" #rx#"abc" #px#"abc"))
+(define b1 (box #rx".*"))
+(define b2 (box #px".*"))
+(define b3 (box #rx#".*"))
+(define b4 (box #px#".*"))
+(define c1 (ann (box (ann #rx"abc" #rx"abc")) (Boxof #rx"abc")))
+(define c2 (ann (box (ann #px"abc" #px"abc")) (Boxof #px"abc")))
+(define c3 (ann (box (ann #rx#"abc" #rx#"abc")) (Boxof #rx#"abc")))
+(define c4 (ann (box (ann #px#"abc" #px#"abc")) (Boxof #px#"abc")))
+
+(vector-set! v 0 #rx".*")
+(vector-set! v 1 #px".*")
+(vector-set! v 2 #rx#".*")
+(vector-set! v 3 #px#".*")
+(set-box! b1 #rx"abc")
+(set-box! b1 #px"abc") ;; Upcast #px to Regexp: b1 is a (Boxof Regexp)
+(set-box! b2 #px"abc")
+(set-box! b3 #rx#"abc")
+(set-box! b3 #px#"abc") ;; Upcast #px# to Byte-Regexp: b3 is a (Boxof Regexp)
+(set-box! b4 #px#"abc")
+;; (set-box! c1 #rx".*") ouch, it would be nice if this worked
+;; (set-box! c2 #px".*") ouch, it would be nice if this worked
+;; (set-box! c3 #rx#".*") ouch, it would be nice if this worked
+;; (set-box! c4 #px#".*") ouch, it would be nice if this worked
+(set-box! c1 (ann #rx"abc" #rx"abc"))
+(set-box! c2 (ann #px"abc" #px"abc"))
+(set-box! c3 (ann #rx#"abc" #rx#"abc"))
+(set-box! c4 (ann #px#"abc" #px#"abc"))
+
+
+(ann (let ([x : #rx"abc" #rx"abc"])
+       (if ((make-predicate #rx"abc") x)
+           x
+           0))
+     #rx"abc")
+
+(ann (let ([x : #px"abc" #px"abc"])
+       (if ((make-predicate #px"abc") x)
+           x
+           0))
+     #px"abc")
+
+(ann (let ([x : #rx#"abc" #rx#"abc"])
+       (if ((make-predicate #rx#"abc") x)
+           x
+           0))
+     #rx#"abc")
+
+(ann (let ([x : #px#"abc" #px#"abc"])
+       (if ((make-predicate #px#"abc") x)
+           x
+           0))
+     #px#"abc")

--- a/typed-racket-test/succeed/shallow/ll-lambda.rkt
+++ b/typed-racket-test/succeed/shallow/ll-lambda.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+
+;; Test tc-app lambda special case for ((lambda ...) ...)
+
+(module a typed/racket/deep
+  (define-values [a b]
+     ((lambda (x) (values x (list 'A 'A))) 42)))
+
+(module r racket/base
+  (provide f)
+  (define (f x) (values x '(A A))))
+
+(module b typed/racket/shallow
+  (define-values [x0 x1]
+     ((lambda (x) (values x (list 'A 'A))) 42))
+
+  (require/typed
+    (submod ".." r)
+    (f (-> Integer (Values Integer (Listof Symbol)))))
+
+  (define-values [x2 x3]
+     ((lambda (x) (f x)) 42))
+
+  (define-values [x4 x5]
+     (f 42))
+  )
+
+(require 'a 'b)

--- a/typed-racket-test/succeed/shallow/lots-o-bugs.rkt
+++ b/typed-racket-test/succeed/shallow/lots-o-bugs.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket/shallow
+
+;; (All (a ...) ( -> (a ... a -> Integer)))
+
+(plambda: (a ...) ()
+          (lambda: [ys : a ... a] 3))
+
+(define x (plambda: (a ...) () (lambda: [ys : a ... a] 3)))
+
+
+
+(: y (All (a ...) ( -> (a ... a -> Integer))))
+(define y (plambda: (a ...) () (lambda: [ys : a ... a] 3)))
+
+(: z (All (a ...) ( -> (a ... a -> Integer))))
+(define z (lambda () (lambda ys 3)))
+
+#;((plambda: (a ...) () (lambda: [ys : a ... a] 3)))
+
+#;((plambda: (a ...) [xs : a ... a] (lambda: [ys : a ... a] 3))
+   1 2 3 "foo")

--- a/typed-racket-test/succeed/shallow/make-hasheq.rkt
+++ b/typed-racket-test/succeed/shallow/make-hasheq.rkt
@@ -1,0 +1,5 @@
+#lang typed/racket/base/shallow
+
+;; Test the predicate for a mutable hashtable
+
+((begin make-hasheq))

--- a/typed-racket-test/succeed/shallow/make-predicate-top-level.rkt
+++ b/typed-racket-test/succeed/shallow/make-predicate-top-level.rkt
@@ -1,0 +1,9 @@
+#lang racket/load
+
+(require typed/racket/shallow)
+
+(: f (Any -> Boolean : Number))
+(define f (make-predicate Number))
+
+(: g (Listof Number))
+(define g (filter f '(1 2 3 4 "5")))

--- a/typed-racket-test/succeed/shallow/mandelbrot.rkt
+++ b/typed-racket-test/succeed/shallow/mandelbrot.rkt
@@ -1,0 +1,31 @@
+#lang typed/racket/base/shallow #:optimize
+(require racket/future racket/flonum)
+(define: MAX-ITERS : Positive-Fixnum 50)
+(define MAX-DIST 2.0)
+(define: N : Positive-Fixnum 512)
+(: mandelbrot-point : Integer Integer -> Integer)
+(define (mandelbrot-point x y)
+  (define c
+    (+ (- (/ (* 2.0 (->fl x)) N) 1.5)
+       (* 0.0+1.0i (- (/ (* 2.0 (->fl y)) N) 1.0))))
+  (let loop ((i 0) (z 0.0+0.0i))
+    (cond
+      [(> i MAX-ITERS) (char->integer #\*)]
+      [(> (magnitude z) MAX-DIST)
+       (char->integer #\space)]
+      [else (loop (add1 i) (+ (* z z) c))])))
+
+(: fs (Listof (Futureof Bytes)))
+(define fs
+  (for/list ([y (in-range N)])
+    (let ([bstr (make-bytes N)])
+      (future
+       (lambda ()
+         (for ([x (in-range N)])
+           (bytes-set! bstr x (mandelbrot-point x y)))
+         bstr)))))
+
+(lambda ()
+  (for: ([f : (Futureof Bytes) (in-list fs)])
+    (write-bytes (touch f))
+    (newline)))

--- a/typed-racket-test/succeed/shallow/match-define.rkt
+++ b/typed-racket-test/succeed/shallow/match-define.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/shallow
+
+;; Test that `match-define` works in locally-defensive code
+
+(struct foo ([x : Symbol]))
+
+(: g (-> foo Boolean))
+(define (g f)
+  (match-define (foo q) f)
+  (symbol=? q 'rrr))
+

--- a/typed-racket-test/succeed/shallow/method-default.rkt
+++ b/typed-racket-test/succeed/shallow/method-default.rkt
@@ -1,0 +1,62 @@
+#lang typed/racket/shallow
+
+;; Test immediate and expression defaults
+;;  for optional & keyword arguments
+
+
+(let ()
+  ;; optional, value
+  (: c1% (Class (f (->* [Integer] [Integer] Integer))))
+  (define c1%
+    (class object%
+      (super-new)
+      (define/public (f x [y 0]) (+ 4 4))))
+  (send (new c1%) f 0))
+
+(let ()
+  ;; optional, expression
+  (: c1% (Class (f (->* [Integer] [Integer] Integer))))
+  (define c1%
+    (class object%
+      (super-new)
+      (define/public (f x [y (+ 0 1)]) (+ 4 4))))
+  (send (new c1%) f 0))
+
+(let ()
+  ;; optional, field
+  (: c1% (Class (field (a Integer)) (f (->* [Integer] [Integer] Integer))))
+  (define c1%
+    (class object%
+      (super-new)
+      (field (a 42))
+      (define/public (f x [y a]) (+ 4 4))))
+  (send (new c1%) f 0))
+
+(let ()
+  ;; keyword, value
+  (: c1% (Class (f (->* [Integer] [#:y Integer] Integer))))
+  (define c1%
+    (class object%
+      (super-new)
+      (define/public (f x #:y [y 0]) (+ 4 4))))
+  (send (new c1%) f 0))
+
+(let ()
+  ;; keyword, expression
+  (: c1% (Class (f (->* [Integer] [#:y Integer] Integer))))
+  (define c1%
+    (class object%
+      (super-new)
+      (define/public (f x #:y [y (+ 0 1)]) (+ 4 4))))
+  (send (new c1%) f 0))
+
+(let ()
+  ;; keyword, field
+  (: c1% (Class (field (a Integer)) (f (->* [Integer] [#:y Integer] Integer))))
+  (define c1%
+    (class object%
+      (super-new)
+      (field (a 42))
+      (define/public (f x #:y [y a]) (+ 4 4))))
+  (send (new c1%) f 0))
+

--- a/typed-racket-test/succeed/shallow/module-client.rkt
+++ b/typed-racket-test/succeed/shallow/module-client.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket/base/shallow
+
+;; Test:
+;; 1. enclosing module is locally-defensive
+;; 2. contains a Racket submodule
+;; 3. import a value with the right constructor & the wrong type
+;; 4. send the value back to untyped code, get low-level error from untyped
+
+(require "module-server.rkt" ) ;; import a typed function
+
+(: h (-> Real Real))
+(define (h n)
+  (* n n))
+
+(f 3 h)
+
+
+(module u racket/base
+  (provide xs)
+  (define xs '(A B C)))
+(require/typed 'u
+  (xs (Listof Natural)))
+
+(with-handlers ((exn:fail:contract? (lambda (_) #true)))
+  (filter zero? xs))

--- a/typed-racket-test/succeed/shallow/module-lang.rkt
+++ b/typed-racket-test/succeed/shallow/module-lang.rkt
@@ -1,0 +1,18 @@
+#lang scheme/load
+
+(module m typed/racket/shallow
+  (: f (All (a) (a -> a)))
+  (define (f x) x)
+  (provide f))
+
+(module n typed/racket/shallow
+  (require 'm))
+
+(require typed/racket/shallow)
+
+(require 'n)
+
+(current-namespace (module->namespace ''n))
+
+(f 1)
+

--- a/typed-racket-test/succeed/shallow/module-plus.rkt
+++ b/typed-racket-test/succeed/shallow/module-plus.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base/shallow
+
+;; Make sure defender runs in module+
+
+(module u racket/base
+  (define b
+    (box "hello"))
+  (provide b))
+
+(require/typed 'u (b (Boxof Integer)))
+
+(module+ test
+  (require typed/rackunit)
+
+  (check-exn exn:fail:contract?
+    (lambda () (unbox b))))

--- a/typed-racket-test/succeed/shallow/module-server.rkt
+++ b/typed-racket-test/succeed/shallow/module-server.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/base/shallow
+
+;; Not a test, just provides a locally-defensive function
+
+(provide f filter)
+
+(: f (-> Real (-> Real Real) Real))
+(define (f r g)
+  (g (g r)))

--- a/typed-racket-test/succeed/shallow/module-star.rkt
+++ b/typed-racket-test/succeed/shallow/module-star.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base/shallow
+
+;; Make sure defender runs in module*
+
+(module u racket/base
+  (define b
+    (box "hello"))
+  (provide b))
+
+(require/typed 'u (b (Boxof Integer)))
+
+(module* test #f
+  (require typed/rackunit)
+
+  (check-exn exn:fail:contract?
+    (lambda () (unbox b))))

--- a/typed-racket-test/succeed/shallow/nested-poly.rkt
+++ b/typed-racket-test/succeed/shallow/nested-poly.rkt
@@ -1,0 +1,20 @@
+#lang typed/racket/shallow
+
+(require typed-racket/base-env/extra-procs)
+
+(: f (All (A ...) (All (B ...) (A ... A -> Integer))))
+
+(define (f . xs) 5)
+
+(: map-with-funcs
+   (All (A ...)
+        (All (B ...)
+             ((B ... B -> A) ... A ->
+              (B ... B -> (values A ... A))))))
+(define (map-with-funcs . fs)
+  (lambda as
+    (apply values (map (plambda: (C) ([f : (B ... B -> C)])
+                                 (apply f as))
+                        fs))))
+
+(inst map-with-funcs Integer Integer Integer Integer)

--- a/typed-racket-test/succeed/shallow/new-metrics.rkt
+++ b/typed-racket-test/succeed/shallow/new-metrics.rkt
@@ -1,0 +1,508 @@
+#lang typed/racket/shallow
+(provide results run-all-tests)
+
+(require (except-in scheme/list count) scheme/math scheme/path mzlib/match
+         (prefix-in srfi13: srfi/13) scheme/file
+         (for-syntax scheme/base))
+
+
+(require/typed (prefix-in srfi48: srfi/48)
+               [srfi48:format ( Port String String Any * -> Any)] )
+
+(define-type-alias NumF (U Number #f))
+
+(define-type-alias (Unit C) ((C ->  (Listof NumF)) -> (Path -> (Listof (U #f (Listof NumF))))))
+
+;; ============================================================
+;; CONFIG
+(define COLLECTS-PATH (make-parameter (build-path "/home/samth/Desktop/collects-tmp/")))
+(define PLANET-CODE-PATH (make-parameter (build-path "/home/samth/Desktop/most-recent-archives/")))
+
+; collects-path : a path to the collects directory to compare
+; planet-code-path : a path to the "other" code to compare (i.e. unpacked, most recent versions
+;   of all planet packages)
+
+;; ============================================================
+;; STATS
+
+(: t-test  ((Listof Number) (Listof Number) -> Number))
+;; computes t value for the given sequences. t-tests measure
+;; the extent to which difference in mean between two sets of
+;; _interval-valued_ samples (e.g. distances, times, weights, counts ...)
+;; can be explained by chance. Generally speaking, higher absolute
+;; values of t correspond to higher confidence that an observed difference
+;; in mean cannot be explained by chance.
+(define (t-test seqA seqB)
+  (manual-t-test
+   (avg seqA) (avg seqB)
+   (variance seqA) (variance seqB)
+   (length seqA) (length seqB)))
+
+(: manual-t-test (Number Number Number Number Number Number -> Number))
+(define (manual-t-test avga avgb vara varb cta ctb)
+  (/ (- avga avgb)
+     (assert (sqrt (+ (/ vara cta) (/ varb ctb))) number?)))
+
+(: chi-square  ((Listof Number) (Listof Number) -> Number))
+;; chi-square is a simple measure of the extent to which the
+;; difference in the frequency of 0's and 1's in the first
+;; sequence and their frequency in the second sequence can
+;; be explained by chance. higher numbers means higher confidence
+;; that they cannot.
+(define (chi-square seqA seqB)
+  (with-handlers ([exn:fail? (λ (e) +nan.0)])
+    (let* ([ct-a (length seqA)]
+           [ct-b (length seqB)]
+           [total-subjects (+ ct-a ct-b)]
+           [a-hits (apply + seqA)]
+           [b-hits (apply + seqB)] ;; these assume that the data is coded as 1 = present, 0 = not present
+           [a-misses (- ct-a a-hits)]
+           [b-misses (- ct-b b-hits)]
+           [table
+            `((,a-hits ,b-hits)
+              (,a-misses ,b-misses))]
+           [expected (λ: ([i : Integer] [j : Integer])
+                         (/ (* (row-total i table) (col-total j table)) total-subjects))])
+      (exact->inexact
+       (table-sum
+        (λ (i j) (/ (sqr (- (expected i j) (table-ref i j table))) (expected i j)))
+        table)))))
+
+;; ============================================================
+;; UNITS OF MEASUREMENT IMPLEMENTATIONS
+
+(: per-module (All (X) (((Listof Any) ->  X) -> (Path -> (List (U #f X))))))
+(define (per-module f)
+  (λ (path)
+    (with-handlers ([exn:fail:read? (λ (e) (list #f))])
+      (let ([initial-sexp (with-input-from-file path read)])
+        (match initial-sexp
+          [`(module ,_ ,_  ,bodies ...)
+           (list (f bodies))]
+          [_ (list #f)])))))
+
+(: per-module-top-level-expression ((Any -> (Listof NumF)) -> MetricFn))
+(define (per-module-top-level-expression f)
+  (let ([calc (per-module (λ: ([exprs : (Listof Any)]) (map f exprs)))])
+    (λ (p) (let ([r  (calc p)]) (if (car r) (car r) r)))))
+
+;; ============================================================
+;; BASIC CALCULATIONS
+;; (for use with metric definitions below)
+
+;; ----------------------------------------
+;; depth
+
+(: sexp-depth (Any -> Integer))
+(define (sexp-depth sexp)
+  (cond
+    [(pair? sexp)
+     (+ (max-sexp-depth sexp) 1)]
+    [else 0]))
+
+(: max-sexp-depth (Any -> Integer))
+(define (max-sexp-depth losx)
+  (improper-foldr (λ: ([t : Any] [r : Integer]) (max (sexp-depth t) r)) 0 losx))
+
+(: avg-sexp-depth ((Listof Any) -> Number))
+(define (avg-sexp-depth sexps)
+  (cond
+    [(null? sexps) 0]
+    [else (avg (map sexp-depth sexps))]))
+
+;; ----------------------------------------
+;; setbang counts
+
+(: count-setbangs/ilist (Any -> Number))
+(define (count-setbangs/ilist exprs)
+  (apply + (imap count-setbangs/expr exprs)))
+(: count-setbangs/expr (Any -> Number))
+(define (count-setbangs/expr expr)
+  (match expr
+    [`(,(? setbang?) ,rest ...) (+ 1 (count-setbangs/ilist rest))]
+    [('quote _) 0]
+    [('quasiquote _) 0] ; undercount potentially, but how many `,(set! ...)'s can there be?
+    [`(,e1 . ,e2) (count-setbangs/ilist expr)]
+    [_ 0]))
+
+(: setbang?  (Any -> Any))
+(define (setbang? v)
+  (and (symbol? v)
+       (regexp-match #rx"^set(-.*)?!" (symbol->string v))))
+
+;; count-fns
+(: count-fns-with-setbangs ((Listof Any) -> Number))
+(define (count-fns-with-setbangs exprs)
+  (apply + (map (λ (e) (if (= (count-setbangs/expr e) 0) 0 1)) exprs)))
+(: module-has-setbangs? ((Listof Any) -> Boolean))
+(define (module-has-setbangs? exprs) (ormap expr-uses-setbangs? exprs))
+(: expr-uses-setbangs? (Any -> Boolean))
+(define (expr-uses-setbangs? expr)
+  (not (= (count-setbangs/expr expr) 0)))
+
+(: setbangs-per-1000-atoms ((Listof Any) -> NumF))
+(define (setbangs-per-1000-atoms exprs)
+  (if (null? exprs)
+      #f
+      (let ([set!s (count-setbangs/ilist exprs)]
+            [atoms (atoms exprs)])
+        (* (/ set!s atoms) 1000.0))))
+
+;; ----------------------------------------
+;; contracts
+
+(: uses-contracts ((Listof Any) -> Boolean))
+(define (uses-contracts exprs)
+  (ormap (λ (e)
+           (ann
+            (match e
+              [`(provide/contract ,_ ...) #t]
+              [_ #f])
+            : Boolean))
+         exprs))
+
+(: contracted-provides ((Listof Any) -> Number))
+(define (contracted-provides exprs)
+  (foldl
+   (λ: ([t : Any] [r : Number])
+       (ann
+        (match t
+          [(provide/contract ,p ...) (+ (length p) r)]
+          [_ r]) : Number))
+   0
+   exprs))
+
+(: uncontracted-provides ((Listof Any) -> Number))
+(define (uncontracted-provides exprs)
+  (foldl
+   (λ: ([t : Any] [r : Number])
+       (ann
+        (match t
+          [`(provide ,p  ...) (+ (length p) r)]
+          [_ r]) : Number))
+   0
+   exprs))
+
+;; ----------------------------------------
+;; macros
+
+(: number-of-macro-definitions (Any -> Number))
+(define (number-of-macro-definitions expr)
+  (match expr
+    [`(define-syntax ,_ ...) 1]
+    [`(define-syntaxes (,s ...) ,_ ...) (length s)]
+    [`(define-syntax-set (,s ...) ,_ ...) (length s)]
+    [_ 0]))
+
+(: num-of-define-syntax ((Listof Any) -> Number))
+(define (num-of-define-syntax exprs)
+  (foldl (λ: ([t : Any] [r : Number]) (+ (number-of-macro-definitions t) r)) 0 exprs))
+
+;; ----------------------------------------
+;; expression size
+
+(: atoms (Any -> Integer))
+(define (atoms sexp)
+  (cond
+    [(null? sexp) 0]
+    [(not (pair? sexp)) 1]
+    [else (+ (atoms (car sexp)) (atoms (cdr sexp)))]))
+
+(: max-atoms ((Listof Any) -> NumF))
+(define (max-atoms exprs)
+  (let ([atom-counts (map atoms exprs)])
+    (if (null? atom-counts)
+        #f
+        (apply max atom-counts))))
+
+(: avg-atoms ((Listof Any) -> NumF))
+(define (avg-atoms exprs)
+  (let ([atom-counts (map atoms exprs)])
+    (if (null? atom-counts)
+        #f
+        (avg (map atoms exprs)))))
+
+(: total-atoms ((Listof Any) -> Number))
+(define (total-atoms exprs)
+  (apply + (map atoms exprs)))
+
+
+;; ============================================================
+;; METRIC DEFINITIONS
+;; 'a 'b metric : (string * (listof sexp -> 'a option) * ((listof 'a) (listof 'a) -> 'b)
+(define-typed-struct (b c d) metric ([analysis-unit : (Unit c)]
+                                     [computation : (c -> d)]
+                                     [>display : ((Listof d) (Listof d) -> b)]))
+
+(define-type-alias Table (Listof (Listof Number)))
+(define-type-alias Atom-display (cons Symbol (Listof Number)))
+
+(: standard-display (Symbol ((Listof Number) -> Number) ((Listof Number) (Listof Number) -> Number)
+                     -> ((Listof NumF) (Listof NumF) -> Atom-display)))
+(define ((standard-display name summarize significance-test) seqA seqB)
+    (let ([clean-seqA (nonfalses seqA)]
+          [clean-seqB (nonfalses seqB)])
+      (list name (summarize clean-seqA) (summarize clean-seqB) (significance-test clean-seqA clean-seqB))))
+
+(: interval (All (c) ((Unit c) Symbol (c -> NumF) -> (metric Atom-display c NumF))))
+(define (interval u name compute) (make-metric u compute (standard-display name avg t-test)))
+
+(: count (All (c) ((Unit c) Symbol (c -> Boolean) -> (metric  Atom-display c NumF))))
+(define (count u name compute) (make-metric u (λ: ([es : c]) (if (compute es) 1 0)) (standard-display name avg chi-square)))
+
+(: combine-metrics (All (c) ((Listof (metric Atom-display c NumF)) -> (metric (Listof Atom-display) c (Listof NumF)))))
+(define (combine-metrics ms)
+  (let ([u (metric-analysis-unit (car ms))])
+    ;; This test now redundant b/c of typechecking
+    (unless (andmap (λ: ([m : (metric Atom-display c NumF) ]) (eq? u (metric-analysis-unit m))) ms)
+      (error 'combine-metrics "all combined metrics must operate on the same unit of analysis"))
+
+    (make-metric
+     u
+     (λ: ([exprs : c]) (map (λ: ([m : (metric Atom-display c NumF)]) ((metric-computation m) exprs)) ms))
+     (λ: ([seqA : (Listof (Listof NumF))] [seqB : (Listof (Listof NumF))])
+              (map (λ: ([m : (metric Atom-display c NumF)]
+                             [sA : (Listof NumF)]
+                             [sB : (Listof NumF)])
+                            ((metric->display m) sA sB)) ms (pivot seqA) (pivot seqB))))))
+
+;; FIXME - (filter (lambda (x) x) l)
+(: nonfalses (All (X) ((Listof (U #f X)) -> (Listof X))))
+(define (nonfalses l)
+  (let loop ([lst l])
+    (if (null? lst)
+        '()
+        (let ([x (car lst)])
+          (if x
+              (cons x (loop (cdr lst)))
+              (loop (cdr lst)))))))
+
+(: avg ((Listof Number) -> Number))
+(define (avg l) (/ (exact->inexact (apply + l)) (length l)))
+(: avg* ((Listof Number) -> Number))
+(define (avg* l) (avg (nonfalses l)))
+
+(define-syntax define-metrics
+  (syntax-rules ()
+    [(define-metrics all-metrics-id unit-of-analysis  (name kind fn) ...)
+     (begin
+       (define u unit-of-analysis)
+       (define name (kind u 'name fn )) ...
+       (define all-metrics-id (combine-metrics (list name ...))))]))
+
+(define-metrics module-metrics #{per-module @ (Listof NumF)}
+  (maximum-sexp-depth        interval  max-sexp-depth)
+  (average-sexp-depth        interval  avg-sexp-depth)
+  (number-of-setbangs/mod    interval  count-setbangs/ilist)
+  (number-of-exprs           interval  #{length @ Any})
+  (uses-setbang?/mod         count     module-has-setbangs?)
+  (uses-contracts?           count     uses-contracts)
+  (number-of-contracts       interval  contracted-provides)
+  (num-uncontracted-provides interval  uncontracted-provides)
+  (number-of-macro-defs      interval  num-of-define-syntax)
+  (maximum-num-atoms         interval  max-atoms)
+  (average-num-atoms         interval  avg-atoms)
+  (total-num-atoms/mod       interval  total-atoms)
+  (set!s-per-1000-atoms      interval  setbangs-per-1000-atoms))
+
+(define-metrics tl-expr-metrics per-module-top-level-expression
+  (uses-setbang?/fn          count     expr-uses-setbangs?)
+  (number-of-setbangs/fn     interval  count-setbangs/expr)
+  (total-num-atoms/fn        interval  atoms))
+
+(: all-metrics (List (metric (Listof Atom-display) (Listof Any) (Listof NumF))
+                     (metric (Listof Atom-display) Any (Listof NumF)) ))
+(define all-metrics (list module-metrics tl-expr-metrics))
+
+;; ============================================================
+;; EXPERIMENT RUNNING
+
+(define-syntax (define-excluder stx)
+
+  (define (path->clause c)
+    (syntax-case c ()
+      [(item ...)
+       #`[`(#,@(reverse (syntax-e #'(item ...))) ,_ (... ...)) #t]]
+      [item
+       #`[`(item) #t]]))
+
+  (syntax-case stx ()
+    [(_ name path ...)
+     (with-syntax ([(match-clause ...) (map path->clause (syntax-e #'(path ...)))])
+       #`(define (name p )
+           (let* ([dirnames (map path->string (filter path? (explode-path p)))])
+             (match (reverse dirnames) ; goofy backwards matching because ... matches greedily
+               match-clause ...
+               [_ #f]))))]))
+
+(: default-excluder (Path -> Boolean))
+(define-excluder default-excluder
+  "compiled" ".svn" #;("collects" "drscheme") #;("collects" "framework"))
+
+(define exclude-directory? (make-parameter default-excluder))
+
+;; ----------------------------------------
+;; apply-to-scheme-files: (path[file] -> X) path[directory] -> (listof X)
+;; applies the given function to each .rkt or .ss or .scm file in the given
+;; directory hierarchy; returns all results in a list
+(: apply-to-scheme-files (All (X) ((Path -> X) Path -> (Listof X))))
+(define  (apply-to-scheme-files f root)
+  (fold-files
+   (λ: ([path : Path] [kind : (U 'file 'dir 'link)] [acc : (Listof X)])
+     (case kind
+       [(file)
+        (let ([extension (filename-extension path)])
+          (cond
+            [(not extension) (values acc #t)]
+            [(regexp-match #rx"(ss|scm)$" extension)
+             (let ([resl (f path)])
+               (if resl
+                   (values (cons resl acc) #t)
+                   (values acc #t)))]
+            [else (values acc #t)]))]
+       [(dir)
+        (let* ([p (normalize-path path root)])
+          (if ((exclude-directory?) p)
+              (values acc #f)
+              (values acc #t)))]
+       [(link) (values acc #t)]))
+   '()
+   root))
+(define-typed-struct (a b c) result ([metric : (metric b c a)] [seqA : (Listof a)] [seqB : (Listof a)]))
+(define-type-alias MetricFn (Path -> (Listof (U #f (Listof NumF)))))
+
+(define-type-alias (M b c) (metric b c (Listof NumF)))
+(define-type-alias (M2 b c c*) (U (M b c) (M b c*)))
+
+;; get-sequences : (listof 'a metric) path -> (listof (listof 'a))
+(: get-sequences (All (b c C) ((List (M b c) (M b C)) Path -> (Listof (Listof (Listof NumF))))))
+(define (get-sequences metrics path)
+  (: selector (case-lambda [(M b c) -> MetricFn] [(M b C) -> MetricFn]))
+  (define (selector m) ((metric-analysis-unit m) (metric-computation m)))
+  (let* ([metric-fns (map #{selector :: ((M2 b c C) -> MetricFn)} metrics)]
+         [result-seqs (apply-to-scheme-files
+                       (λ: ([file : Path])
+                           (map (λ: ([fn : MetricFn]) (fn file)) metric-fns)) path)])
+    (map
+     (λ: ([l : (Listof (Listof (U #f (Listof NumF))))])
+         (nonfalses (apply append l)))
+     (pivot (nonfalses result-seqs)))))
+
+
+(: compare*
+   (All (b c c*)
+        ((List (M b c) (M b c*))
+         ->
+         (List (result (Listof NumF) b c)
+               (result (Listof NumF) b c*)))))
+(define (compare* metrics)
+  (let* ([seqAs (get-sequences metrics (COLLECTS-PATH))]
+         [seqBs (get-sequences metrics (PLANET-CODE-PATH))])
+    (list
+     (make-result (car metrics) (car seqAs) (car seqBs))
+     (make-result (cadr metrics) (cadr seqAs) (cadr seqBs)))))
+
+(: show (All (a b c) ((result a b c) -> b)))
+(define (show result)
+  ((metric->display (result-metric result))
+   (result-seqA result)
+   (result-seqB result)))
+
+(: pretty-print-result
+   (case-lambda
+     ((result (Listof NumF) (Listof Atom-display) (Listof Any)) -> Void)
+     ((result (Listof NumF) (Listof Atom-display) Any) -> Void)))
+(define (pretty-print-result result)
+  (for-each
+   (λ: ([l : (Listof Any)])
+            (apply srfi48:format
+                   (current-output-port)
+                   "~26F  | ~8,2F  | ~6,2F  | ~12,2F\n"
+                   (format "~a" (car l))
+                   (cdr l)))
+   (list* '("test name" "collects" "planet" "significance")
+          '("---------" "--------" "------" "------------")
+          (show result))))
+
+;; applies only to the combined metric [or more generally to listof-answer results]
+(: total (All (b c) (Integer (result (Listof Number) b c) -> (Listof Number))))
+(define (total experiment-number result)
+  (: total/s (Table -> Number))
+  (define (total/s s) (apply + (list-ref (pivot s) experiment-number)))
+  (list (total/s (result-seqA result)) (total/s (result-seqB result))))
+
+;; ============================================================
+;; UTILITY
+
+(: imap (All (Y) ((Any -> Y) Any -> (Listof Y))))
+(define (imap f il)
+  (cond
+    [(null? il) '()]
+    [(not (pair? il)) (list (f il))]
+    [else (cons (f (car il)) (imap f (cdr il)))]))
+
+(: pivot (All (X) ((Listof (Listof X)) -> (Listof (Listof X)))))
+(define (pivot l)
+  (cond
+    [(null? l) '()]
+    [else
+     (let ([n (length (car l))])
+       (build-list n (λ: ([i : Integer]) (map (λ: ([j : (Listof X)]) (list-ref j i)) l))))]))
+
+(: variance ((Listof Number) -> Number))
+(define (variance xs)
+  (let ([avg (/ (apply + xs) (length xs))])
+    (/ (apply + (map (λ: ([x : Number]) (sqr (- x avg))) xs))
+       (sub1 (length xs)))))
+
+(: table-ref (Integer Integer Table -> Number))
+(define (table-ref i j table)
+  (list-ref (list-ref table i) j))
+(: row-total (Integer Table -> Number))
+(define (row-total i table)
+  (apply + (list-ref table i)))
+(: col-total (Integer Table -> Number))
+(define (col-total j table)
+  (apply + (map (λ: ([x : (Listof Number)]) (list-ref x j)) table)))
+(: table-sum ((Integer Integer -> Number) Table -> Number))
+(define (table-sum f table)
+  (let ([rows (length table)]
+        [cols (length (car table))])
+    (let loop  ([i 0] [j 0] [#{sum : Number} 0])
+      (cond
+        [(>= j cols) sum]
+        [(>= i rows) (loop 0 (add1 j) sum)]
+        [else        (loop (add1 i) j (+ sum (f i j)))]))))
+
+(: improper-foldr (All (Y) ((Any Y -> Y) Y Any -> Y)))
+(define (improper-foldr f b l)
+  (cond
+    [(null? l) b]
+    [(not (pair? l))
+     (f l b)]
+    [else
+     (f (car l) (improper-foldr f b (cdr l)))]))
+
+(: /* (All (a ...) ((Listof Number) (Listof Number) ... a -> (Listof Number))))
+(define (/* arg . args)
+    (apply map (λ: ([n : Number] . [ns : Number ... a]) (apply / n ns)) arg args))
+
+
+;; ============================================================
+;; MAIN ENTRY POINT
+
+(: results (U #f (Listof (U (result (Listof NumF) (Listof Atom-display) (Listof Any))
+                            (result (Listof NumF) (Listof Atom-display) Any)))))
+(define results #f) ; just in case i want to do some more analysis on the results afterwards,
+; so i don't have to waste a minute if i forget to bind the return value to something
+
+(define (run-all-tests)
+  (let ([rs (compare* all-metrics)])
+        (set! results rs)
+    (for-each
+     (ann pretty-print-result ((U (result (Listof NumF) (Listof Atom-display) (Listof Any))
+                                  (result (Listof NumF) (Listof Atom-display) Any))
+                               -> Any))
+     rs)
+    rs))
+

--- a/typed-racket-test/succeed/shallow/no-bound-fl.rkt
+++ b/typed-racket-test/succeed/shallow/no-bound-fl.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/shallow
+
+(: fold-left (All (a b ...) ((a b ... -> a) a (Listof b) ... -> a)))
+(define (fold-left f a . bss)
+  (if (ormap null? bss)
+      a
+      (apply fold-left
+             f
+             (apply f a (map car bss))
+             (map cdr bss))))
+

--- a/typed-racket-test/succeed/shallow/object-typed.rkt
+++ b/typed-racket-test/succeed/shallow/object-typed.rkt
@@ -1,0 +1,37 @@
+#lang racket
+
+(module t typed/racket/shallow
+  (define-type C0% (Class (init-field (s String)) (f (-> Integer Integer))))
+  (: c0% C0%)
+  (define c0%
+    (class object%
+      (super-new)
+      (init-field s)
+      (define/public (f x) (+ 4 4))))
+
+  (define-type C1% (Class (init-field (s String)) (f (->* [Integer] [#:y Integer] Integer))))
+  (: c1% C1%)
+  (define c1%
+    (class object%
+      (super-new)
+      (init-field s)
+      (define/public (f x #:y [y 0]) (+ 4 4))))
+  (provide c0% c1%))
+
+(require 't rackunit)
+
+(define o0 (new c0% (s "hello")))
+(check-exn exn:fail:contract?
+  (lambda () (send o0 f 'NaN)))
+(check-not-exn
+  (lambda () (new c0% (s 'NotString))))
+
+(define o1 (new c1% (s "hello")))
+(check-exn exn:fail:contract?
+  (lambda () (send o1 f 'NaN #:y 1)))
+(check-exn exn:fail:contract?
+  (lambda () (send o1 f 0 #:y 'NaN)))
+(check-not-exn
+  (lambda () (send o1 f 0)))
+(check-not-exn
+  (lambda () (send o1 f 0 #:y 1)))

--- a/typed-racket-test/succeed/shallow/object-untyped.rkt
+++ b/typed-racket-test/succeed/shallow/object-untyped.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket/shallow
+
+;; Copied from TR -test/fail/ directory
+
+(module u racket
+  (define c%
+    (class object%
+      (super-new)
+      (define/public (f x) '(+ x 1))))
+  (provide c%))
+
+(define-type C% (Class (f (-> Integer Integer))))
+
+(require typed/rackunit)
+(require/typed (submod "." u)
+  (c% C%))
+
+(: g (-> (Vector (Instance C%)) Integer))
+(define (g vo)
+  (define o (vector-ref vo 0))
+  (send o f 2))
+
+(check-exn exn:fail:contract?
+  (lambda () (g (vector (new c%)))))
+

--- a/typed-racket-test/succeed/shallow/opaque-object.rkt
+++ b/typed-racket-test/succeed/shallow/opaque-object.rkt
@@ -1,0 +1,23 @@
+#lang racket/base
+
+;; Shallow does not make opaque contracts
+
+(require racket/class)
+
+(module a typed/racket/shallow
+  (provide o)
+  (: o (Object))
+  (define o
+    (new
+      (class object%
+        (super-new)
+        (field [x 0])
+        (define/public (m) (void))))))
+
+(module b racket
+  (require (submod ".." a))
+  (set-field! x o "wrong type")
+  (get-field x o)
+  (send o m))
+
+(require 'b)

--- a/typed-racket-test/succeed/shallow/pict.rkt
+++ b/typed-racket-test/succeed/shallow/pict.rkt
@@ -1,0 +1,74 @@
+#lang typed/racket/shallow
+
+;; Test typed/pict
+
+(require typed/pict typed/racket/draw)
+
+(pict-children (blank 50 50))
+
+(blank)
+(blank 1)
+(blank 3 4 5)
+(blank 3 4 5 6)
+
+(text "a")
+(text "a" (cons 'bold 'roman))
+(text "a" 'modern 14)
+(text "a" 'modern 14 30)
+
+(hline 1 5)
+(hline 1 5 #:segment #f)
+(vline 1 5)
+(vline 1 5 #:segment 4)
+
+(frame (circle 5) #:segment 2)
+(frame (circle 5) #:color "red")
+(frame (circle 5) #:line-width 4)
+
+(ellipse 40 80)
+(ellipse 40 80 #:border-color "blue")
+(ellipse 40 80 #:border-width 6)
+
+(circle 20 #:border-color "black")
+(circle 20 #:border-width #f)
+
+(filled-ellipse 100 50)
+(filled-ellipse 100 50 #:draw-border? #f)
+(filled-ellipse 100 50 #:color "gray")
+(filled-ellipse 100 50 #:draw-border? #t #:border-color "green")
+(filled-ellipse 100 50 #:draw-border? #t #:border-width 2)
+
+(disk 60)
+(disk 60 #:draw-border? #t)
+(disk 60 #:color "green")
+(disk 60 #:border-color (make-object color% "blue"))
+(disk 60 #:draw-border? #t #:border-width 3)
+
+(rectangle 10 100)
+(rectangle 10 100 #:border-color "red")
+(rectangle 10 100 #:border-width 4)
+
+(filled-rectangle 80 80)
+(filled-rectangle 80 80 #:draw-border? #f)
+(filled-rectangle 80 80 #:draw-border? #t #:color "white")
+(filled-rectangle 80 80 #:draw-border? #t #:border-color "white")
+(filled-rectangle 80 80 #:border-width 16)
+
+(rounded-rectangle 80 80)
+(rounded-rectangle 80 80 4)
+(rounded-rectangle 80 80 #:angle 4)
+(rounded-rectangle 80 80 #:border-color "salmon")
+(rounded-rectangle 80 80 #:border-width 3)
+
+(filled-rounded-rectangle 80 80)
+(filled-rounded-rectangle 80 80 5)
+(filled-rounded-rectangle 80 80 #:draw-border? #f)
+(filled-rounded-rectangle 80 80 #:color "gainsboro")
+(filled-rounded-rectangle 80 80 #:border-color "yellow")
+(filled-rounded-rectangle 80 80 #:border-width 11)
+
+(define hl (hline 1 5))
+(define-values (x y) (lt-find hl hl))
+
+(standard-fish 40 20 #:direction 'left #:color "olive")
+

--- a/typed-racket-test/succeed/shallow/poly-apply.rkt
+++ b/typed-racket-test/succeed/shallow/poly-apply.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/shallow
+
+(: my-apply (All (a ...) ((Any ... a -> Any) a ... a -> Any)))
+(define (my-apply f . x) (apply f x))
+
+(: id (All (a) (a -> a)))
+(define (id x) x)
+
+(my-apply id 'y)

--- a/typed-racket-test/succeed/shallow/poly-dots.rkt
+++ b/typed-racket-test/succeed/shallow/poly-dots.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket/base/shallow
+
+(: map-with-funcs (All (b ...) ((List (b ... b -> b) ... b ) -> (b ... b -> (values b ... b)))))
+(define (map-with-funcs fs)
+  (lambda bs
+    (apply values (map (plambda: (c) ([f : (b ... b -> c)])
+                         (apply f bs)) fs))))
+
+(map-with-funcs (list + - /))
+

--- a/typed-racket-test/succeed/shallow/poly-ref.rkt
+++ b/typed-racket-test/succeed/shallow/poly-ref.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/base/shallow
+
+;; Test that type variables do not have a run-time check
+;;  (no need for a check, because a context cannot make assumptions about the value)
+
+(: f (All (A) (-> (Vectorof A) A)))
+(define (f x)
+  (vector-ref x 0))
+
+(f (vector 1 2 3))
+(f '#(four five six))

--- a/typed-racket-test/succeed/shallow/poly-require-typed.rkt
+++ b/typed-racket-test/succeed/shallow/poly-require-typed.rkt
@@ -1,0 +1,17 @@
+#lang racket/base
+
+;; Test require/typed with a polymorphic type
+
+(module util racket/base
+  (provide random-from)
+  (require racket/list)
+
+  (define (random-from xs)
+    (first (shuffle xs))))
+
+(module client typed/racket/base/shallow
+  (require/typed (submod ".." util)
+    (random-from (All (A) (-> (Listof A) A))))
+
+  (random-from '(1 2 3)))
+(require 'client)

--- a/typed-racket-test/succeed/shallow/poly-union.rkt
+++ b/typed-racket-test/succeed/shallow/poly-union.rkt
@@ -1,0 +1,13 @@
+#lang typed/racket/shallow
+
+;; Test inspired by the suffixtree benchmark.
+;; Function returns a union of polymorphic variables and should have no check
+
+(: f (All (A B) (-> (-> A) (-> B) (U A B))))
+(define (f a b)
+  (: helper (-> Integer (U A B)))
+  (define (helper n)
+    (if (zero? n) (a) (b)))
+  (helper 0))
+
+(f (lambda () #true) (lambda () 'false))

--- a/typed-racket-test/succeed/shallow/pr11545+11776.rkt
+++ b/typed-racket-test/succeed/shallow/pr11545+11776.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket/shallow
+
+(: stuff (All [X ...] (X ... X -> (Listof Any))))
+(define (stuff . xs) xs)
+
+(: thing (-> (Listof Any)))
+(define (thing)
+  ((inst stuff)))
+
+(inst values Any)

--- a/typed-racket-test/succeed/shallow/pr11669.rkt
+++ b/typed-racket-test/succeed/shallow/pr11669.rkt
@@ -1,0 +1,16 @@
+#lang racket/load
+
+(require typed/racket/shallow)
+
+;; Test that struct: and define-struct: work at the
+;; top-level.
+;;
+;; Test for PR 11669
+(struct: Foo ([x : Integer]))
+(define-struct: Bar ([y : Foo]))
+(define-type Qux (U String Integer))
+(struct: Quux ([qux : Qux]))
+Quux-qux
+Foo
+make-Bar
+

--- a/typed-racket-test/succeed/shallow/pr12913.rkt
+++ b/typed-racket-test/succeed/shallow/pr12913.rkt
@@ -1,0 +1,10 @@
+#lang racket
+
+;; Test that `define-type` works at the top-level
+
+(define ns (make-base-namespace))
+(eval '(require typed/racket/shallow) ns)
+(eval '(define-type Foo (U String Symbol)) ns)
+(eval '(: x Foo) ns)
+(eval '(define x 'x) ns)
+

--- a/typed-racket-test/succeed/shallow/pr13503.rkt
+++ b/typed-racket-test/succeed/shallow/pr13503.rkt
@@ -1,0 +1,5 @@
+#lang racket/load
+(require typed/racket/shallow)
+(:print-type +)
+(:print-type (values 2 3 4))
+(:print-type (error 'ManyTypes))

--- a/typed-racket-test/succeed/shallow/pr13576.rkt
+++ b/typed-racket-test/succeed/shallow/pr13576.rkt
@@ -1,0 +1,4 @@
+#lang typed/racket/base/shallow
+
+(define: (A ...) (lister args : A ... A) : (List A ... A)
+   args)

--- a/typed-racket-test/succeed/shallow/pr13747.rkt
+++ b/typed-racket-test/succeed/shallow/pr13747.rkt
@@ -1,0 +1,13 @@
+#lang racket
+
+;; Test that `require/typed` works at the top-level
+
+(require racket/sandbox)
+
+(define evaluator
+  (call-with-trusted-sandbox-configuration
+   (λ () (make-evaluator 'typed/racket/shallow))))
+
+(evaluator '(require/typed racket/base [values (Integer -> Integer)]))
+(evaluator '(values 1))
+

--- a/typed-racket-test/succeed/shallow/pr14138.rkt
+++ b/typed-racket-test/succeed/shallow/pr14138.rkt
@@ -1,0 +1,3 @@
+#lang typed/racket/shallow
+(: f (case->))
+(define (f x) (add1 "foo"))

--- a/typed-racket-test/succeed/shallow/pr226-variation-2.rkt
+++ b/typed-racket-test/succeed/shallow/pr226-variation-2.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket/shallow
+
+;; Chaperoned struct predicates must be wrapped in a contract.
+;; (Even though `struct-predicate-procedure?` will return
+;;  true for these values)
+
+(module untyped racket
+  (struct s ())
+  (define s?? (chaperone-procedure s? (lambda (x) (x) x)))
+  ;; provide enough names to trick #:struct
+  (provide s struct:s (rename-out [s?? s?])))
+
+(require/typed 'untyped
+  [#:struct s ()])
+
+(define (fail-if-called)
+  (error 'pr226 "Untyped code invoked a higher-order value passed as 'Any'"))
+
+(require typed/rackunit)
+(check-exn #rx"Untyped code invoked a higher-order value"
+  (lambda () (s? fail-if-called)))

--- a/typed-racket-test/succeed/shallow/pr226-variation-3.rkt
+++ b/typed-racket-test/succeed/shallow/pr226-variation-3.rkt
@@ -1,0 +1,26 @@
+#lang typed/racket/shallow
+
+;; Untyped should not be able to pass arbitrary code in
+;;  in place of a struct predicate.
+
+(module untyped racket
+  (struct s ())
+  (define (s?? x)
+    (when (box? x)
+      (set-box! x (void)))
+    #t)
+  (provide s struct:s (rename-out [s?? s?])))
+
+(require/typed 'untyped
+  [#:struct s ()])
+
+(: suitcase (Boxof '$$$))
+(define suitcase (box '$$$))
+
+(with-handlers ([exn:fail:contract? (lambda (x) (void))])
+  (s? suitcase)
+  (void))
+
+(require typed/rackunit)
+(check-exn exn:fail:contract?
+  (lambda () (unbox suitcase)))

--- a/typed-racket-test/succeed/shallow/pr241-variation-1.rkt
+++ b/typed-racket-test/succeed/shallow/pr241-variation-1.rkt
@@ -1,0 +1,20 @@
+#lang racket/base
+
+;; #:opaque predicates may change the type of their arguments in shallow
+
+(module untyped racket/base
+ (define (bad x)
+   (set-box! x 5)
+   #t)
+ (provide bad))
+
+(module typed typed/racket/base/shallow
+ (require typed/rackunit)
+ (require/typed (submod ".." untyped)
+   [#:opaque T bad])
+ (: b (Boxof String))
+ (define b (box "hi"))
+ (bad b)
+ (check-exn exn:fail:contract? (lambda () (unbox b))))
+
+(require 'typed)

--- a/typed-racket-test/succeed/shallow/pr241-variation-5.rkt
+++ b/typed-racket-test/succeed/shallow/pr241-variation-5.rkt
@@ -1,0 +1,400 @@
+#lang racket/base
+
+;; Check that any-wrap/c handles all base types
+;; We do this by:
+;; - enumerating the base types from `base-env/base-types.rkt`
+;; - for each type:
+;;   - define a value
+;;   - typecheck the value
+;;   - wrap the value as 'Any', check failure / use in untyped code
+
+(require
+  (for-syntax racket/base)
+  racket/require
+  (for-syntax racket/extflonum))
+
+(begin-for-syntax
+  (define (->fl n) (if (single-flonum-available?) (real->single-flonum n) n))
+  (define-syntax-rule (ext e)
+    (if (extflonum-available?)
+        `(e)
+        null))
+
+  (define-syntax-rule (single e)
+    (if (single-flonum-available?)
+        `(e)
+        null)))
+
+;; When #t, print a warning if some base-types do not have tests
+(define-for-syntax WARN-MISSING #t)
+
+;; `known-base-types` is a list of triples:
+;;  [TYPE VALUE USE]
+;; TYPE is a base type exported by Typed Racket
+;; VALUE is an expression with type TYPE
+;; USE is an untyped function of 1 argument, or #f.
+;;  If a function, a test will apply (USE (contract VALUE any-wrap/c)).
+;;  If #f, a test will assert that (contract VALUE any-wrap/c) fails.
+;; These USE functions should exercise specific functionality
+;;  and not be dummy functions like (lambda (x) x).
+(define-for-syntax known-base-types `(
+ ;; --- TODO missing value for these types
+ ;[Read-Table (or (current-readtable) (error 'noo)) #f]
+ ;[Internal-Definition-Context (syntax-local-make-definition-context) #f]
+ ;[Place (place hi (void)) place-kill]
+
+ ;; --- Types that should NOT be passes as 'Any' are marked with #f
+ [Async-ChannelTop (make-async-channel) #f]
+ [ClassTop object% #f]
+ [Compiled-Expression (compile-syntax #'#t) #f]
+ [Continuation-Mark-KeyTop (make-continuation-mark-key) #f]
+ [Continuation-Mark-Set (current-continuation-marks) #f]
+ [Custodian (current-custodian) #f]
+ [Identifier (syntax exit) #f]
+ [MPairTop (mcons 1 1) #f]
+ [Namespace (make-empty-namespace) #f]
+ [Parameterization (current-parameterization) #f]
+ [Prompt-TagTop (make-continuation-prompt-tag) #f]
+ [Security-Guard (current-security-guard) #f]
+ [SequenceTop empty-sequence #f]
+ [Special-Comment (make-special-comment 'hi) #f]
+ [Struct-Type-Property (let-values ([(n g s) (make-struct-type-property 'foo)]) n) #f]
+ [Syntax (syntax 'B) #f]
+ [Syntax-E (syntax-e (syntax 'A)) #f]
+ [Thread-CellTop (make-thread-cell 'X) #f]
+ [UnitTop (unit (import) (export)) #f]
+ [Variable-Reference (let ([x 4]) (#%variable-reference x)) #f]
+ [Weak-BoxTop (make-weak-box 3) #f]
+
+ ;; -- Normal base types
+ [Subprocess
+  (let*-values ([(sp _out _in _err) (subprocess #f #f #f ".")])
+    (close-output-port _in)
+    (close-input-port _out)
+    (close-input-port _err)
+    sp)
+  choice-evt]
+ ,@(single [Single-Flonum-Complex ,(make-rectangular (->fl 1f0) (->fl 1f0)) add1])
+ ,@(ext [ExtFlonum-Zero 0.0t0 extflround])
+ ,@(ext [ExtFlonum-Negative-Zero -0.0t0 extflround])
+ ,@(ext [ExtFlonum-Positive-Zero +0.0t0 extflround])
+ [Complex 0 add1]
+ [Number 0 add1]
+ [Exact-Complex 1/3+1/3i zero?]
+ [Inexact-Complex (let ([n (exact->inexact 1/3+1/3i)]) (if (not (real? n)) n (error 'pr241 "Failed to make Inexact-Complex"))) zero?]
+ [Float-Complex 1.0+1i add1]
+ [Imaginary 0+3i add1]
+ [Exact-Imaginary 0+3i add1]
+ ,@(ext [Inexact-Imaginary 0+3.0i add1])
+ [Exact-Number 0 add1]
+ [Real 0 add1]
+ [Nonpositive-Real 0 add1]
+ [Negative-Real -1 add1]
+ [Nonnegative-Real 0 add1]
+ [Positive-Real 1 add1]
+ [Real-Zero 0 add1]
+ [Inexact-Real (exact->inexact 1/3) add1]
+ ,@(single [Single-Flonum ,(->fl 1.0f0) add1])
+ [Nonpositive-Inexact-Real (- (exact->inexact 1/3)) add1]
+ ,@(single [Nonpositive-Single-Flonum ,(->fl -1.0f0) add1])
+ [Negative-Inexact-Real ,(->fl -1.0f0) add1]
+ ,@(single [Negative-Single-Flonum ,(->fl -1.0f0) add1])
+ ,@(single [Positive-Single-Flonum ,(->fl +1.0f0) add1])
+ [Nonnegative-Inexact-Real (exact->inexact 1/3) add1]
+ ,@(single [Nonnegative-Single-Flonum ,(->fl 1.0f0) add1])
+ [Positive-Inexact-Real ,(->fl 1.0f0) add1]
+ [Inexact-Real-Nan +nan.0 zero?]
+ [Inexact-Real-Zero 0.0 add1]
+ [Inexact-Real-Negative-Zero -0.0 add1]
+ [Inexact-Real-Positive-Zero 0.0 add1]
+ ,@(single [Single-Flonum-Nan ,(->fl +nan.f) add1])
+ ,@(single [Single-Flonum-Zero ,(->fl 0f0) add1])
+ ,@(single [Single-Flonum-Negative-Zero ,(->fl -0f0) add1])
+ ,@(single [Single-Flonum-Positive-Zero ,(->fl 0f0) add1])
+ [Float 1.0 add1]
+ [Flonum 1.0 add1]
+ [Nonpositive-Float -1.0 add1]
+ [Nonpositive-Flonum -1.0 add1]
+ [Negative-Float -1.0 add1]
+ [Negative-Flonum -1.0 add1]
+ [Nonnegative-Float 1.0 add1]
+ [Nonnegative-Flonum 1.0 add1]
+ [Positive-Float 1.0 add1]
+ [Positive-Flonum 1.0 add1]
+ [Float-Nan +nan.0 add1]
+ [Flonum-Nan +nan.0 add1]
+ [Float-Zero 0.0 add1]
+ [Flonum-Zero 0.0 add1]
+ [Float-Negative-Zero -0.0 add1]
+ [Flonum-Negative-Zero -0.0 add1]
+ [Float-Positive-Zero 0.0 add1]
+ [Flonum-Positive-Zero 0.0 add1]
+ [Exact-Rational 1/3 add1]
+ [Nonpositive-Exact-Rational 0/1 add1]
+ [Negative-Exact-Rational -3/2 add1]
+ [Nonnegative-Exact-Rational 1 add1]
+ [Positive-Exact-Rational 4/3 add1]
+ [Integer 0 add1]
+ [Nonpositive-Integer 0 add1]
+ [Negative-Integer -2 add1]
+ [Exact-Nonnegative-Integer 0 add1]
+ [Nonnegative-Integer 0 add1]
+ [Natural 62 add1]
+ [Exact-Positive-Integer 6 add1]
+ [Positive-Integer 6 add1]
+ [Fixnum 9 add1]
+ [Negative-Fixnum -3 add1]
+ [Nonpositive-Fixnum -4 add1]
+ [Nonnegative-Fixnum 4 add1]
+ [Positive-Fixnum 2 add1]
+ [Index 3 add1]
+ [Positive-Index 3 add1]
+ [Byte 0 add1]
+ [Positive-Byte 1 add1]
+ [Zero 0 add1]
+ [One  1 add1]
+ ,@(ext [ExtFlonum pi.t extflround])
+ ,@(ext [Nonpositive-ExtFlonum (->extfl -1) extflround])
+ ,@(ext [Negative-ExtFlonum (->extfl -1) extflround])
+ ,@(ext [Nonnegative-ExtFlonum (->extfl 1) extflround])
+ ,@(ext [Positive-ExtFlonum (->extfl 1) extflround])
+ ,@(ext [ExtFlonum-Nan +nan.t (lambda (n) (extfl= n n))])
+
+ [Any 'a boolean?]
+ [Boolean #f not]
+ [BoxTop (box 5) boolean?]
+ [Byte-PRegexp (byte-pregexp #"\\d\\d") (lambda (p) (regexp-match? p "013a"))]
+ [Byte-Regexp (byte-regexp #"hi$") (lambda (p) (regexp-match? p "hi"))]
+ [Bytes #"hello" bytes-length]
+ [Bytes-Converter (or (bytes-open-converter "UTF-8" "UTF-8") (error 'pr241 "Failed to make bytes converter")) bytes-close-converter]
+ [ChannelTop (make-channel) channel-try-get]
+ [Char #\space char->integer]
+ [Datum 'A (lambda (x) (datum->syntax #f x))]
+ [Environment-Variables (current-environment-variables) environment-variables-names]
+ [EOF eof eof-object?]
+ ,@(ext [ExtFlVector (extflvector pi.t) extflvector-length])
+ [FSemaphore (make-fsemaphore 0) fsemaphore-post]
+ [False #f not]
+ [FlVector (flvector 1.14 2.14 3.14) flvector-length]
+ [FxVector (fxvector 1) fxvector-length]
+ [HashTableTop (hash) (lambda (h) (hash-ref h 'a #f))]
+ [Impersonator-Property (let-values ([(i i? i-val) (make-impersonator-property 'i)]) i) (lambda (i) (impersonate-procedure (lambda () (void)) #f i 2))]
+ [Input-Port (current-input-port) port?]
+ [Inspector (current-inspector) (lambda (i) (parameterize ([current-inspector i]) (void)))]
+ [Keyword (string->keyword "hi") keyword->string]
+ [Log-Level 'info symbol->string]
+ [Log-Receiver (make-log-receiver (current-logger) 'info) choice-evt]
+ [Logger (current-logger) (lambda (l) (log-level? l 'info))]
+ [Module-Path "hello.rkt" module-path?]
+ [Mutable-HashTableTop (make-hash) (lambda (h) (hash-ref h 'a #f))]
+ [Mutable-VectorTop (vector 1 2 3) (lambda (x) (vector-ref x 0))]
+ [Null '() length]
+ [Output-Port (current-output-port) port?]
+ [PRegexp #px"\\d\\d" (lambda (p) (regexp-match? p "013a"))]
+ [Path (current-directory) path->string]
+ [Path-For-Some-System (current-directory) path->string]
+ [Path-String "foo/bar" relative-path?]
+ [Place-Channel (let-values ([(p1 p2) (place-channel)]) p1) choice-evt]
+ [Port (current-input-port) port?]
+ [Pretty-Print-Style-Table (pretty-print-current-style-table) (lambda (x) (pretty-print-extend-style-table x '() '()))]
+ [Procedure (lambda (x) x) (lambda (f) (procedure-arity-includes? f 1))]
+ [Pseudo-Random-Generator (current-pseudo-random-generator) pseudo-random-generator->vector]
+ [Regexp #rx"hi$" (lambda (p) (regexp-match? p "hi"))]
+ [Resolved-Module-Path (make-resolved-module-path (current-directory)) resolved-module-path-name]
+ [Semaphore (make-semaphore) semaphore-post]
+ [Sexp (syntax->datum (syntax 'foo)) (lambda (x) x)]
+ [String "yolo" string->symbol]
+ [Symbol 'a symbol->string]
+ [TCP-Listener (tcp-listen 0) choice-evt]
+ [Thread (thread (lambda () (void))) choice-evt]
+ [Thread-Group (current-thread-group) make-thread-group]
+ [True #t not]
+ [UDP-Socket (udp-open-socket) udp-close]
+ [VectorTop (vector 1 2 3) (lambda (x) (vector-ref x 0))]
+ [Void (void) void?]
+ [Weak-HashTableTop (make-weak-hash) (lambda (h) (hash-ref h 'a #f))]
+ [Will-Executor (make-will-executor) choice-evt]
+))
+
+(define-values-for-syntax (base-untyped* base-typed*)
+  (for/fold ([u* '()] [t* '()])
+            ([tvf (in-list known-base-types)])
+    (unless (and (list? tvf) (= 3 (length tvf)))
+      (error 'pr241 "Expected (TYPE VAL FUN)"))
+    (with-syntax ([type (car tvf)]
+                  [val (cadr tvf)]
+                  [use (caddr tvf)]
+                  [pos-blame 'pr241-test]
+                  [neg-blame 'known-base-types]
+                  [id (gensym (car tvf))])
+      ;; Wrap value in contract, pass it to `use` or assert a wrap failure
+      ;; Ignore the result
+      (define u-stx
+        (if (eq? #f (caddr tvf))
+          #'(with-handlers ([exn:fail:contract? (lambda (e) (void))])
+              (contract any-wrap/c val 'pos-blame 'neg-blame)
+              (error 'pr241 (format "Higher-Order value '~a' incorrectly allowed as Any" val)))
+          #'((lambda any* (void))
+             (use (contract any-wrap/c val 'pos-blame 'neg-blame)))))
+      ;; Bind the value to a typed identifier
+      (define t-stx
+        #'(begin (: id type) (define id val)))
+      (values
+        (cons u-stx u*)
+        (cons t-stx t*)))))
+
+;; `known-polymorphic-types` is a list of 4-lists:
+;;   [TYPE-TAG TYPE VALUE USE]
+;; TYPE-TAG is a polymorphic type exported by Typed Racket
+;; TYPE is an instantiation of TYPE-TAG
+;; VALUE is an expression with type TYPE
+;; USE is the same as for `known-base-types`
+(define-for-syntax known-poly-types '(
+  ;; --- Higher-Order polymorphic types
+  [Async-Channelof (Async-Channelof Any) (make-async-channel) #f]
+  [Continuation-Mark-Keyof (Continuation-Mark-Keyof Any) (make-continuation-mark-key 'X) #f]
+  [Custodian-Boxof (Custodian-Boxof Integer) (make-custodian-box (current-custodian) 1) #f]
+  [Ephemeronof (Ephemeronof Integer) (make-ephemeron 'key 4) #f]
+  [Evtof (Evtof String) never-evt choice-evt]
+  [Futureof (Futureof Integer) (future (lambda () 4)) #f]
+  [MPairof (MPairof Integer String) (mcons 4 "ad") #f]
+  [MListof (MListof Integer) (mcons 4 '()) #f]
+  [Prompt-Tagof (Prompt-Tagof Any Any) (make-continuation-prompt-tag) #f]
+  [Struct-Property (Struct-Property (U Exact-Nonnegative-Integer Input-Port)) prop:input-port #f]
+  [Syntaxof (Syntaxof Integer) #'1 #f]
+  [Thread-Cellof (Thread-Cellof Integer) (make-thread-cell 1) #f]
+  [Weak-Boxof (Weak-Boxof Integer) (make-weak-box 1) #f]
+
+  ;; -- Wrappable polymorphic types
+  [Boxof (Boxof Integer) (box 3) (lambda (v) (add1 (unbox v)))]
+  [Channelof (Channelof Integer) (make-channel) channel-try-get]
+  [HashTable (HashTable Symbol String) (hash) (lambda (h) (hash-ref h 'a #f))]
+  [Immutable-HashTable (Immutable-HashTable Symbol String) (hash) (lambda (h) (hash-set h 'a "a"))]
+  [Immutable-Vector (Immutable-Vector Integer) (vector-immutable 1) (lambda (v) (vector-ref v 0))]
+  [Immutable-Vectorof (Immutable-Vectorof Integer) (vector-immutable 1) (lambda (v) (vector-ref v 0))]
+  [Listof (Listof Integer) (list 1) (lambda (xs) (add1 (car xs)))]
+  [Mutable-HashTable (Mutable-HashTable Symbol String) (make-hash)
+   (lambda (h)
+     (hash-ref h 'a #f)
+     (with-handlers ([exn:fail:contract? void])
+       (hash-set! h 'a "a")
+       (error 'pr241 "mutable hashtable ~a incorrectly allowed to be set!" h)))]
+  [Mutable-Vector (Mutable-Vector Integer) (vector 1)
+   (lambda (v)
+     (vector-ref v 0)
+     (with-handlers ([exn:fail:contract? void])
+       (vector-set! v 0 1)
+       (error 'pr241 "mutable vector ~a incorrectly allowed to be set!" v)))]
+  [Mutable-Vectorof (Mutable-Vectorof Integer) (vector 1)
+   (lambda (v)
+     (vector-ref v 0)
+     (with-handlers ([exn:fail:contract? void])
+       (vector-set! v 0 1)
+       (error 'pr241 "mutable vectorof ~a incorrectly allowed to be set!" v)))]
+  [Option (Option Integer) 1 add1]
+  [Pair (Pair Integer Boolean) (cons 1 #t) (lambda (v) (add1 (car v)))]
+  [Pairof (Pairof Integer Boolean) (cons 1 #f) (lambda (v) (add1 (car v)))]
+  [Promise (Promise Integer) (delay 3) force]
+  [Sequenceof (Sequenceof Natural) '(1 2 3) sequence->list]
+  [Setof (Setof Integer) (set) set-empty?]
+  [Sexpof (Sexpof Integer) (syntax->datum #'(1 2 3)) (lambda (xs) (add1 (car xs)))]
+  [Weak-HashTable (Weak-HashTable Symbol String) (make-weak-hash)
+   (lambda (h)
+     (hash-ref h 'a #f)
+     (with-handlers ([exn:fail:contract? void])
+       (hash-set! h 'a "a")
+       (error 'pr241 "weak hashtable ~a incorrectly allowed to be set!" h)))]
+  [Vector (Vector Integer) (vector 1) (lambda (v) (vector-ref v 0))]
+  [Vectorof (Vectorof Integer) (vector 1) (lambda (v) (add1 (vector-ref v 0)))]
+))
+
+;; We don't have values to test these types with, but trust they're wrapped correctly
+(define-for-syntax whitelist '(
+ (Undefined . #f)
+ (Nothing . #f)
+ (Struct-TypeTop . #f)
+ (Module-Path-Index . #f)
+ (Compiled-Module-Expression . #f)
+ (Namespace-Anchor . #f)
+))
+
+(define-values-for-syntax (poly-untyped* poly-typed*)
+  (for/fold ([u* '()] [t* '()])
+            ([gtvf (in-list known-poly-types)])
+    (unless (and (list? gtvf) (= 4 (length gtvf)))
+      (error 'pr241 "Expected (TYPE-TAG TYPE VAL FUN)"))
+    (with-syntax ([_tag (car gtvf)] ;; Unused here
+                  [type (cadr gtvf)]
+                  [val (caddr gtvf)]
+                  [use (cadddr gtvf)]
+                  [pos-blame 'pr241-test]
+                  [neg-blame 'known-poly-types]
+                  [id (gensym (car gtvf))])
+      ;; Wrap value in contract, pass it to `use` or assert a wrap failure
+      ;; Ignore the result
+      (define u-stx
+        (if (eq? #f (cadddr gtvf))
+          #'(with-handlers ([exn:fail:contract? (lambda (e) (void))])
+              (contract any-wrap/c val 'pos-blame 'neg-blame)
+              (error 'pr241 (format "Higher-Order value '~a' incorrectly allowed as Any" val)))
+          #'((lambda any* (void))
+             (use (contract any-wrap/c val 'pos-blame 'neg-blame)))))
+      ;; Bind the value to a typed identifier
+      (define t-stx
+        #'(begin (: id type) (define id val)))
+      (values
+        (cons u-stx u*)
+        (cons t-stx t*)))))
+
+(define-syntax (known-types->tests stx)
+  ;; Put the `use-` list in an untyped module,
+  ;;  put the `declare-` list in a typed module.
+  #`(begin
+      (module check-uses racket
+       (require
+         racket/async-channel
+         racket/flonum
+         racket/extflonum
+         racket/fixnum
+         typed-racket/utils/any-wrap)
+       #,@base-untyped*
+       #,@poly-untyped*
+       (printf "Successfully used ~a wrapped values\n"
+         #,(+ (length base-untyped*) (length poly-untyped*))))
+      (module check-types typed/racket/shallow
+        (require
+          racket/flonum
+          racket/fixnum
+          racket/extflonum)
+        (require/typed racket/base
+          [variable-reference->module-path-index (-> Any Module-Path-Index)])
+        (require/typed racket/async-channel
+          [make-async-channel (-> (Async-Channelof Any))])
+        #,@base-typed*
+        #,@poly-typed*
+        (printf "Successfully typechecked ~a identifiers\n"
+          #,(+ (length base-typed*) (length poly-typed*))))))
+
+(define-for-syntax (known-string? str)
+  (define s (string->symbol str))
+  (member* s known-base-types known-poly-types whitelist))
+
+(define-for-syntax (member* s . x**)
+  (for*/or ([x* (in-list x**)]
+            [x (in-list x*)])
+    (eq? s (car x))))
+
+(require
+  (filtered-in
+    (if WARN-MISSING
+      (lambda (str)
+        (when (not (known-string? str)) (printf "WARNING: Missing test for base type '~a'\n" str))
+        #f)
+      (lambda (str) #f))
+    typed-racket/base-env/base-types))
+
+(known-types->tests)
+
+(require
+ 'check-uses
+ 'check-types)

--- a/typed-racket-test/succeed/shallow/pr390-variation-4.rkt
+++ b/typed-racket-test/succeed/shallow/pr390-variation-4.rkt
@@ -1,0 +1,47 @@
+#lang typed/racket/base/shallow
+
+;; Test Hash Table functions with "complicated" types
+
+(require typed/rackunit)
+
+(test-case "hash-copy" ;; returns a mutable hash with same 'key-holding strength'
+  (check-pred hash?
+    (ann (hash-copy (make-immutable-hash)) Mutable-HashTableTop))
+  (check-pred hash?
+    (ann (hash-copy (make-immutable-hash '((1 . 1)))) (Mutable-HashTable Integer Integer)))
+
+  (check-pred hash?
+    (ann (hash-copy (make-hash '((1 . 1)))) (Mutable-HashTable Integer Integer)))
+  (check-pred hash?
+    (ann (hash-copy (make-hash)) Mutable-HashTableTop))
+
+  (check-pred hash-weak?
+    (ann (hash-copy (make-weak-hash '((1 . 1)))) (Weak-HashTable Integer Integer)))
+  (check-pred hash-weak?
+    (ann (hash-copy (make-weak-hash)) Weak-HashTableTop)))
+
+(test-case "hash-copy-clear" ;; returns hash with same mutability
+  (check-pred immutable?
+    (ann (hash-copy-clear (make-immutable-hash)) (Immutable-HashTable Any Any)))
+  (check-pred immutable?
+    (ann (hash-copy-clear (make-immutable-hash '((a . b)))) (Immutable-HashTable Symbol Symbol)))
+
+  (check-pred hash?
+    (ann (hash-copy-clear (make-hash)) Mutable-HashTableTop))
+  (check-pred hash?
+    (ann (hash-copy-clear (make-hash '((a . b)))) (Mutable-HashTable Symbol Symbol)))
+
+  (check-pred hash-weak?
+    (ann (hash-copy-clear (make-weak-hash)) Weak-HashTableTop))
+  (check-pred hash-weak?
+    (ann (hash-copy-clear (make-weak-hash '((a . b)))) (Weak-HashTable Symbol Symbol))))
+
+(test-case "hash-remove" ;; only for immutable hashtables, but the TR type allows mutable/weak
+  (check-pred immutable?
+    (ann (hash-remove (make-immutable-hash '((a . A))) 'a) (Immutable-HashTable Symbol Symbol)))
+
+  (check-exn exn:fail:contract?
+    (λ () (hash-remove (make-hash '((a . A))) 'a)))
+
+  (check-exn exn:fail:contract?
+    (λ () (hash-remove (make-weak-hash '((a . A))) 'a))))

--- a/typed-racket-test/succeed/shallow/pr476-compile-time-images.rkt
+++ b/typed-racket-test/succeed/shallow/pr476-compile-time-images.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/shallow
+
+(require typed/images/compile-time)
+
+(require (for-syntax images/icons/stickman))
+
+(cons (compiled-bitmap (standing-stickman-icon #:height 8 #:head-color "red" #:body-color "red") 90)
+      (compiled-bitmap-list (for/list ([step (in-range 0.0 1.0 1/12)]) (running-stickman-icon step #:height 8))))

--- a/typed-racket-test/succeed/shallow/prefab-field-provide.rkt
+++ b/typed-racket-test/succeed/shallow/prefab-field-provide.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+
+(module m typed/racket/base/shallow
+
+  (struct foo ([x : Integer]) #:prefab)
+  (define f (foo 42))
+  (struct bar ([y : Integer]) #:prefab #:mutable)
+  (define b (bar 43))
+  (provide f foo-x b bar-y set-bar-y!))
+
+(module n racket/base
+  (require (submod ".." m) rackunit)
+  (set-bar-y! b 44)
+  (check-not-exn (lambda () (set-bar-y! b "44"))))
+
+(require (submod 'n))

--- a/typed-racket-test/succeed/shallow/prefab.rkt
+++ b/typed-racket-test/succeed/shallow/prefab.rkt
@@ -1,0 +1,471 @@
+#lang typed/racket/shallow
+
+;; Test prefab struct declarations
+
+(require typed/rackunit)
+(provide (all-defined-out))
+
+(struct foo ([x : Symbol]) #:prefab)
+(struct bar foo ([y : String] [z : String]) #:prefab)
+(define-struct foo* ([x : Symbol]) #:prefab)
+(define-struct (bar* foo*) ([y : String] [z : String]) #:prefab)
+
+(: a-bar (Prefab (bar foo 1) Symbol String String)) 
+(define a-bar (bar 'foo "bar1" "bar2"))
+
+(ann (foo-x (foo 'foo)) Symbol)
+(ann (bar-y (bar 'foo "bar1" "bar2")) String)
+(ann (foo-x #s(foo "hi")) String)
+(ann (foo-x #s((bar foo 1) #t 42 "!")) True)
+(ann (bar-y #s((bar foo 1) #t 42 "!")) Number)
+(ann (bar-z #s((bar foo 1) #t 42 "!")) String)
+
+(foo*-x (make-foo* 'foo))
+(bar*-y (make-bar* 'foo "bar1" "bar2"))
+
+;; prefab keys may be normalized or not
+(: a-bar-2 (Prefab (bar 2 foo 1 (0 #f) #()) Symbol String String))
+(define a-bar-2 (bar 'foo "bar1" "bar2"))
+
+;; prefab subtyping is computed via the key and field length
+(: a-bar-3 (Prefab foo Symbol))
+(define a-bar-3 (bar 'foo "bar1" "bar2"))
+
+
+(: read-some-unknown-foo1 (-> (PrefabTop foo 1) Any))
+(define (read-some-unknown-foo1 f)
+  (foo-x f))
+
+(: read-some-unknown-foo2 (-> (Prefab foo Any) Any))
+(define (read-some-unknown-foo2 f)
+  (foo-x f))
+
+
+(ann read-some-unknown-foo1 (-> (Prefab foo Any) Any))
+
+(ann read-some-unknown-foo2 (-> (PrefabTop foo 1) Any))
+ 
+
+(: read-some-unknown-foo3 (-> Any Any))
+(define (read-some-unknown-foo3 x)
+  (if (foo? x)
+      (read-some-unknown-foo1 x)
+      42))
+
+
+(: read-some-unknown-foo4 (-> Any Any))
+(define (read-some-unknown-foo4 x)
+  (if (bar? x)
+      (read-some-unknown-foo1 x)
+      42))
+
+(define-predicate foo/sym1? foo)
+(: read-known-foo1 (-> Any Symbol))
+(define (read-known-foo1 f)
+  (if (foo/sym1? f)
+      (foo-x f)
+      'other))
+
+(: foo/sym2? (-> Any Boolean : foo))
+(define (foo/sym2? x)
+  (and (foo? x) (symbol? (foo-x x))))
+
+(: read-known-foo2 (-> Any Symbol))
+(define (read-known-foo2 f)
+  (if (foo/sym2? f)
+      (foo-x f)
+      'other))
+
+(: bar/str-str? (-> Any Boolean : bar))
+(define (bar/str-str? x)
+  (and (foo? x)
+       (symbol? (foo-x x))
+       (bar? x)
+       (string? (bar-y x))
+       (string? (bar-z x))))
+
+(: foo/sym-or-num? (-> Any Boolean : (Prefab foo (U Symbol Number))))
+(define (foo/sym-or-num? x)
+  (and (foo? x) (or (symbol? (foo-x x))
+                    (number? (foo-x x)))))
+
+(: foo/sym-or-str? (-> Any Boolean : (Prefab foo (U Symbol String))))
+(define (foo/sym-or-str? x)
+  (and (foo? x) (or (symbol? (foo-x x))
+                    (string? (foo-x x)))))
+
+(: foo/num-or-str? (-> Any Boolean : (Prefab foo (U Number String))))
+(define (foo/num-or-str? x)
+  (and (foo? x) (or (number? (foo-x x))
+                    (string? (foo-x x)))))
+
+(: read-known-foo3 (-> Any Symbol))
+(define (read-known-foo3 f)
+  (if (and (foo/sym-or-num? f)
+           (foo/sym-or-str? f)
+           (foo/num-or-str? f))
+      (+ 'dead "code")
+      'other))
+
+(: empty-intersection-check1 (-> Any Any))
+(define (empty-intersection-check1 x)
+  (cond
+    [(and (foo? x) (foo*? x)) (+ 1 "2")]
+    [else 42]))
+
+(: empty-intersection-check2 (-> Any Any))
+(define (empty-intersection-check2 x)
+  (cond
+    [(and (foo? x) (bar*? x)) (+ 1 "2")]
+    [else 42]))
+
+;; Mutable prefab structs
+
+(struct baz ([x : String]) #:mutable #:prefab)
+(define-struct baz* ([x : String]) #:mutable #:prefab)
+
+(define a-baz (baz "baz"))
+(set-baz-x! a-baz "baz2")
+(baz-x a-baz)
+
+(define a-baz* (make-baz* "baz"))
+(set-baz*-x! a-baz* "baz2")
+(baz*-x a-baz*)
+
+
+(: set-some-baz-x! (All (A) (-> (Prefab (baz #(0)) A) A Void)))
+(define (set-some-baz-x! b val)
+  (set-baz-x! b val)) 
+
+
+(: read-some-baz-x (All (A) (-> (Prefab (baz #(0)) A) A)))
+(define (read-some-baz-x b)
+  (baz-x b))
+
+
+(: read-some-unknown-baz-x1 (-> (PrefabTop (baz #(0)) 1) Any))
+(define (read-some-unknown-baz-x1 b)
+  (baz-x b))
+
+
+(: read-some-unknown-baz-x2 (-> Any Any))
+(define (read-some-unknown-baz-x2 b)
+  (if (baz? b)
+      (baz-x b)
+      42))
+
+
+;; Polymorphic prefab structs
+
+(struct (X) poly ([x : X]) #:prefab)
+(define-struct (X) poly* ([x : X]) #:prefab)
+
+(poly-x (poly "foo"))
+(poly-x (poly 3))
+(poly-x #s(poly "foo"))
+
+(poly*-x (make-poly* "foo"))
+(poly*-x (make-poly* 3))
+(poly*-x #s(poly* "foo"))
+
+;; Test match (indirectly tests unsafe-struct-ref)
+(match (foo 'x) [(foo s) s])
+(match (foo* 'x) [(foo* s) s])
+
+(struct point ([x : Number] [y : Number])
+  #:prefab)
+
+;; although point prefabs with strings can be
+;; created, the constructor `point` should enforce
+;; the fields we asked it to enforce
+(assert-typecheck-fail
+ (point "1" "2")) 
+
+;; the point predicate does not tell us
+;; what values are in the point
+(: maybe-point-x (-> Any Void))
+(define (maybe-point-x p)
+  (when (point? p)
+    (assert-typecheck-fail (ann (point-x p) Number))
+    (void)))
+
+
+(struct initials ([first : Symbol] [last : Symbol])
+  #:prefab
+  #:mutable)
+
+
+;; although initials prefabs with strings can be
+;; created, the constructor `initials` should enforce
+;; the fields we asked it to enforce
+(assert-typecheck-fail
+ (initials "1" "2"))
+
+
+;; the initials predicate does not tell us
+;; what values are in the field
+(: maybe-initials-first (-> Any Symbol))
+(define (maybe-initials-first i)
+  (cond
+    [(initials? i)
+     (assert-typecheck-fail
+      (initials-first i)
+      #:result 'default)]
+    [else 'also-okay]))  
+
+;; we cannot write to a mutable prefab when
+;; we do not know what type it's fields have
+;; (and the predicate does not tell us that)
+(: maybe-set-initials-first! (-> Any Void))
+(define (maybe-set-initials-first! i)
+  (when (initials? i)
+    (assert-typecheck-fail
+     (set-initials-first! i (error "any-value")))))
+
+;; should fail because the number of fields for initials is
+;; incorrect (i.e. the initials we defined above has 2 fields
+;; but this PrefabTop says its for initials with 3 fields)
+(: set-some-initials-first! (-> (PrefabTop (initials #(0 1)) 3) Void))
+(define (set-some-initials-first! i)
+  (assert-typecheck-fail
+   (set-initials-first! i (error "any-value"))))
+
+
+
+(struct (A B) tuple ([fst : A] [snd : B]) #:prefab)
+
+(define-predicate is-tuple? (tuple Any Any))
+(define-predicate is-num-tuple? (tuple Number Number))
+
+(define good-point (tuple 1 2))
+(define bad-point1 (tuple "1" 2))
+(define bad-point2 (tuple 1 "2"))
+
+(unless (is-tuple? (if (zero? (random 1)) good-point "other value"))
+  (error "is-tuple? broken!"))
+
+(unless (is-num-tuple? (if (zero? (random 1)) good-point "other value"))
+  (error "is-tuple? broken!"))
+
+(when (is-num-tuple? (if (zero? (random 1)) bad-point1 good-point))
+  (error "is-num-tuple? broken!"))
+
+(when (is-num-tuple? (if (zero? (random 1)) bad-point2 good-point))
+  (error "is-num-tuple? broken!"))
+
+
+(struct num-num ([n1 : Number] [n2 : Number]) #:prefab)
+(struct num-num-str-str-str num-num ([s1 : String] [s2 : String] [s3 : String]) #:prefab)
+
+
+(num-num 1 2)
+(assert-typecheck-fail
+ (num-num 1 "2"))
+(assert-typecheck-fail
+ (num-num "1" 2))
+(num-num-str-str-str 1 2 "1" "2" "3")
+(assert-typecheck-fail
+ (num-num-str-str-str 1 2 1 "2" "3"))
+(assert-typecheck-fail
+ (num-num-str-str-str 1 2 "1" 2 "3"))
+(assert-typecheck-fail
+ (num-num-str-str-str 1 2 "1" "2" 3))
+(unless (equal? 1 (ann (num-num-n1 (num-num-str-str-str 1 2 "3" "4" "5")) Number))
+  (error "oh no! didn't get 1!"))
+(unless (equal? 1 (ann (num-num-n1 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) Number))
+  (error "oh no! didn't get 1!"))
+(unless (equal? 2 (ann (num-num-n2 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) Number))
+  (error "oh no! didn't get 2!"))
+(unless (equal? 2 (ann (num-num-n2 (num-num-str-str-str 1 2 "3" "4" "5")) Number))
+  (error "oh no! didn't get 2!"))
+(unless (equal? "3" (ann (num-num-str-str-str-s1 (num-num-str-str-str 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"3\""))
+(unless (equal? "3" (ann (num-num-str-str-str-s1 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"3\""))
+(unless (equal? "4" (ann (num-num-str-str-str-s2 (num-num-str-str-str 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"4\""))
+(unless (equal? "4" (ann (num-num-str-str-str-s2 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"4\""))
+(unless (equal? "5" (ann (num-num-str-str-str-s3 (num-num-str-str-str 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"5\""))
+(unless (equal? "5" (ann (num-num-str-str-str-s3 #s((num-num-str-str-str num-num 2) 1 2 "3" "4" "5")) String))
+  (error "oh no! didn't get \"5\""))
+
+
+(unless (equal?
+         (let ([val : (PrefabTop (num-num-str-str-str num-num 2) 5)
+                    #s((num-num-str-str-str num-num 2) "one" "two" 'three 'four 'five)])
+           (ann (cond
+                  [(not (num-num? val)) (+ "dead" 'code)]
+                  [(not (num-num-str-str-str? val)) (+ "dead" 'code)]
+                  [(string? (num-num-n1 val)) (num-num-n1 val)]  
+                  [(string? (num-num-n2 val)) (num-num-n2 val)]
+                  [(symbol? (num-num-str-str-str-s1 val)) (symbol->string (num-num-str-str-str-s1 val))]
+                  [(symbol? (num-num-str-str-str-s2 val)) (symbol->string (num-num-str-str-str-s2 val))]
+                  [(symbol? (num-num-str-str-str-s3 val)) (symbol->string (num-num-str-str-str-s3 val))]
+                  [else "missed"])
+                String))
+         "one")
+  (error "accessors broken num-num-str-str-str 1")) 
+
+(unless (equal?
+         (let ([val : Any #s((num-num-str-str-str num-num 2) "one" "two" 'three 'four 'five)])
+           (ann (cond
+                  [(not (num-num-str-str-str? val)) "nope"]
+                  [(string? (num-num-n1 val)) (num-num-n1 val)] 
+                  [(string? (num-num-n2 val)) (num-num-n2 val)]
+                  [(symbol? (num-num-str-str-str-s1 val)) (symbol->string (num-num-str-str-str-s1 val))]
+                  [(symbol? (num-num-str-str-str-s2 val)) (symbol->string (num-num-str-str-str-s2 val))]
+                  [(symbol? (num-num-str-str-str-s3 val)) (symbol->string (num-num-str-str-str-s3 val))]
+                  [else "missed"])
+                String))
+         "one")
+  (error "accessors broken num-num-str-str-str 2"))
+ 
+(unless (equal?
+         (match (ann #s((num-num-str-str-str num-num 2) "one" "two" three four five) Any)
+           [(num-num-str-str-str fld1 fld2 fld3 fld4 fld5)
+            (list fld1 fld2 fld3 fld4 fld5)])
+         (list "one" "two" 'three 'four 'five))
+  (error "prefab pattern matching broken! num-num-str-str-str"))
+
+
+
+(struct sym-sym ([n1 : Symbol] [n2 : Symbol]) #:prefab #:mutable)
+(struct sym-sym-str-str-str sym-sym ([s1 : String] [s2 : String] [s3 : String]) #:prefab)
+
+
+(sym-sym 'one 'two)
+(sym-sym-str-str-str 'one 'two "1" "2" "3")
+(unless (equal? 'one (ann (sym-sym-n1 (sym-sym-str-str-str 'one 'two "3" "4" "5")) Symbol))
+  (error "oh no! didn't get 'one!"))
+(unless (equal? 'two (ann (sym-sym-n2 (sym-sym-str-str-str 'one 'two "3" "4" "5")) Symbol))
+  (error "oh no! didn't get 'two!"))
+(unless (equal? "3" (ann (sym-sym-str-str-str-s1 (sym-sym-str-str-str 'one 'two "3" "4" "5")) String))
+  (error "oh no! didn't get \"3\""))
+(unless (equal? "4" (ann (sym-sym-str-str-str-s2 (sym-sym-str-str-str 'one 'two "3" "4" "5")) String))
+  (error "oh no! didn't get \"4\""))
+(unless (equal? "5" (ann (sym-sym-str-str-str-s3 (sym-sym-str-str-str 'one 'two "3" "4" "5")) String))
+  (error "oh no! didn't get \"5\""))
+
+(unless
+    (equal?
+     (let ([val : Any (read (open-input-string "#s((sym-sym-str-str-str sym-sym 2 #(0 1)) \"one\" \"two\" 'three 'four 'five)"))])
+       (ann (cond
+              [(not (sym-sym-str-str-str? val)) "nope"]
+              [else
+               (let ([fld1 (sym-sym-n1 val)]
+                     [fld2 (sym-sym-n2 val)]
+                     [fld3 (sym-sym-str-str-str-s1 val)]
+                     [fld4 (sym-sym-str-str-str-s2 val)]
+                     [fld5 (sym-sym-str-str-str-s3 val)])
+                 (cond
+                   [(string? fld1) fld1]
+                   [(string? fld2) fld2]
+                   [(symbol? fld3) (symbol->string fld3)]
+                   [(symbol? fld4) (symbol->string fld4)]
+                   [(symbol? fld5) (symbol->string fld5)]
+                   [else "missed"]))])
+            String))
+     "one")
+  (error "accessors broken sym-sym-str-str-str"))
+
+(match (ann (read (open-input-string "#s((sym-sym-str-str-str sym-sym 2 #(0 1)) \"one\" \"two\" three four five)"))
+            Any)
+  [(sym-sym-str-str-str fld1 fld2 fld3 fld4 fld5)
+   (unless (equal? (list fld1 fld2 fld3 fld4 fld5)
+                   (list "one" "two" 'three 'four 'five))
+     (error 'sym-sym-str-str-str "prefab pattern matching broken! got: ~a\n"
+            (list fld1 fld2 fld3 fld4 fld5)))]
+  [val (error "prefab pattern matching broken! sym-sym-str-str-str did not match ~a\n"
+              val)])
+
+
+(struct num-num-sym-sym-sym num-num ([s1 : Symbol] [s2 : Symbol] [s3 : Symbol]) #:prefab #:mutable)
+
+(num-num-sym-sym-sym 1 2 'three 'four 'five)
+(unless (equal? 1 (ann (num-num-n1 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Number))
+  (error "oh no! didn't get 1e!"))
+(unless (equal? 2 (ann (num-num-n2 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Number))
+  (error "oh no! didn't get 2!"))
+(unless (equal? 'three (ann (num-num-sym-sym-sym-s1 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Symbol))
+  (error "oh no! didn't get \"3\""))
+(unless (equal? 'four (ann (num-num-sym-sym-sym-s2 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Symbol))
+  (error "oh no! didn't get \"4\""))
+(unless (equal? 'five (ann (num-num-sym-sym-sym-s3 (num-num-sym-sym-sym 1 2 'three 'four 'five)) Symbol))
+  (error "oh no! didn't get \"5\""))
+
+
+(unless
+    (equal?
+     (let ([val : Any (read (open-input-string "#s((num-num-sym-sym-sym #(0 1 2) num-num 2) \"one\" \"two\" 3 4 5)"))])
+       (ann (cond
+              [(not (num-num-sym-sym-sym? val)) "nope"]
+              [else
+               (let ([fld1 (num-num-n1 val)] 
+                     [fld2 (num-num-n2 val)]
+                     [fld3 (num-num-sym-sym-sym-s1 val)]
+                     [fld4 (num-num-sym-sym-sym-s2 val)]
+                     [fld5 (num-num-sym-sym-sym-s3 val)])
+                 (cond
+                   [(string? fld1) fld1]
+                   [(string? fld2) fld2]
+                   [(number? fld3) (number->string fld3)]
+                   [(number? fld4) (number->string fld4)]
+                   [(number? fld5) (number->string fld5)]
+                   [else "missed"]))])
+            String))
+     "one")
+  (error "accessors broken num-num-sym-sym-sym"))
+
+(struct str-str ([s1 : String] [s2 : String]) #:prefab #:mutable)
+(struct str-str-num-num-num str-str ([n1 : Number] [n2 : Number] [n3 : Number]) #:prefab #:mutable)
+
+
+(unless
+    (equal?
+     (let ([val : Any (read (open-input-string
+                             "#s((str-str-num-num-num #(0 1 2) str-str 2 #(0 1)) one two three four five)"))])
+       (ann (cond
+              [(not (str-str-num-num-num? val)) "nope"]
+              [else
+               (let ([fld1 (str-str-s1 val)]
+                     [fld2 (str-str-s2 val)]
+                     [fld3 (str-str-num-num-num-n1 val)]
+                     [fld4 (str-str-num-num-num-n2 val)]
+                     [fld5 (str-str-num-num-num-n3 val)])
+                 (cond
+                   [(string? fld1) fld1]
+                   [(string? fld2) fld2]
+                   [(number? fld3) (number->string fld3)]
+                   [(number? fld4) (number->string fld4)]
+                   [(number? fld5) (number->string fld5)]
+                   [else "missed"]))])
+            String))
+     "missed")
+  (error "accessors broken num-num-sym-sym-sym"))
+
+(unless (equal?
+         (match (ann (read (open-input-string
+                             "#s((str-str-num-num-num #(0 1 2) str-str 2 #(0 1)) one two three four five)"))
+                     Any)
+           [(str-str-num-num-num fld1 fld2 fld3 fld4 fld5)
+            (list fld1 fld2 fld3 fld4 fld5)])
+         (list 'one 'two 'three 'four 'five))
+  (error "prefab pattern matching broken! str-str-num-num-num"))
+
+
+(struct vec ([x : Float] [y : Float]))
+
+
+(struct par-vec ([x : Float] [y : Float]) #:prefab)
+
+
+(: partial-dec (-> Any vec))
+(define (partial-dec x)
+  (cond
+    [(and (par-vec? x)
+          (flonum? (par-vec-x x))
+          (flonum? (par-vec-y x)))
+     (vec (par-vec-x x) (par-vec-y x))]
+    [else (error "invalid encoding")]))

--- a/typed-racket-test/succeed/shallow/primitives.rkt
+++ b/typed-racket-test/succeed/shallow/primitives.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/shallow
+
+;; Test trusted primitives
+
+(rest '(1 2 3))
+(apply + '(1 2 3))
+
+(struct foo ())
+(foo? 4)

--- a/typed-racket-test/succeed/shallow/procedure-top.rkt
+++ b/typed-racket-test/succeed/shallow/procedure-top.rkt
@@ -1,0 +1,16 @@
+#lang racket
+
+(module example typed/racket/shallow
+  (: id (Procedure -> Procedure))
+  (define (id x) x)
+
+  (: f (Integer -> Integer))
+  (define (f x) (+ x 1))
+
+  (define g (id f))
+
+  (provide g))
+
+(require 'example)
+
+(g 3)

--- a/typed-racket-test/succeed/shallow/promise-any.rkt
+++ b/typed-racket-test/succeed/shallow/promise-any.rkt
@@ -1,0 +1,11 @@
+#lang racket
+
+(module typed typed/racket/shallow
+  (: d Any)
+  (define d (delay (lambda: ([x : Integer]) (+ x 1))))
+  (provide d))
+
+(require 'typed)
+
+((force d) 6)
+

--- a/typed-racket-test/succeed/shallow/prompt-tag.rkt
+++ b/typed-racket-test/succeed/shallow/prompt-tag.rkt
@@ -1,0 +1,32 @@
+#lang typed/racket/shallow
+
+(: pt (Prompt-Tagof String (Integer -> Integer)))
+(define pt (make-continuation-prompt-tag))
+
+;; Test abort
+(call-with-continuation-prompt
+ (λ () (string-append "foo" (abort-current-continuation pt 5)))
+ pt
+ (λ: ([x : Integer]) x))
+
+(: pt2 (Prompt-Tagof Integer ((Integer -> Integer) -> Integer)))
+(define pt2 (make-continuation-prompt-tag))
+
+;; Test call/comp & abort
+(call-with-continuation-prompt
+ (λ () (+ 1 ((inst call-with-composable-continuation
+                   Integer ((Integer -> Integer) -> Integer) Integer)
+             (λ: ([k : (Integer -> Integer)])
+               (abort-current-continuation pt2 k))
+             pt2)))
+ pt2
+ (λ: ([f : (Integer -> Integer)]) (f 5)))
+
+;; Test the default handler
+(: pt3 (Prompt-Tagof Integer ((-> Integer) -> Integer)))
+(define pt3 (make-continuation-prompt-tag))
+
+(+ 2
+   (call-with-continuation-prompt
+    (λ () (+ 1 (abort-current-continuation pt3 (λ () 5))))
+    pt3))

--- a/typed-racket-test/succeed/shallow/provide-struct.rkt
+++ b/typed-racket-test/succeed/shallow/provide-struct.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+;; Test providing a struct (and its types)
+
+(module t typed/racket/base/shallow
+
+  (provide (struct-out foo) wepa)
+
+  (struct foo ((a : Natural)))
+
+  (define (wepa (f : foo))
+    (+ 1 (foo-a f))))
+
+(require 't rackunit)
+
+(check-pred values (foo 1))
+(check-pred values (foo 'a))
+
+(check-exn #rx"shape-check"
+  (λ () (wepa (foo 'a))))
+
+(check-equal?
+  (foo-a (foo 'a))
+  'a)

--- a/typed-racket-test/succeed/shallow/qmap.rkt
+++ b/typed-racket-test/succeed/shallow/qmap.rkt
@@ -1,0 +1,31 @@
+#lang typed/racket/base/shallow
+
+;; TODO parse error in type; used a type variable not bound with ... as a bound on a ...
+
+(require
+  racket/list)
+
+(define-type (Stream A)
+  (Rec Stream (U Null (Boxof (U (-> (Pair A Stream))
+                                (Pair A Stream))))))
+
+(struct: (A) Queue ([front : (Stream A)]
+                    [rear  : (Listof A)]
+                    [scdul : (Stream A)]))
+
+;; similar to list map function. apply is expensive so using case-lambda
+;; in order to saperate the more common case
+(: qmap : 
+   (All (A C B ...) 
+        (case-lambda 
+          ((A -> C) (Queue A) -> Void)
+          ((A B ... B -> C) (Queue A) (Queue B) ... B -> Void))))
+(define qmap
+  (pcase-lambda: (A C B ...)
+                 [([func : (A -> C)]
+                   [deq  : (Queue A)])
+                  (void)]
+                 [([func : (A B ... B -> C)]
+                   [deq  : (Queue A)] . [deqs : (Queue B) ... B])
+                  (void)]))
+

--- a/typed-racket-test/succeed/shallow/rackunit-suite.rkt
+++ b/typed-racket-test/succeed/shallow/rackunit-suite.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket/shallow
+
+(require typed/rackunit
+         typed/rackunit/text-ui)
+
+(define passing-suite
+  (test-suite "Example Typed Rackunit test suite"
+    (check-equal? 1 1)))
+
+(check-equal? (run-tests passing-suite 'quiet) 0)

--- a/typed-racket-test/succeed/shallow/rec-factorial.rkt
+++ b/typed-racket-test/succeed/shallow/rec-factorial.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/shallow
+
+(: factorial (-> Natural Natural))
+(define (factorial n)
+  (if (zero? n)
+    1
+    (* n (factorial (- n 1)))))
+
+(factorial 6)

--- a/typed-racket-test/succeed/shallow/recursive-type-alias-top-level.rkt
+++ b/typed-racket-test/succeed/shallow/recursive-type-alias-top-level.rkt
@@ -1,0 +1,20 @@
+#lang racket
+
+;; Make sure type aliases are registered from a module
+;; to another context appropriately
+
+(require racket/sandbox)
+
+(define evaluator
+  (call-with-trusted-sandbox-configuration
+   (λ () (make-evaluator 'typed/racket/shallow))))
+
+(evaluator '(require typed/racket/shallow))
+(evaluator '(module a typed/racket/shallow
+              (define-type (Foo A) (Option (Listof (Foo A))))
+              (: x (Foo Integer))
+              (define x #f)
+              (provide x)))
+(evaluator '(require 'a))
+(evaluator 'x)
+

--- a/typed-racket-test/succeed/shallow/rest-star-hash-examples.rkt
+++ b/typed-racket-test/succeed/shallow/rest-star-hash-examples.rkt
@@ -1,0 +1,52 @@
+#lang typed/racket/base/shallow
+
+(provide my-hash my-hash-set*)
+
+(require racket/match)
+
+(define-type (KV-List K V) (Rec T (U Null (List* K V T))))
+
+(: my-hash (All (K V) (->* () #:rest-star (K V) (Immutable-HashTable K V))))
+(define (my-hash . k/v-list)
+  (let loop ([h : (Immutable-HashTable K V) (hash)]
+             [to-add : (KV-List K V) k/v-list])
+    (match to-add
+      [(cons k (cons v rst)) 
+       (loop (hash-set h k v) rst)]   
+      [_ h])))
+
+(: my-mutable-hash (All (K V) (->* () #:rest-star (K V) (Mutable-HashTable K V))))
+(define (my-mutable-hash . k/v-list)
+  (define h : (Mutable-HashTable K V) (make-hash))
+  (let loop! ([to-add : (KV-List K V) k/v-list])
+    (match to-add
+      [(cons k (cons v rst))
+       (hash-set! h k v)
+       (loop! rst)]
+      [_ h])))
+
+
+(: my-hash-set* (All (K V) (->* ((Immutable-HashTable K V)) #:rest-star (K V) (Immutable-HashTable K V))))
+(define (my-hash-set* orig . k/v-list)
+  (let loop ([h : (Immutable-HashTable K V) orig]
+             [to-add : (KV-List K V) k/v-list])
+    (match to-add
+      [(cons k (cons v rst))
+       (loop (hash-set h k v) rst)]
+      [_ h])))
+
+(: my-hash-set*! (All (K V) (->* ((Mutable-HashTable K V)) #:rest-star (K V) Void)))
+(define (my-hash-set*! orig . k/v-list)
+  (let loop! ([to-add : (KV-List K V) k/v-list])
+    (match to-add
+      [(cons k (cons v rst))
+       (hash-set! orig k v)
+       (loop! rst)]
+      [_ (void)])))
+
+
+(define h (my-hash "Hello" 'world "How" 'are "you" 'today?))
+(my-hash-set* h "one" 'more)
+
+(define mh (my-mutable-hash "Hello" 'world "How" 'are "you" 'today?))
+(my-hash-set*! mh "one" 'more)

--- a/typed-racket-test/succeed/shallow/scoped-type-vars.rkt
+++ b/typed-racket-test/succeed/shallow/scoped-type-vars.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket/base/shallow
+
+
+(: f1 (All (A) (A -> A)))
+(define f1 (lambda: ((x : A)) x))
+
+(: f2 (All (A) (A A A -> A)))
+(define f2
+  (ann 
+    (plambda: (C) ((x : A) (y : B) (z : C)) (or x y z))
+    (All (B) (B B B -> B))))
+
+(: f3 (All (A ...) (All (B ...) (A ... A -> (B ... B -> Natural)))))
+(define f3 (lambda: (x : A ... A) (lambda: (y : B ... B) (+ (length x) (length y)))))
+
+;; PR 13622
+(: f4 (All (x) (All (y z) (x x x -> Any))))
+(define f4 (plambda: (x) ((x : x) (y : x) (z : x)) (or x y z)))
+
+;; PR 13539
+(: f5 (All (A) (All (B) (A B -> Integer))))
+(define (f5 x y)
+  (: z B)
+  (define z y)
+  5)

--- a/typed-racket-test/succeed/shallow/scribble-example.rkt
+++ b/typed-racket-test/succeed/shallow/scribble-example.rkt
@@ -1,0 +1,45 @@
+#lang racket/base
+
+;; test evaluators, as used in Scribble docs
+
+(require scribble/example)
+
+(for ((the-eval (in-list (list
+                           (make-base-eval #:lang 'typed/racket)
+                           (make-base-eval '(require typed/racket))))))
+  ;; define-predicate : non-function polymorphic type
+  ;; cast : bad list
+  (examples
+    #:label #f #:eval the-eval
+    (eval:error (define-predicate p? (All (A) (Listof A))))
+    (require/typed racket/base
+      [object-name (-> (U (Listof Real) Regexp)
+                       (U #f String Bytes Symbol))])
+    (object-name #rx"a regexp")
+    (eval:error (object-name (cast '(A B C) (Listof Real))))))
+
+(for ((the-eval (in-list (list
+                           (make-base-eval #:lang 'typed/racket/shallow)
+                           (make-base-eval '(require typed/racket/shallow))))))
+  ;; object-name returns #f (shape-check error)
+  (examples
+    #:label #f #:eval the-eval
+    (eval:error (define-predicate p? (All (A) (Listof A))))
+    (require/typed racket/base
+      [object-name (-> (U (Listof Real) Regexp)
+                       (U String Bytes Symbol))])
+    (object-name #rx"a regexp")
+    (eval:error (object-name (cast '(A B C) (Listof Real))))))
+
+(for ((the-eval (in-list (list
+                           (make-base-eval #:lang 'typed/racket/optional)
+                           (make-base-eval '(require typed/racket/optional))))))
+  (examples
+    #:label #f #:eval the-eval
+    (eval:error (define-predicate p? (All (A) (Listof A))))
+    (require/typed racket/base
+      [object-name (-> (U (Listof Real) Regexp)
+                       (U String Bytes Symbol))])
+    (object-name #rx"a regexp")
+    (object-name (cast '(A B C) (Listof Real)))))
+

--- a/typed-racket-test/succeed/shallow/send-no-type.rkt
+++ b/typed-racket-test/succeed/shallow/send-no-type.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/shallow
+
+;; Defender should work for 'send' calls in a dead lambda branch
+
+(define-type C% (Class [f (-> Real Real)]))
+
+(: c% C%)
+(define c%
+  (class object%
+    (super-new)
+    (define/public (f x)
+      (+ x x))))
+
+(if #true
+  (void)
+  (void (send (new c%) f 42)))

--- a/typed-racket-test/succeed/shallow/sequence.rkt
+++ b/typed-racket-test/succeed/shallow/sequence.rkt
@@ -1,0 +1,23 @@
+#lang typed/racket/base/shallow
+
+(define (f0 (tm : (Listof Exact-Nonnegative-Integer)))
+  (for/list : (Listof String)
+            ([n : Exact-Nonnegative-Integer tm])
+    (number->string n)))
+(void (f0 '(33 313)))
+
+(define (f1 (fields : (Sequenceof (Pair String (-> String)))))
+  (for/list : (Listof String)
+            ([fd : (Pair String (-> String)) fields])
+    "hi"))
+(void (f1 (list (cons "A" (lambda () "B")))))
+
+(: f2 (All (A) (-> (-> A String) (Vectorof A) String)))
+(define (f2 k xs)
+  (apply string-append
+    (for/list : (Listof String)
+              ([x : A xs])
+      (k x))))
+(void (f2 symbol->string '#(A B)))
+
+(ann (for ([z (open-input-string "foobar")]) (add1 z)) Void) 

--- a/typed-racket-test/succeed/shallow/sequenceof-integer.rkt
+++ b/typed-racket-test/succeed/shallow/sequenceof-integer.rkt
@@ -1,0 +1,29 @@
+#lang racket/base
+
+(module typed typed/racket/base/shallow
+  (provide foo)
+  (: foo (-> (U Integer (Sequenceof Integer)) String))
+  (define (foo x)
+    (if (integer? x)
+        (format "I got an integer: ~a" x)
+        (error "I did not get an integer: ~a" x))))
+
+(module other-typed typed/racket/base/shallow
+  (provide bar)
+  (require (submod ".." typed))
+  (define (bar) (foo 0)))
+
+(module contract-test typed/racket/base/shallow
+  (define b* : (Sequenceof (Boxof Integer)) (list (box 0)))
+  (provide b*))
+
+(require 'typed
+         'other-typed
+         'contract-test
+         rackunit)
+(check-equal? (foo 0) "I got an integer: 0")
+(check-equal? (bar) "I got an integer: 0")
+(check-not-exn
+  (λ () (set-box! (car b*) 'NaN)))
+(check-not-exn ;; untyped context
+  (λ () (unbox (car b*))))

--- a/typed-racket-test/succeed/shallow/sequences.rkt
+++ b/typed-racket-test/succeed/shallow/sequences.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket/shallow
+
+(ann (for ([z (list 1 2 3)]) (add1 z)) Void)
+(ann (for ([z (vector 1 2 3)]) (add1 z)) Void)
+(ann (for ([z "foobar"]) (string z)) Void)
+(ann (for ([z #"foobar"]) (add1 z)) Void)
+(ann (for ([z (open-input-string "foobar")]) (add1 z)) Void)
+
+(ann (for ([z (in-list (list 1 2 3))]) (add1 z)) Void)
+(ann (for ([z (in-vector (vector 1 2 3))]) (add1 z)) Void)

--- a/typed-racket-test/succeed/shallow/shallow-contract.rkt
+++ b/typed-racket-test/succeed/shallow/shallow-contract.rkt
@@ -1,0 +1,48 @@
+#lang racket/base
+
+;; Test shallow contract utils
+
+(module+ test
+  (require rackunit
+           typed-racket/utils/shallow-contract)
+
+  (test-case "procedure-arity-includes-keywords?:no-kws"
+    (for ((f (in-list (list (lambda () (void))
+                            (lambda args (void))))))
+      (check-true (procedure-arity-includes-keywords? f '() '()))
+      (check-false (procedure-arity-includes-keywords? f '(#:a) '()))
+      (check-false (procedure-arity-includes-keywords? f '() '(#:b)))))
+
+  (test-case "procedure-arity-includes-keywords?:mandatory-only"
+    (let ((f (lambda (#:a a #:b b) (void))))
+      (check-true (procedure-arity-includes-keywords? f '(#:a #:b) '()))
+      (check-false (procedure-arity-includes-keywords? f '(#:b #:a) '()))
+      (check-false (procedure-arity-includes-keywords? f '(#:b) '()))
+      (check-false (procedure-arity-includes-keywords? f '() '()))
+      (check-false (procedure-arity-includes-keywords? f '() '(#:a #:b)))
+      (check-false (procedure-arity-includes-keywords? f '(#:a #:b) '(#:c)))))
+
+  (test-case "procedure-arity-includes-keywords?:optional-only"
+    (let ((f (lambda (#:a [a #f] #:b [b #f]) (void))))
+      (check-true (procedure-arity-includes-keywords? f '() '(#:a #:b)))
+      (check-true (procedure-arity-includes-keywords? f '(#:a #:b) '()))
+      (check-true (procedure-arity-includes-keywords? f '(#:b #:a) '())) ;; TODO test
+      (check-true (procedure-arity-includes-keywords? f '(#:b) '())) ;; TODO test
+      (check-true (procedure-arity-includes-keywords? f '() '())) ;; TODO test
+      (check-false (procedure-arity-includes-keywords? f '(#:a #:b) '(#:c)))
+      (check-false (procedure-arity-includes-keywords? f '(#:c #:b) '()))))
+
+  (test-case "procedure-arity-includes-keywords?:mandatory+optional"
+    (let ((f (lambda (#:a a #:b [b #f] #:c [c #f]) (void))))
+      (check-true (procedure-arity-includes-keywords? f '(#:a) '()))
+      (check-true (procedure-arity-includes-keywords? f '(#:a #:b) '()))
+      (check-true (procedure-arity-includes-keywords? f '(#:a #:b #:c) '()))
+      (check-true (procedure-arity-includes-keywords? f '(#:a #:c #:b) '()))
+      (check-true (procedure-arity-includes-keywords? f '(#:a) '(#:b #:c)))
+      (check-true (procedure-arity-includes-keywords? f '(#:a) '(#:c #:b)))
+
+      (check-false (procedure-arity-includes-keywords? f '(#:b #:a) '()))
+      (check-false (procedure-arity-includes-keywords? f '() '()))
+      (check-false (procedure-arity-includes-keywords? f '(#:a #:x) '()))
+      (check-false (procedure-arity-includes-keywords? f '(#:a) '(#:x)))))
+)

--- a/typed-racket-test/succeed/shallow/shallow-deep-id-0.rkt
+++ b/typed-racket-test/succeed/shallow/shallow-deep-id-0.rkt
@@ -1,0 +1,15 @@
+#lang typed/racket/base
+
+;; basic shallow -> deep, is ok
+
+(module shallow typed/racket/base/shallow
+  (provide xxx)
+  (define xxx '$$$)
+  xxx)
+
+(require 'shallow)
+xxx
+
+(define (f y)
+  xxx)
+

--- a/typed-racket-test/succeed/shallow/shallow-deep-id-1.rkt
+++ b/typed-racket-test/succeed/shallow/shallow-deep-id-1.rkt
@@ -1,0 +1,40 @@
+#lang racket/base
+
+;; deep should protect itself from shallow
+
+(module uuu racket/base
+  (provide bad-list)
+  (define bad-list '(X X)))
+
+(module sss typed/racket/shallow
+
+  (require/typed (submod ".." uuu)
+    (bad-list (Listof (List Symbol))))
+
+  (provide f)
+
+  (: f (-> (-> (List Symbol) Symbol) (Listof Symbol)))
+  (define (f x)
+    (map x bad-list)))
+
+(module ttt typed/racket
+  (require (submod ".." sss))
+
+  (: g (-> (List Symbol) Symbol))
+  (define (g n)
+    (car n))
+
+  (define (go1)
+    (f g))
+
+  (define (go2)
+    ;; second function, to be sure all occurrences of `f` get a contract
+    (f g))
+
+  (provide go1 go2))
+
+(require 'ttt rackunit)
+
+(check-exn exn:fail:contract? go1)
+(check-exn exn:fail:contract? go2)
+

--- a/typed-racket-test/succeed/shallow/shallow-deep-id-2.rkt
+++ b/typed-racket-test/succeed/shallow/shallow-deep-id-2.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket/base
+
+(module shallow typed/racket/base/shallow
+  (provide bad-dom bad-cod)
+
+  (: bad-dom (-> (Vectorof Real) Void))
+  (define (bad-dom vr)
+    (vector-set! (cast vr (Vectorof String)) 0 "X")
+    (void))
+
+  (: bad-cod (-> (Vectorof Symbol)))
+  (define (bad-cod)
+    (cast (vector 0) (Vectorof Symbol))))
+
+(require 'shallow typed/rackunit)
+
+(check-exn #rx"bad-dom: broke its own contract"
+  (lambda () (bad-dom (vector 0 1))))
+
+(check-exn #rx"bad-cod: broke its own contract"
+  (lambda () (vector-ref (bad-cod) 0)))

--- a/typed-racket-test/succeed/shallow/shallow-deep-id-3.rkt
+++ b/typed-racket-test/succeed/shallow/shallow-deep-id-3.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket/base
+
+(module shallow typed/racket/base/shallow
+  (provide bad-dom bad-cod)
+
+  (: bad-cod (-> (Listof String)))
+  (define (bad-cod)
+    (cast (list 0) (Listof String)))
+
+  (: bad-dom (-> (-> (Listof String) (Listof String)) (Listof String)))
+  (define (bad-dom f)
+    (f (cast (list 1) (Listof String)))))
+
+(require 'shallow typed/rackunit)
+
+(check-exn #rx"bad-cod: broke its own contract"
+  (lambda () (car (bad-cod))))
+
+(check-exn #rx"bad-dom: broke its own contract"
+  (lambda () (bad-dom values)))
+

--- a/typed-racket-test/succeed/shallow/shallow-provide.rkt
+++ b/typed-racket-test/succeed/shallow/shallow-provide.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+
+;; Test providing value to untyped
+
+(module a typed/racket/base/shallow
+        (provide f)
+        (define (f (x : (Boxof Integer)))
+          (unbox x)))
+
+(require 'a rackunit)
+(check-exn #rx"shape-check"
+  (lambda () (f 0)))

--- a/typed-racket-test/succeed/shallow/shallow-syntax.rkt
+++ b/typed-racket-test/succeed/shallow/shallow-syntax.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(module a typed/racket/base/shallow
+  (provide f)
+  (define-syntax-rule (f x)
+    (car (car x))))
+
+(require 'a)
+(f '((a) b c))

--- a/typed-racket-test/succeed/shallow/simple-object.rkt
+++ b/typed-racket-test/succeed/shallow/simple-object.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/shallow
+(require typed/rackunit)
+
+(define-type C% (Class (f (-> Integer Integer))))
+
+(define c% : C%
+  (class object%
+    (super-new)
+    (define/public (f x) (+ x 1))))
+
+(: g (-> (Vector (Instance C%)) Integer))
+(define (g vo)
+  (define o (vector-ref vo 0))
+  (send o f (send o f 2)))
+
+(check-equal? (g (vector (new c%))) 4)

--- a/typed-racket-test/succeed/shallow/struct-match-0.rkt
+++ b/typed-racket-test/succeed/shallow/struct-match-0.rkt
@@ -1,0 +1,15 @@
+#lang racket/base
+
+(module s typed/racket/base/shallow
+  (require racket/match)
+
+  (struct posn ([x : Real] [y : Real]))
+
+  (: f (-> posn Void))
+  (define (f p)
+    (match p
+     ((posn x y) (void (+ x y)))
+     (_ (void)))))
+
+(require 's)
+

--- a/typed-racket-test/succeed/shallow/struct-match-1.rkt
+++ b/typed-racket-test/succeed/shallow/struct-match-1.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+
+(module t typed/racket/base
+  (struct posn ([x : Real] [y : Real]))
+  (provide (struct-out posn)))
+
+(module s typed/racket/base/shallow
+  (require racket/match
+           (submod ".." t))
+  (: f (-> posn Void))
+  (define (f p)
+    (match p
+     ((posn x y) (void (+ x y)))
+     (_ (void)))))
+
+(require 's)

--- a/typed-racket-test/succeed/shallow/struct.rkt
+++ b/typed-racket-test/succeed/shallow/struct.rkt
@@ -1,0 +1,19 @@
+#lang typed/racket/shallow
+
+;; Test structs: definition, creation, accessors
+
+(struct A ((x : Integer) (y : (Listof Integer)) (z : (-> Integer Integer))))
+
+(define a (A 1 '(1) (lambda ((x : Integer)) (+ x x))))
+
+(+ ((A-z a) (A-x a)) (car (A-y a)))
+
+((lambda (x) x) 3)
+
+
+(: f (-> (Listof A) Integer))
+(define (f x)
+  (define mya (car x))
+  (A-x mya))
+
+(f (list a))

--- a/typed-racket-test/succeed/shallow/stx-cdr.rkt
+++ b/typed-racket-test/succeed/shallow/stx-cdr.rkt
@@ -1,0 +1,19 @@
+#lang typed/racket/base/shallow
+(require typed/syntax/stx)
+
+;; ... no idea whats wrong
+;; - guarded never fails so far
+;; - shallow passes with no cod-check
+;;   when type says (List ....)
+;;   bun NOT when (Listof ....)
+
+;(: x (Syntaxof (Pairof Identifier (List Identifier))))
+(: x (Syntaxof (Pairof Identifier (Listof Identifier))))
+(define x #'(a b))
+x
+;;(: y (List Identifier))
+(: y (Listof Identifier))
+(define y (stx-cdr x))
+y
+(and (list? y) (= 1 (length y)))
+

--- a/typed-racket-test/succeed/shallow/stx.rkt
+++ b/typed-racket-test/succeed/shallow/stx.rkt
@@ -1,0 +1,64 @@
+#lang typed/racket/shallow
+
+;; Test that the typed/syntax/stx library can be used
+
+(require typed/syntax/stx
+         typed/rackunit)
+
+(check-true (stx-null? null))
+(check-true (stx-null? #'()))
+(check-false (stx-null? #'(a)))
+
+(check-true (stx-pair? (cons #'a #'b)))
+(check-true (stx-pair? #'(a . b)))
+
+(check-true (stx-list? #'(a b c d)))
+(check-false (stx-list? #'a))
+
+(ann (stx->list #'(a b c d)) (Listof (Syntaxof Symbol)))
+(ann (syntax-e (car (stx->list #'(a b c d)))) Symbol)
+(ann (stx->list (list #'a #'b)) (Listof (Syntaxof Symbol)))
+(ann (stx->list (list 'a 'b)) (Listof Symbol))
+(ann (add1 (car (stx->list '(1 2 3)))) Positive-Index)
+(ann (stx->list #'(a b . (c d))) (Listof (Syntaxof Symbol)))
+(ann (stx->list (cons #'a #'(b . (c d)))) (Listof (Syntaxof Symbol)))
+;; Make sure case-> type doesn't have intersecting domains with
+;; incompatible result types
+(ann (assert (stx->list (ann #'(a b c) (Syntaxof Any))))
+     (Listof (Syntaxof Any)))
+
+(ann (stx-car #'(a b)) (Syntaxof 'a))
+(ann (stx-cdr #'(a b)) (List (Syntaxof 'b)))
+
+(ann (stx-map (λ: ([id : Identifier]) (free-identifier=? id #'a))
+              #'(a b c d))
+     (Listof Boolean))
+(ann (stx-map (λ: ([id : Symbol]) (symbol=? id 'a))
+              '(a b c d))
+     (Listof Boolean))
+(ann (stx-map (λ: ([id : Identifier]) (free-identifier=? id #'a))
+              (cons #'a #'(b . (c d))))
+     (Listof Boolean))
+(ann (stx-map (λ: ([x : (Syntaxof Real)] [y : (Syntaxof Real)])
+                (+ (syntax-e x) (syntax-e y)))
+              #'(1 2 3)
+              #'(1 2 3))
+     (Listof Real))
+(ann (stx-map +
+              '(1 2 3)
+              '(1 2 3))
+     (Listof Real))
+(ann (stx-map (λ: ([x : (Syntaxof Real)] [y : (Syntaxof Real)])
+                (+ (syntax-e x) (syntax-e y)))
+              #'(1 . (2 3))
+              (cons #'1 #'(2 . (3))))
+     (Listof Real))
+
+(module-or-top-identifier=? #'a #'b)
+
+(ann (let* ([ xs : (Listof Syntax) (list #'1 #'2)]
+            [ id : (-> Syntax Syntax) (λ (x) x)]
+            [ x  : (Syntaxof Any) #`(#,@(map id xs) #'foo)]
+            )
+       x)
+     (Syntaxof Any))

--- a/typed-racket-test/succeed/shallow/submodule-list-0.rkt
+++ b/typed-racket-test/succeed/shallow/submodule-list-0.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/shallow
+
+;; Test importing a list
+
+(module u racket/base
+  (define x* (list 1))
+  (provide x*))
+
+(require/typed 'u
+  (x* (Listof Integer)))
+
+(+ (car x*) 1)

--- a/typed-racket-test/succeed/shallow/submodule-list-1.rkt
+++ b/typed-racket-test/succeed/shallow/submodule-list-1.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/shallow
+
+;; Test importing a list with incorrect type
+
+(module u racket/base
+  (define x* (list "NaN"))
+  (provide x*))
+
+(require/typed 'u
+  (x* (Listof Integer)))
+
+(ann (append x* (list 1 2 3)) (Listof Integer))

--- a/typed-racket-test/succeed/shallow/submodule-opaque-0.rkt
+++ b/typed-racket-test/succeed/shallow/submodule-opaque-0.rkt
@@ -1,0 +1,17 @@
+#lang typed/racket/shallow
+
+;; Test opaque import
+
+(module u racket/base
+  (struct posn [x y])
+  (define origin (posn 0 0))
+  (provide origin (struct-out posn)))
+
+(require/typed 'u
+  (#:opaque Posn posn?)
+  (origin Posn)
+  (posn (-> Integer Integer Posn))
+  (posn-x (-> Posn Integer)))
+
+(+ (posn-x origin) (posn-x (posn 4 0)))
+

--- a/typed-racket-test/succeed/shallow/submodule-opaque-1.rkt
+++ b/typed-racket-test/succeed/shallow/submodule-opaque-1.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket/shallow
+
+;; Test opaque import that would break Any-wrap contracts
+
+(module u racket/base
+  (define (posn? x)
+    (when (box? x)
+      (set-box! x 'nan))
+    #false)
+  (provide posn?))
+
+(require typed/rackunit)
+(require/typed 'u
+  (#:opaque Posn posn?))
+
+(define b : (Boxof Real) (box 0))
+
+(check-not-exn
+  (lambda ()
+    (posn? b)))
+
+(check-exn #rx"shape-check"
+  (lambda ()
+    (+ 1 (unbox b))))
+

--- a/typed-racket-test/succeed/shallow/submodule-shallow.rkt
+++ b/typed-racket-test/succeed/shallow/submodule-shallow.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base/shallow
+
+;; shallow submodules of shallow mod
+
+(module t typed/racket/base/shallow
+  (: f (-> Real (-> Real Real) Real))
+  (define (f r g)
+    (g (g r)))
+  (provide f))
+(require 't)
+
+(: h (-> Real Real))
+(define (h n)
+  (* n n))
+
+(f 3 h)

--- a/typed-racket-test/succeed/shallow/submodule-struct-0.rkt
+++ b/typed-racket-test/succeed/shallow/submodule-struct-0.rkt
@@ -1,0 +1,14 @@
+#lang typed/racket/shallow
+
+;; Test importing a struct
+
+(module u racket/base
+  (struct posn [x y])
+  (define origin (posn 0 0))
+  (provide origin (struct-out posn)))
+
+(require/typed 'u
+  (#:struct posn ((x : Real) (y : Real)))
+  (origin posn))
+
+(+ (posn-x origin) (posn-y origin))

--- a/typed-racket-test/succeed/shallow/submodule-struct-1.rkt
+++ b/typed-racket-test/succeed/shallow/submodule-struct-1.rkt
@@ -1,0 +1,15 @@
+#lang typed/racket/shallow
+
+(module u racket/base
+  (struct posn [x y])
+  (define origin (posn 0 0))
+  (provide origin (struct-out posn)))
+
+(require/typed 'u
+  (#:struct posn ((x : Symbol) (y : Symbol)))
+  (origin posn))
+(require typed/rackunit)
+
+(check-exn exn:fail:contract?
+  (lambda () (posn-x origin)))
+

--- a/typed-racket-test/succeed/shallow/submodule.rkt
+++ b/typed-racket-test/succeed/shallow/submodule.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/base/shallow
+
+;; Test importing a flat value
+
+(module u racket/base
+  (define x 3)
+  (provide x))
+
+(require/typed 'u
+  (x Byte))
+
+(+ x 1)

--- a/typed-racket-test/succeed/shallow/subst-poly-dots.rkt
+++ b/typed-racket-test/succeed/shallow/subst-poly-dots.rkt
@@ -1,0 +1,17 @@
+#lang typed/racket/shallow
+
+(: f (All (A B ...) (A ... B -> (List (Boxof A) ... B))))
+(define (f . args)
+    (map (inst box A) args))
+
+(: h (-> Nothing))
+(define (h) (h))
+
+(: g (All (A B ...) (A ... B -> (Values (Boxof A) ... B))))
+(define (g . args)
+   (h))
+
+
+(ann ((inst f String Symbol Symbol) "c" "d") (List (Boxof String) (Boxof String)))
+(lambda (x)
+  (ann ((inst g String Symbol Symbol) "c" "d") (values (Boxof String) (Boxof String))))

--- a/typed-racket-test/succeed/shallow/tc-app-list.rkt
+++ b/typed-racket-test/succeed/shallow/tc-app-list.rkt
@@ -1,0 +1,20 @@
+#lang typed/racket/base/shallow
+
+;; Test special-cases in tc-app-list
+
+(list* '(1 2 3))
+
+(ann (reverse '(1 2 3)) (Listof Natural))
+(ann (reverse '(1 2 3)) (List Natural Natural Natural))
+(reverse '(1 2 3))
+(lambda ((xs : (Listof Natural)))
+  (reverse xs))
+(lambda ((xs : (Pairof Integer (Listof Integer))))
+  (reverse xs))
+
+(: main (-> String Void))
+(define (main filename)
+  (define raw (with-input-from-file filename read))
+  (if (list? raw)
+    (void (ann (reverse raw) (Listof Any)))
+    (error "bad input")))

--- a/typed-racket-test/succeed/shallow/tc-app-special.rkt
+++ b/typed-racket-test/succeed/shallow/tc-app-special.rkt
@@ -1,0 +1,6 @@
+#lang typed/racket/base/shallow
+
+;; Test `call-with-values` because it has a special typing rule
+
+(call-with-values (lambda () '42) (lambda ((n : Real)) (+ n 1)))
+(call-with-values (lambda () (values 1 42)) (lambda ((n : Real) (m : Real)) (+ n m)))

--- a/typed-racket-test/succeed/shallow/test-case.rkt
+++ b/typed-racket-test/succeed/shallow/test-case.rkt
@@ -1,0 +1,16 @@
+#lang typed/racket/base/shallow
+
+;; Make sure shallow checks happen within
+;;  a test-case form.
+
+(module u racket/base
+  (define strs (cons "A" "B"))
+  (provide strs))
+
+(require/typed 'u
+  (strs (Pairof Symbol Symbol)))
+(require typed/rackunit)
+
+(test-case "a"
+  (check-exn exn:fail:contract?
+    (lambda () (car strs))))

--- a/typed-racket-test/succeed/shallow/test2.rkt
+++ b/typed-racket-test/succeed/shallow/test2.rkt
@@ -1,0 +1,52 @@
+#lang typed/racket/shallow
+
+(: f (Number String -> Number))
+(define (f x z) #;(f x z) 7)
+(lambda: ([x : Any] [y : Any]) (values (number? y) (number? x)))
+(lambda: ([x : Any] [y : Any]) (values (number? x) (number? y)))
+(lambda: ([x : Any] [y : Any]) (values (and (number? x) (boolean? y)) (number? y)))
+(lambda: ([x : Any]) (values (number? x) (number? x)))
+(: g (Any -> Boolean : Number))
+(define g (lambda: ([x : Any]) (number? x)))
+(: q ((Number -> Number) -> Number))
+(define q (lambda: ([x : (Number -> Number)]) (x 1)))
+;(q (lambda (z) (f z "foo")))
+
+(: p (Number * -> Number))
+(define (p . x) 7)
+
+(lambda x (number? x))
+(+)
+(+ 1 2 3)
+(+ 1 2 3.5)
+
+(define-struct: (Z) X ([y : Z]))
+(define:  my-x : (X Number) (make-X 1))
+(X-y my-x)
+
+; FIXME - doesn't work yet
+(number? (X-y my-x))
+(if (number? (X-y my-x)) (+ 1 (X-y my-x)) 7)
+
+
+(define: (f2) : (U) (error 'foo))
+(lambda: ([x : Number]) #{((f2)) :: (U)})
+
+(: f3 (U (Number -> Number) (Number -> String)))
+(define (f3 x) 7)
+
+(define: x : (List Any Any) (list 1 23 ))
+(car x)
+(if (number? (car x)) (add1 (car #{x :: (Pair Number Any)})) 7)
+(if (number? (car x)) (add1 (car x)) 7)
+
+;; error
+;(f 12 "hi")
+
+(map + (list 1 2 3))
+(map + (list 1 2 3) (list 1 2 3))
+;; error
+;(map + (list 1 2 3) (list 1 2 "foo"))
+
+((lambda (a b . c) (+ a b (car c))) 1 2 3 4)
+

--- a/typed-racket-test/succeed/shallow/top-level-begin-for-syntax.rkt
+++ b/typed-racket-test/succeed/shallow/top-level-begin-for-syntax.rkt
@@ -1,0 +1,8 @@
+#lang racket/load
+
+;; Test for PR 13878, ensure that this doesn't produce
+;; an internal type-checker error
+
+(require typed/racket/shallow)
+(begin-for-syntax 3)
+

--- a/typed-racket-test/succeed/shallow/top-level-begin.rkt
+++ b/typed-racket-test/succeed/shallow/top-level-begin.rkt
@@ -1,0 +1,11 @@
+#lang racket
+
+;; Test various (begin ...)s at the top-level. In
+;; particular, avoid a (begin) regression.
+
+(define ns (make-base-namespace))
+(eval '(require typed/racket/shallow) ns)
+(eval '(begin) ns)
+(eval '(begin 1 2) ns)
+(eval '(begin (+ 1 2) 5 3 "foo") ns)
+

--- a/typed-racket-test/succeed/shallow/top-level-make-predicate.rkt
+++ b/typed-racket-test/succeed/shallow/top-level-make-predicate.rkt
@@ -1,0 +1,5 @@
+#lang racket/load
+;; Test for PR 14030
+(require typed/racket/shallow)
+(make-predicate Integer)
+

--- a/typed-racket-test/succeed/shallow/toplevel-redefinition.rkt
+++ b/typed-racket-test/succeed/shallow/toplevel-redefinition.rkt
@@ -1,0 +1,9 @@
+#lang racket/load
+
+;; Test that variable redefinition works at the top-level
+
+(require typed/racket/shallow)
+(: x Integer)
+(define x 3)
+(define x 5)
+

--- a/typed-racket-test/succeed/shallow/type-printer-single-level.rkt
+++ b/typed-racket-test/succeed/shallow/type-printer-single-level.rkt
@@ -1,0 +1,48 @@
+#lang racket
+
+;; Make sure that the type printer expands only a single
+;; level for (:type ...)
+
+(require rackunit
+         racket/sandbox)
+
+(define out (open-output-string))
+
+(define tr-eval
+  (parameterize ([sandbox-output out])
+    (call-with-trusted-sandbox-configuration
+     (thunk (make-evaluator 'typed/racket/shallow)))))
+
+(tr-eval '(require typed/racket/shallow))
+(tr-eval '(define-type Foo (U String Integer)))
+(tr-eval '(define-type Bar (Foo -> Foo)))
+
+(tr-eval '(:type Foo))
+(tr-eval '(:type Bar))
+(tr-eval '(:type (Number -> Integer)))
+
+;; if #:verbose, make sure it's the full type
+(tr-eval '(:type #:verbose Bar))
+
+(check-equal? (get-output-string out)
+              (string-append "(U Integer String)\n[can expand further: Integer]"
+                             "(-> Foo Foo)\n[can expand further: Foo]"
+                             "(-> Number Integer)\n[can expand further: Integer Number]"
+                             "(-> (U 0\n"
+                             "       1\n"
+                             "       Byte-Larger-Than-One\n"
+                             "       Negative-Fixnum\n"
+                             "       Negative-Integer-Not-Fixnum\n"
+                             "       Positive-Fixnum-Not-Index\n"
+                             "       Positive-Index-Not-Byte\n"
+                             "       Positive-Integer-Not-Fixnum\n"
+                             "       String)\n"
+                             "    (U 0\n"
+                             "       1\n"
+                             "       Byte-Larger-Than-One\n"
+                             "       Negative-Fixnum\n"
+                             "       Negative-Integer-Not-Fixnum\n"
+                             "       Positive-Fixnum-Not-Index\n"
+                             "       Positive-Index-Not-Byte\n"
+                             "       Positive-Integer-Not-Fixnum\n"
+                             "       String))\n"))

--- a/typed-racket-test/succeed/shallow/typed-provide.rkt
+++ b/typed-racket-test/succeed/shallow/typed-provide.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+
+;; Test providing a value to an untyped context
+
+(module a typed/racket/base
+  (provide f)
+  (define (f (x : (Boxof (Boxof Integer))))
+    (unbox (unbox x))))
+
+(module b racket/base
+  (provide bbx)
+  (define bbx (box 0)))
+
+(module c typed/racket/base/shallow
+  (require (submod ".." a))
+  (require/typed (submod ".." b) (bbx (Boxof (Boxof Integer))))
+  (provide do-c bbx)
+  (define (do-c)
+    (f bbx)))
+
+(require 'a rackunit)
+(check-exn #rx"f: contract violation"
+  (lambda () (f 0)))
+
+(require 'c)
+(check-not-exn (lambda () (unbox bbx)))
+(check-exn #rx"f: contract violation"
+  do-c)

--- a/typed-racket-test/succeed/shallow/typed-untyped-id.rkt
+++ b/typed-racket-test/succeed/shallow/typed-untyped-id.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+(module a racket/base
+  (require racket/contract)
+  (provide
+    (contract-out [f0 (-> symbol? symbol?)]))
+  (define (f0 x) 'a))
+
+(module b typed/racket/base
+  (provide f1)
+  (define (f1 (x : Symbol)) : Symbol 'a))
+
+(module c racket/base
+  (require (submod ".." a) (submod ".." b) typed/untyped-utils)
+  (define-typed/untyped-identifier f f1 f0)
+  (provide f))
+
+(module d typed/racket/base/shallow
+  ;; fail = (require (submod ".." c))
+  (require/typed (submod ".." c)
+                 (f (-> Symbol Symbol)))
+  f)
+
+(require 'd)

--- a/typed-racket-test/succeed/shallow/untyped-contract-aux/lib.rkt
+++ b/typed-racket-test/succeed/shallow/untyped-contract-aux/lib.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket
+
+(provide f)
+
+(: f (-> (U Symbol String) Void))
+(define (f x)
+  (void))

--- a/typed-racket-test/succeed/shallow/untyped-contract-aux/untyped.rkt
+++ b/typed-racket-test/succeed/shallow/untyped-contract-aux/untyped.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+
+(require
+  typed/racket/base
+  typed/untyped-utils)
+
+(require/untyped-contract "lib.rkt"
+                          (f (-> Symbol Void)))
+
+(provide f)

--- a/typed-racket-test/succeed/shallow/untyped-contract-deep.rkt
+++ b/typed-racket-test/succeed/shallow/untyped-contract-deep.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket
+
+;; Identifier imported from untyped-contract should have original type,
+;;  not the type for the refined contract
+
+(require "untyped-contract-aux/untyped.rkt")
+
+(define (g (z : (U Symbol String))) : Void
+  (f z))

--- a/typed-racket-test/succeed/shallow/untyped-contract-optional.rkt
+++ b/typed-racket-test/succeed/shallow/untyped-contract-optional.rkt
@@ -1,0 +1,13 @@
+#lang typed/racket/optional
+
+;; Identifier imported from untyped-contract stuck with refined type
+;;  in an optional context.
+;; Need to abide by that refined type
+
+(require "untyped-contract-aux/untyped.rkt")
+
+(define (g (z : (U Symbol String))) : Void
+  ;; (f z) = type error
+  (f (assert z symbol?)))
+
+

--- a/typed-racket-test/succeed/shallow/untyped-contract-shallow.rkt
+++ b/typed-racket-test/succeed/shallow/untyped-contract-shallow.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/shallow
+
+;; Identifier imported from untyped-contract stuck with refined type
+;;  in a shallow context.
+;; Need to abide by that refined type
+
+(require "untyped-contract-aux/untyped.rkt")
+
+(define (g (z : (U Symbol String))) : Void
+  ;; (f z) = type error
+  (f (assert z symbol?)))
+

--- a/typed-racket-test/succeed/shallow/untyped-struct-properties-with-self.rkt
+++ b/typed-racket-test/succeed/shallow/untyped-struct-properties-with-self.rkt
@@ -1,0 +1,15 @@
+#lang racket
+
+(module foo racket
+  (define-values (prop:hi hi? hi-ref) (make-struct-type-property 'hi))
+  (provide prop:hi hi? hi-ref yyy)
+  (define yyy 10))
+
+(module ty-foo typed/racket/shallow
+  (require/typed (submod ".." foo) [prop:hi (Struct-Property (-> Self Any))]  [hi-ref (-> Any (-> Any Void))])
+  (struct bar () #:property prop:hi (λ ([self : bar])
+                                      (display (format "instance bar\n" ))))
+  (hi-ref (bar))
+  )
+
+(require 'ty-foo)

--- a/typed-racket-test/succeed/shallow/val-ctc-test.rkt
+++ b/typed-racket-test/succeed/shallow/val-ctc-test.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket/base/shallow
+
+;; A symbol type should generate a contract that accepts the same symbol
+
+(module uuu racket/base
+  (define FOUNDING 'FOUNDING)
+  (provide FOUNDING))
+
+(require/typed/provide 'uuu
+  (FOUNDING 'FOUNDING))

--- a/typed-racket-test/succeed/shallow/values-dots-result.rkt
+++ b/typed-racket-test/succeed/shallow/values-dots-result.rkt
@@ -1,0 +1,6 @@
+#lang typed/racket/base/shallow
+
+(define #:forall (A ...) (f [v : (List A ... A)])
+  (apply values v))
+
+(f '(1 2 3))

--- a/typed-racket-test/succeed/shallow/values-dots.rkt
+++ b/typed-racket-test/succeed/shallow/values-dots.rkt
@@ -1,0 +1,30 @@
+#lang typed/racket/base/shallow
+
+(require typed-racket/base-env/extra-procs)
+
+
+(call-with-values (lambda () (values 1 2)) (lambda: ([x : Number] [y : Number]) (+ x y)))
+
+(#{call-with-values @ Integer Integer Integer} (lambda () (values 1 2)) (lambda: ([x : Integer] [y : Integer]) (+ x y)))
+
+
+(call-with-values (lambda () (values 1 2)) (lambda: ([x : Integer] [y : Integer]) (+ x y)))
+
+(: map-with-funcs (All (b ...) ((b ... b -> b) ... b -> (b ... b -> (values b ... b)))))
+(define (map-with-funcs . fs)
+  (lambda bs
+    (apply values (map (plambda: (c) ([f : (b ... b -> c)])
+                         (apply f bs)) fs))))
+
+(map-with-funcs + - * /)
+
+(inst map-with-funcs Integer Integer)
+
+(map-with-funcs
+ (lambda: ([x : Integer] [y : Integer]) (+ x y))
+ (lambda: ([x : Integer] [y : Integer]) (- x y)) )
+
+(((inst map-with-funcs Integer Integer)
+    (lambda: ([x : Integer] [y : Integer]) (+ x y))
+    (lambda: ([x : Integer] [y : Integer]) (- x y)))
+   3 4)

--- a/typed-racket-test/succeed/shallow/vector-ref.rkt
+++ b/typed-racket-test/succeed/shallow/vector-ref.rkt
@@ -1,0 +1,23 @@
+#lang typed/racket/shallow
+
+;; Test successful vector-ref operations
+
+(: f (-> (Vectorof Natural) Natural))
+(define (f x)
+  (+ (vector-ref x 0)
+     (vector-ref x 1)))
+
+(f (vector 4 4 4 4))
+
+(: g (-> (Vectorof (Vectorof Natural)) Natural))
+(define (g x)
+  (define v (vector-ref x 0))
+  (+ (vector-ref (vector-ref x 0) 0) (vector-ref v 1)))
+
+(g (vector (vector 1 2 2 3 4)))
+
+(: h (-> (Vector Natural Symbol) Natural))
+(define (h x)
+  (vector-ref x 0))
+
+(h (vector 1 'asdf))

--- a/typed-racket-test/succeed/shallow/with-input-from-file.rkt
+++ b/typed-racket-test/succeed/shallow/with-input-from-file.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/base/shallow
+
+;; Test 'with-input-from-file'
+
+(: main (-> Path-String Void))
+(define (main filename)
+  (define q (with-input-from-file filename (lambda () (read))))
+  (void))

--- a/typed-racket-test/succeed/shallow/with-syntax.rkt
+++ b/typed-racket-test/succeed/shallow/with-syntax.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/shallow
+(require racket/syntax)
+
+(: f : -> (Syntaxof Any))
+(define (f)
+  (with-syntax* ([(x ...) (list 1 2 3)])
+    #`(#,(syntax +) x ...)))
+  

--- a/typed-racket-test/succeed/shallow/with-type-bug.rkt
+++ b/typed-racket-test/succeed/shallow/with-type-bug.rkt
@@ -1,0 +1,3 @@
+#lang scheme
+(require (prefix-in T: typed/racket/shallow))
+((T:with-type #:result (T:Integer T:-> T:Integer) add1) 1/2)

--- a/typed-racket-test/succeed/shallow/with-type-lift.rkt
+++ b/typed-racket-test/succeed/shallow/with-type-lift.rkt
@@ -1,0 +1,25 @@
+#lang racket/base
+
+;; Test syntax lifting in `with-type`
+
+(require rackunit typed/racket/shallow)
+
+(with-type #:result Number
+  (define-syntax (m stx)
+    (syntax-local-lift-expression #'(+ 1 2)))
+  (m))
+
+(define-syntax (m2 stx)
+  (syntax-local-lift-expression #'(+ 1 2)))
+
+(with-type #:result Number (m2))
+
+(with-type ([val Number]) (define val (m2)))
+(check-equal? val 3)
+
+(with-type #:result (Listof String)
+  ;; casts do lifts for the contract
+  (define x (cast '() (Listof String)))
+  ;; as do predicates
+  (make-predicate (Listof String))
+  x)

--- a/typed-racket-test/succeed/shallow/with-type-typed-context-flag.rkt
+++ b/typed-racket-test/succeed/shallow/with-type-typed-context-flag.rkt
@@ -1,0 +1,14 @@
+#lang racket/load
+
+(require (only-in typed/racket/shallow with-type)
+         syntax/macro-testing)
+
+;; Test that the typed-context? flag is properly reset
+
+(with-handlers ([exn:fail:syntax? void])
+  (convert-compile-time-error
+   (with-type [] (+ 1 "foo"))))
+
+;; this should succeed instead of an error due to the typed-context?
+;; flag being set to #t
+(with-type [] (+ 1 3))

--- a/typed-racket-test/succeed/shallow/with-type.rkt
+++ b/typed-racket-test/succeed/shallow/with-type.rkt
@@ -1,0 +1,22 @@
+#lang scheme
+(require typed/racket/shallow)
+
+(with-type #:result Number 3)
+
+(let ([x "hello"])
+  (with-type #:result String
+    #:freevars ([x String])
+    (string-append x ", world")))
+
+(define-values (a b)
+  (with-type #:result (values Number String)
+             (values 3 "foo")))
+
+(with-type ([fun (Number -> Number)]
+            [val Number])
+  (define (fun x) x)
+  (define val 17))
+
+(fun val)
+val
+

--- a/typed-racket-test/succeed/shallow/with-type3.rkt
+++ b/typed-racket-test/succeed/shallow/with-type3.rkt
@@ -1,0 +1,10 @@
+#lang scheme
+
+(require typed/racket/shallow)
+
+(define-values (a b)
+  (with-type
+   #:result (values String (Number -> Number))
+   (values "foo" (lambda (x) x))))
+
+(b a)

--- a/typed-racket-test/succeed/shallow/zordoz-opt.rkt
+++ b/typed-racket-test/succeed/shallow/zordoz-opt.rkt
@@ -1,0 +1,28 @@
+#lang typed/racket/base/shallow
+
+;; Originally raised error in optimizer,
+;;  expected kernel-literal (or something) got gensym var
+
+(require racket/match)
+
+(define-type result Symbol)
+(define-type zo Symbol)
+(define zo? symbol?)
+
+(define-type Context (U zo (Listof zo) (Listof result)))
+(define-type History (Listof Context))
+(define-type History* (Listof History))
+
+(: find (-> String Context History History* (Values Context History History*)))
+(define (find raw ctx hist pre-hist)
+  (define arg "hello")
+  (cond [(and arg (zo? ctx))
+         (define results : (Listof result) '())
+         (match results
+           ['()
+            (values ctx hist pre-hist)]
+           [_
+            (values ctx '() pre-hist)])]
+        [else
+         (values ctx hist pre-hist)]))
+

--- a/typed-racket-test/succeed/take5-typecheck.rkt
+++ b/typed-racket-test/succeed/take5-typecheck.rkt
@@ -1,0 +1,71 @@
+#lang typed/racket/base
+
+;; Fragment of the GTP benchmark take5
+;;
+;; 2022-07-12 raises an internal error on the `transient-pr` branch
+;;  when typechecking an occurrence of `internal%`,
+;;  specifically when calling `setter->type`
+
+(require
+  typed/racket/class)
+
+(define-type Name Natural)
+(define-type Face Natural)
+(define-type Bulls Natural)
+
+(struct card (
+ [face : Face]
+ [bulls : Bulls])
+#:transparent)
+
+(define-type Card card)
+
+(define-type Player%
+  (Class
+    (init-field (n Name))
+    (field [my-cards [Listof Card]])))
+
+(define-type Player (Instance Player%))
+
+(: player% Player%)
+(define player%
+  (class object%
+    (init-field n)
+    (field [my-cards '()])
+    (super-new)))
+
+(define-type Internal%
+  (Class
+    #:implements Player%
+    (init-field [player Player])
+    (field [my-bulls Natural])))
+
+(define-type Internal (Instance Internal%))
+
+(define-type Dealer%
+  (Class
+    (init-field (players (Listof Player)))
+    (field
+     (internal% Internal%)
+     (internals (Listof Internal)))))
+
+(define-type Dealer (Instance Dealer%))
+
+(define dealer% : Dealer%
+  (class object%
+    (init-field
+     (players : (Listof Player)))
+
+    (super-new)
+
+    (field
+     [internal% : Internal%
+      (class player%
+        (init-field player)
+        (super-new [n 0])
+        (field [my-bulls 0]))]
+     [internals (for/list : (Listof Internal)
+                          ([p : Player (in-list (get-field players this))])
+                  (new internal% [player p]))])
+    ))
+

--- a/typed-racket-test/unit-tests/all-tests.rkt
+++ b/typed-racket-test/unit-tests/all-tests.rkt
@@ -48,7 +48,8 @@
   "prefab-tests.rkt"
   "json-tests.rkt"
   "typed-units-tests.rkt"
-  "type-constr-tests.rkt")
+  "type-constr-tests.rkt"
+  "shallow-rewrite-expansion/main.rkt")
 
 (struct fold-result [success failure err names])
 

--- a/typed-racket-test/unit-tests/init-env-tests.rkt
+++ b/typed-racket-test/unit-tests/init-env-tests.rkt
@@ -22,13 +22,13 @@
     (test-suite "Convert"
       (check-equal?
         (convert-type (-> -String -Symbol))
-        '(simple-> (list -String) -Symbol))
+        '(simple-> (list -String) -Symbol #:T+ #f))
       (check-equal?
         (convert-type (make-pred-ty -String))
-        '(make-pred-ty (list Univ) -Boolean -String (-arg-path 0)))
+        '(make-pred-ty (list Univ) -Boolean -String (-arg-path 0) #f))
       (check-equal?
         (convert-type (->acc (list (-lst -String)) -String (list -car)))
-        '(->acc (list (-lst -String)) -String (list -car)))
+        '(->acc (list (-lst -String)) -String (list -car) #:T+ #f))
       (check-equal?
         (convert-obj (make-Path '() (cons 0 0)))
         '(-arg-path 0))

--- a/typed-racket-test/unit-tests/init-env-tests.rkt
+++ b/typed-racket-test/unit-tests/init-env-tests.rkt
@@ -25,7 +25,7 @@
         '(simple-> (list -String) -Symbol #:T+ #f))
       (check-equal?
         (convert-type (make-pred-ty -String))
-        '(make-pred-ty (list Univ) -Boolean -String (-arg-path 0) #f))
+        '(make-pred-ty (list Univ) -Boolean -String (-arg-path 0)))
       (check-equal?
         (convert-type (->acc (list (-lst -String)) -String (list -car)))
         '(->acc (list (-lst -String)) -String (list -car) #:T+ #f))

--- a/typed-racket-test/unit-tests/init-env-tests.rkt
+++ b/typed-racket-test/unit-tests/init-env-tests.rkt
@@ -25,7 +25,7 @@
         '(simple-> (list -String) -Symbol #:T+ #f))
       (check-equal?
         (convert-type (make-pred-ty -String))
-        '(make-pred-ty (list Univ) -Boolean -String (-arg-path 0)))
+        '(make-pred-ty (list Univ) -Boolean -String (-arg-path 0) #f))
       (check-equal?
         (convert-type (->acc (list (-lst -String)) -String (list -car)))
         '(->acc (list (-lst -String)) -String (list -car) #:T+ #f))

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/call-with-values.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/call-with-values.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket/base/shallow
+
+(define sym* : (Listof Symbol) '(A B C))
+
+(call-with-values (lambda () sym*) car)
+(call-with-values (lambda () sym*) reverse)
+

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/case-lambda.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/case-lambda.rkt
@@ -1,0 +1,14 @@
+#lang typed/racket/base/shallow
+
+;; Check that things are defended
+;; - shape-check x symbol? in f0
+;; - shape-check 2x that y and z are Nothing
+
+(: f0 (case-> (-> Symbol Symbol)))
+(define f0
+  (case-lambda
+    [(x) x]))
+
+(f0 'x)
+((case-lambda [(x) x]) 'x)
+((case-lambda [(x) x] [(y z) z]) 'x)

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/cdr.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/cdr.rkt
@@ -1,0 +1,18 @@
+#lang typed/racket/shallow
+
+;; Expand, and make sure no shape checks,
+;;  because cdr applied to a list is OK
+
+(require racket/list racket/unsafe/ops)
+
+(define x0 : (Listof Symbol) '(A B C))
+(define x1 : (List Symbol Symbol) '(A B))
+(define x2 : (Pairof Symbol (Listof Symbol)) (cons 'D x0))
+
+(cdr x0)
+(rest x0)
+(cdr x1)
+(cdr x2)
+(unsafe-cdr x0)
+(unsafe-cdr x1)
+(unsafe-cdr x2)

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/default-continuation-prompt-tag.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/default-continuation-prompt-tag.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/base/shallow
+
+;; default-continuation-prompt-tag is separate from the base environment,
+;;  so double-check that it does not get a codomain check
+;;
+;; to test, expand this module and make sure there's no "shape-check"
+
+(default-continuation-prompt-tag)

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/for.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/for.rkt
@@ -1,0 +1,24 @@
+#lang typed/racket/base/shallow
+
+;; For combinators don't need a codomain check,
+;;  or a domain check on the `for-loop` functions
+;;
+;; Expand, look for:
+;; - no "shape-check" around the final result
+;; - no domain "shape-check" for any functions
+;; - no shape-check around unsafe-cdr
+
+(void?
+  (for ((x (in-list '(A B C))))
+    x))
+
+(list?
+  (for/list : (Listof Symbol) ((x '(A B C)))
+    x))
+
+(list?
+  (for/fold
+            ((acc : (Listof Symbol) '()))
+            ((x (in-list '(A B C))))
+    (cons x acc)))
+

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/list.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/list.rkt
@@ -1,0 +1,32 @@
+#lang typed/racket/base/shallow
+
+;; Expand and look for shape-check / lack of.
+;; See comments below.
+
+(let ((x0 : (List) '()))
+  (cdr x0) ;; yes shape-check
+  (cddr x0)) ;; yes shape-check
+
+(let ((x1 : (List Symbol) '(a)))
+  (cdr x1) ;; no shape-check
+  (cddr x1)) ;; yes shape-check
+
+(let ((x2 : (List Symbol Symbol) '(a b)))
+  (cdr x2) ;; no shape-check
+  (cddr x2) ;; no shape-check
+  (cdddr x2)) ;; yes shape-check after (cdr (unsafe-cdr (unsafe-cdr _)))
+
+(let ((x3 : (List Symbol Symbol Symbol) '(a b c)))
+  (cdr x3) ;; no shape-check
+  (cddr x3) ;; no shape-check
+  (cdddr x3) ;; no shape-check
+  (cddddr x3)) ;; yes shape-check after (cdr (unsafe-cdr (unsafe-cdr _)))
+
+(let ((x4 : (List Symbol Symbol Symbol Symbol) '(a b c d)))
+  (cdr x4) ;; no shape-check
+  (cddr x4) ;; no shape-check
+  (cdddr x4) ;; no shape-check
+  (cddddr x4)) ;; no shape-check
+
+(let ((x5 : (Pairof Symbol Null) '(a . ())))
+  (cdr x5)) ;; no shape-check

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/main.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/main.rkt
@@ -1,0 +1,313 @@
+#lang racket/base
+
+;; TODO
+;; - fix datum-literals ?
+;; - enable type-annotation test by upgrading user's annotations to trust codomain
+
+(require
+  "../test-utils.rkt"
+  rackunit
+  racket/pretty
+  racket/list
+  racket/set
+  syntax/parse
+  (only-in racket/format ~a)
+  (only-in syntax/modread with-module-reading-parameterization))
+
+(provide tests)
+(gen-test-main)
+
+(define (filename->path fn)
+  (collection-file-path fn "typed-racket-test" "unit-tests" "shallow-rewrite-expansion"))
+
+(define (filename->stx filename)
+  (define mod-stx
+    ;; thanks: read-lang-file
+    (call-with-input-file (filename->path filename)
+      (lambda (in-port)
+        (port-count-lines! in-port)
+        (with-module-reading-parameterization
+          (lambda ()
+            (read-syntax (object-name in-port) in-port))))))
+  (define stx
+    (parameterize ((current-namespace (make-base-namespace)))
+      (expand mod-stx)))
+  stx)
+
+;; ---
+
+(define-syntax-rule (syntax-predicate pat)
+  (syntax-parser [pat #true] [_ #false]))
+
+(define (no-shape-check? stx)
+  (null? (stx-find-shape-check* stx)))
+
+(define (not-implemented stx)
+  #f)
+
+;; ---
+
+(define (stx-find orig-stx p?)
+  (define stx* (stx-find* orig-stx p?))
+  (if (or (null? stx*)
+          (not (null? (cdr stx*))))
+    (raise-arguments-error 'stx-find "non-unique results" "num matches" (length stx*) "orig-stx" orig-stx "predicate" p? "matches" stx*)
+    (car stx*)))
+
+(define (stx-find* orig-stx p?)
+  (let loop ((stx orig-stx))
+    (cond
+      [(syntax? stx)
+       (let ((v (p? stx)))
+         (if v
+           (list
+             (if (eq? #true v) stx v))
+           (loop (syntax-e stx))))]
+      [(pair? stx)
+       (append (loop (car stx)) (loop (cdr stx)))]
+      [else
+        '()])))
+
+(define (stx-find-shape-check orig-stx)
+  (stx-find orig-stx shape-check?))
+
+(define (stx-find-shape-check* orig-stx)
+  (stx-find* orig-stx shape-check?))
+
+(define shape-check?
+  (syntax-predicate
+    ((~literal #%plain-app) (~datum shallow-shape-check) . _)))
+
+(define (stx-find-define-predicate-ctc stx pred-name)
+  (let* ((lift-id
+           (stx-find stx
+             (syntax-parser
+               #:datum-literals (define-values let-values #%app)
+               ((define-values (name:id) (let-values (((:id) (#%app fcp:id lift:id))) _))
+                #:when (eq? (syntax-e #'name) pred-name)
+                #'lift)
+               (_ #f))
+             ))
+         (lift-ctc
+           (stx-find stx
+             (syntax-parser
+               (((~datum define-values) (lt:id) ctc:id)
+                #:when (eq? (syntax-e #'lt) (syntax-e lift-id))
+                #'ctc)
+               (_ #f))))
+         (ctc*
+           (stx-find* stx
+             (syntax-parser
+               #:datum-literals (define-values lambda)
+               ((define-values (g:id) (lambda (_) body))
+                #:when (eq? (syntax-e #'g) (syntax-e lift-ctc))
+                #'body)
+               (_ #f)))))
+    (cond
+      [(null? ctc*)
+       lift-ctc]
+      [(null? (cdr ctc*))
+       (car ctc*)]
+      [else
+       (raise-arguments-error 'stx-find-define-predicate-ctc "cannot find lifted" "pred" pred-name)])))
+
+(define (split-shape-check stx)
+  (define expr (->datum stx))
+  (define line-num
+    (let* ((v (sixth expr))
+           (snd (and (pair? v) (pair? (cdr v)) (cadr v)))
+           (num (cadr (if (eq? snd 'kernel:srcloc) (fourth v) snd))))
+      num))
+  (values (third expr)
+          (fourth expr)
+          (second (fifth expr))
+          line-num))
+
+(define (->datum x)
+  (if (syntax? x)
+    (syntax->datum x)
+    x))
+
+(define (shape-check-matches #:expr [this-expr #f] #:shape [this-shape #f] #:type [this-type #f] #:line [this-line #f])
+  (procedure-rename
+    (lambda (stx)
+      (define-values [that-expr that-shape that-type that-line] (split-shape-check stx))
+      (and
+        (asym-equal?! this-expr that-expr "expression")
+        (asym-equal?! this-shape that-shape "shape")
+        (asym-equal?! this-type that-type "surface type")
+        (asym-equal?! this-line that-line "line")))
+    (string->symbol
+      (format "shape-check-matcher:~a" (or this-shape this-line)))))
+
+(define (asym-equal?! a b kind)
+  (when a
+    (unless (equal? a b)
+      (raise-arguments-error
+        'shape-check-matches
+        (format "~a mismatch" kind)
+        "expected" a
+        "actual" b))))
+
+(define (one-assert-matches pred assert*)
+  (define *exns (box '()))
+  (define (collect-exn ex)
+    (set-box! *exns (cons ex (unbox *exns)))
+    #f)
+  (or
+    (for/or ((assert (in-list assert*)))
+      (with-handlers ((exn:fail:contract? collect-exn))
+        (pred assert)))
+    (apply
+      raise-arguments-error
+      'one-assert-matches
+      "no matches found"
+      "predicate" (object-name pred)
+      (apply append
+        (for/list ((assert (in-list assert*))
+                   (exn (in-list (reverse (unbox *exns))))
+                   (i (in-naturals 1)))
+          (list (format "stx ~a" i) assert
+                (format "error ~a" i) (exn-message exn)))))))
+
+(define (check-comments-for-shape-check filename)
+  (list filename
+        (lambda (stx) (check-comments filename stx))))
+
+(define (check-comments filename stx)
+  (define all-assert* (stx-find-shape-check* stx))
+  (define line-nums
+    (with-input-from-file (filename->path filename)
+      (lambda ()
+        (for/list ((ln (in-lines))
+                   (n (in-naturals 1))
+                   #:when (regexp-match? #rx"yes shape-check" ln))
+          n))))
+  (and
+    (= (length all-assert*) (length line-nums))
+    (for/and ((assert (in-list all-assert*))
+              (num (in-list line-nums)))
+      ((shape-check-matches #:line num) assert))))
+
+;; ---
+
+(define test-registry
+  (list
+    (list "call-with-values.rkt"
+          (lambda (stx)
+            (define all-assert* (stx-find-shape-check* stx))
+            (and (= 1 (length all-assert*))
+                 (andmap (shape-check-matches #:type "Symbol") all-assert*))))
+
+    (list "case-lambda.rkt"
+          (lambda (stx)
+            (and
+              (let* ((f0-stx (stx-find
+                               stx
+                               (syntax-predicate
+                                 ((~literal define-values) ((~datum f0)) ((~literal case-lambda) _)))))
+                     (f0-assert (stx-find-shape-check f0-stx))
+                     (f0-match? (shape-check-matches #:expr 'x #:shape 'symbol?  #:type "Symbol")))
+                (f0-match? f0-assert))
+              (let* ((all-assert* (stx-find-shape-check* stx))
+                     (y-pred (shape-check-matches #:expr 'y #:shape 'none/c/proc #:type "Nothing"))
+                     (z-pred (shape-check-matches #:expr 'z #:shape 'none/c/proc #:type "Nothing")))
+                (and
+                  (one-assert-matches y-pred all-assert*)
+                  (one-assert-matches z-pred all-assert*))))))
+
+    (list "cdr.rkt"
+          no-shape-check?)
+
+    (list "default-continuation-prompt-tag.rkt"
+          no-shape-check?)
+
+    (list "for.rkt"
+          (lambda (stx)
+            (define all-assert* (stx-find-shape-check* stx))
+            (define num-expected 2)
+            (define car-pred (shape-check-matches #:type "(U 'A 'B 'C)"))
+            (unless (= num-expected (length all-assert*))
+              (raise-arguments-error 'for.rkt
+                                     "wrong number of shape-check"
+                                     "expected" num-expected
+                                     "actual" (length all-assert*)))
+            (for/and ((assert (in-list all-assert*)))
+              (car-pred assert))))
+
+    (check-comments-for-shape-check "list.rkt")
+
+    (list "object-private.rkt"
+          (lambda (stx)
+            (define all-assert* (stx-find-shape-check* stx))
+            (and
+              (= 1 (length all-assert*))
+              (andmap (shape-check-matches #:type "Symbol") all-assert*))))
+
+    (list "parameter.rkt"
+          (lambda (stx)
+            (define all-assert* (stx-find-shape-check* stx))
+            (and
+              (= 1 (length all-assert*))
+              (andmap (shape-check-matches #:type "Symbol") all-assert*))))
+
+    (list "predicate.rkt"
+          (lambda (stx)
+            (define List?-stx (stx-find-define-predicate-ctc stx 'List?))
+            (identifier? List?-stx)))
+
+    (list "struct-predicate.rkt"
+          (lambda (stx)
+            (define all-assert* (stx-find-shape-check* stx))
+            (define all-line*
+              (for/list ((assert (in-list all-assert*)))
+                (define-values [_a _b _c line] (split-shape-check assert))
+                line))
+            (define struct-line-num
+              (with-input-from-file (filename->path "struct-predicate.rkt")
+                (lambda ()
+                  (for/first ((ln (in-lines))
+                              (n (in-naturals))
+                              #:when (regexp-match? #rx"^\\(struct .*\\)$" ln))
+                    n))))
+            (define late-line*
+              (filter (lambda (n) (and n (< struct-line-num n))) all-line*))
+            (= 1 (length late-line*))))
+
+    ;; TODO need to infer trusted-positive for user-defined types, or something
+    #;(list "type-annotation.rkt"
+          (lambda (stx)
+            (define all-assert* (stx-find-shape-check* stx))
+            (define line-nums
+              (with-input-from-file (filename->path "type-annotation.rkt")
+                (lambda ()
+                  (for/list ((ln (in-lines))
+                             (n (in-naturals 1))
+                             #:when (regexp-match? #rx"yes shape-check" ln))
+                    n))))
+            (and
+              (= (length all-assert*) (length line-nums))
+              (for/and ((assert (in-list all-assert*))
+                        (num (in-list line-nums)))
+                ((shape-check-matches #:line num) assert)))))
+
+    (check-comments-for-shape-check "typed-pict.rkt")
+
+    (check-comments-for-shape-check "typed-framework.rkt")
+
+    (list "typed-gui-base.rkt"
+          no-shape-check?)
+
+    (check-comments-for-shape-check "typed-stx.rkt")
+
+  ))
+
+(define tests
+  (test-suite "Shallow Rewrite Tests"
+    (for ((name+pred (in-list test-registry)))
+      (define test-name (car name+pred))
+      (define test-pred (cadr name+pred))
+      (with-check-info (('test-file test-name)
+                        ('test-predicate (object-name test-pred)))
+        (check-pred test-pred (filename->stx test-name))))))
+

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/object-private.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/object-private.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/shallow
+
+;; Expect no shape-check in domain,
+;;  but yes in the body
+
+
+(define c%
+  (class object%
+    (super-new)
+    (define/private (g (x : (Listof Symbol))) : Symbol
+      (car x))))

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/parameter.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/parameter.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/base/shallow
+
+(: my-param (Parameterof Symbol))
+(define my-param (make-parameter 'A))
+
+(my-param 'B) ;; no shape-check
+(my-param) ;; yes shape-check
+

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/predicate.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/predicate.rkt
@@ -1,0 +1,15 @@
+#lang typed/racket/base/shallow
+
+;; List? should expand to a check for `(and/c list? len=2)`
+;;
+;; search for `List?`, looking for a define-values
+
+(define-type Big-T (List (Listof Integer) (List Symbol Integer Integer)))
+(define-predicate List? Big-T)
+
+(: g (-> Any (U #f Big-T)))
+(define (g y)
+  (if (List? y)
+    y
+    #f))
+

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/struct-predicate.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/struct-predicate.rkt
@@ -1,0 +1,19 @@
+#lang typed/racket/base/shallow
+
+;; Struct predicates don't need a typecheck
+;;
+;; Expand this file, jump to the bottom,
+;;  look for ONE shape-check around `a?`
+
+(module a racket/base
+  (provide (struct-out a))
+  (struct a [x]))
+
+(require/typed 'a
+  (#:struct a ([x : Symbol])))
+
+(struct b ((y : Symbol)))
+
+(a? #f) ;; require/typed struct
+(b? #f) ;; TR struct
+(exn? #f) ;; builtin struct

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/type-annotation.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/type-annotation.rkt
@@ -1,0 +1,43 @@
+#lang typed/racket/shallow
+
+;; 2022-02-04 currently broken, not upgrading type annotations because it breaks toplevel redefinitions
+
+;; Annotated function types should quietly get upgraded when Shallow TR
+;;  can trust their results
+
+(module u racket/base
+  (provide v)
+  (define v (list (lambda () 42))))
+(require/typed 'u (v (List (-> String)))) ;; yes shape-check
+
+(: unsafe-fn (-> String))
+(define unsafe-fn (car v)) ;; yes shape-check
+
+(: safe-id-0 (-> Symbol Symbol))
+(define (safe-id-0 x) x) ;; yes shape-check
+
+(: safe-id-1 (All (A) (-> A A)))
+(define (safe-id-1 x) x)
+
+(: safe-id-2 (All (B ...) (-> (List B ... B) (List B ... B))))
+(define (safe-id-2 x) x) ;; yes shape-check
+
+(: safe-id-3 (All (r #:row) (-> (Class #:row-var r) (Class #:row-var r))))
+(define (safe-id-3 cls) cls) ;; yes shape-check
+
+(let ((x : String (unsafe-fn))) ;; yes shape-check
+  (void))
+
+;; no shape-check below this line
+
+(let ((x : Symbol (safe-id-0 'hello)))
+  (void))
+
+(let ((x : Symbol (safe-id-1 'hello)))
+  (void))
+
+(let ((x : (List Symbol) (safe-id-2 (list 'hello))))
+  (void))
+
+(let ((x : (Class) (safe-id-3 (class object% (super-new)))))
+  (void))

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/typed-framework.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/typed-framework.rkt
@@ -1,0 +1,46 @@
+#lang typed/racket/shallow
+;; TODO why fail?
+
+(require typed/framework typed/racket/draw)
+
+;; bitmap% methods
+(: bitmap-test (-> (Instance Bitmap%) Void))
+(define (bitmap-test bm) ;; yes shape-check
+  (send bm get-width)
+  (send bm get-backing-scale)
+  (send bm ok?)
+  (void))
+
+;; do-autosave
+(: autosave (-> (Instance Autosave:Autosavable<%>) Void))
+(define (autosave aa) ;; yes shape-check
+  (send aa do-autosave)
+  (void))
+
+;; get-spell-check-strings
+(: colortext (-> (Instance Color:Text<%>) Void))
+(define (colortext cc) ;; yes shape-check
+  (send cc get-spell-check-strings)
+  (void))
+
+(let ()
+  color:misspelled-text-color-style-name
+  (void))
+
+(let ()
+  (void (application:current-app-name)) ;; yes shape-check
+  (application:current-app-name "test")
+  (void))
+
+(let ()
+  (preferences:default-set? 'xxx)
+  (void))
+
+(let ()
+  (get-current-gl-context)
+  (get-face-list)
+  (make-bitmap 4 4)
+  (make-platform-bitmap 8 8)
+  (recorded-datum->procedure '())
+  (void))
+

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/typed-gui-base.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/typed-gui-base.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/shallow
+
+(require typed/racket/gui/base)
+
+(let ()
+  (get-face-list 'all) ;; no shape-check
+  (get-top-level-windows) ;; no shape-check
+  (find-graphical-system-path 'init-file) ;; no shape-check
+  (system-position-ok-before-cancel?) ;; no shape-check
+  (void))
+

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/typed-pict.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/typed-pict.rkt
@@ -1,0 +1,43 @@
+#lang typed/racket/shallow
+
+(require typed/pict)
+
+(pict-width (blank)) ;; yes shape-check
+
+(let* ((p0 (rectangle 40 40))
+       (p1 (circle 40)))
+  (rtl-superimpose p0 p1)
+  (lc-superimpose p0 p1)
+  (cc-superimpose p0 p1))
+
+(let* ((p0 (rectangle 40 40))
+       (p1 (circle 40)))
+  (vl-append 1 p0 p1)
+  (hc-append 1 p0 p1)
+  (hbl-append 1 p0 p1)
+  (hb-append 1 p0 p1))
+
+(let* ((p0 (rectangle 40 40))
+       (p1 (circle 40)))
+  (call-with-values (lambda () (lt-find p0 p0)) list)
+  (void))
+
+;; -Param
+(let* ()
+  (bitmap-draft-mode) ;; yes shape-check
+  (bitmap-draft-mode #f)
+  (bitmap-draft-mode)) ;; yes shape-check
+
+(let* ((p0 : pict (rectangle 40 40))
+       (p1 : pict (circle 40))
+       (pp : pict (hc-append 100 p0 p1)))
+ (pin-line pp p0 rc-find p1 lc-find)
+ (pin-arrows-line 10 pp p0 rc-find p1 lc-find)
+ (pin-arrow-line 30
+                 pp
+                 p0 rc-find
+                 p1 lc-find
+                 #:line-width 3
+                 #:style 'long-dash
+                 #:color "medium goldenrod"))
+

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/typed-stx.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/typed-stx.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket/shallow
+
+(require typed/syntax/stx)
+
+(let* ((stx #'(a b c)))
+  (stx->list stx) ;; no shape-check
+  (stx-car stx) ;; yes shape-check
+  (stx-cdr stx) ;; yes shape-check
+  (stx-map (ann values (-> Identifier Identifier)) (list #'a #'b)) ;; no shape-check
+  (module-or-top-identifier=? #'ho #'la) ;; no shape-check
+  (void))
+

--- a/typed-racket-test/unit-tests/static-contract-instantiate-tests.rkt
+++ b/typed-racket-test/unit-tests/static-contract-instantiate-tests.rkt
@@ -5,6 +5,7 @@
 
 (require "test-utils.rkt" "evaluator.rkt"
          rackunit
+         (except-in racket/class private)
          (for-syntax
            syntax/parse
            racket/base
@@ -43,4 +44,13 @@
     (let ([vector-1 (sc->contract (vector-length/sc 1))])
       (check-true (vector-1 '#(1)))
       (check-false (vector-1 '#()))
-      (check-false (vector-1 '())))))
+      (check-false (vector-1 '())))
+    (let* ((chk-cls-0 (sc->contract (make-class-shape/sc '(i) '(f) '(p) '(a))))
+           (pre-cls (class object% (super-new) (define/pubment (a x) 42)))
+           (cls-0 (class pre-cls (super-new) (init i) (field (f 0)) (define/public (p x) (void)) (define/augment (a x) (void)))))
+      (check-true (chk-cls-0 cls-0))
+      (check-false (chk-cls-0 (class object% (super-new)))))
+    (let ((obj-0 (sc->contract (make-object-shape/sc '(f) '(m)))))
+      (check-true (obj-0 (new (class object% (super-new) (field (f 0)) (define/public (m x) (void))))))
+      (check-false (obj-0 (new (class object% (super-new) (field (f 0)))))))
+    ))

--- a/typed-racket-test/unit-tests/test-utils.rkt
+++ b/typed-racket-test/unit-tests/test-utils.rkt
@@ -42,11 +42,6 @@
   (and (below? actual expected*)
        (below? expected* actual)))
 
-(define-syntax (check-type-equal? stx)
-  (syntax-case stx ()
-    [(_ nm a b)
-     (syntax/loc stx (test-check nm type-equal? a b))]))
-
 (define-syntax gen-test-main
   (syntax-parser
     [(stx:id)

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -1322,7 +1322,8 @@
                  (list (-Arrow (list -Integer) -Integer
                                #:props (-PS (-not-type (cons 0 0) (-val #f))
                                             (-is-type (cons 0 0) (-val #f)))
-                               #:object (make-Path null (cons 0 0)))))]
+                               #:object (make-Path null (cons 0 0))
+                               #:T+ #t)))]
         [tc-e/t (inst (plambda: (a) [x : a *] (apply list x)) Integer)
                 ((list) -Integer . ->* . (-lst -Integer) : -true-propset)]
 
@@ -3645,11 +3646,11 @@
          #:ret (tc-ret (-polydots (a ...) (->... (list) ((-vec a) a) (t:Un (-val #f) (-vec Univ)))))
          #:expected (tc-ret (-polydots (a ...) (->... (list) ((-vec a) a)
                                                    (t:Un (-val #f) (-vec Univ)))))]
+
        [tc-err
          (lambda xs (andmap (lambda: ([x : #f]) x) xs))
          #:ret (tc-ret (-polydots (a ...) (->... (list) ((-val #f) a) (-val #f))))
          #:expected (tc-ret (-polydots (a ...) (->... (list) ((-val #f) a) (-val #f))))]
-
        [tc-e
         ((letrec ([lp (lambda (x) lp)]) lp) 'y)
         #:ret (tc-ret (t:-> -Symbol Univ) -true-propset)
@@ -4078,7 +4079,7 @@
          (t:-> -NonNegFlonum -Boolean : (-PS (-is-type 0 -FlonumZero) (-is-type 0 -PosFlonum)))]
        [tc-e/t
          (lambda: ([x : Byte]) (if (< 0 x) x 1))
-         (t:-> -Byte -PosByte : (-PS (-is-type (cons 0 0) -Byte) -ff))]
+         (t:-> -Byte -PosByte : (-PS (-is-type (cons 0 0) -Byte) -ff) :T+ #t)]
 
        [tc-e ((inst values Any) "a")
                #:ret (ret -String #f #f)]


### PR DESCRIPTION
Goal: add a new way to run typed/racket programs. The new types are weaker against untyped code, but should run faster.

2021-11-01: This PR is the main development.
~For now, this PR is a preview of the main development at <https://github.com/bennn/typed-racket/tree/transient> . I'm planning to keep a todo list here, listen to feedback, and push changes once I have them. Eventually, I want to merge this branch.~

### Notes for code review

- `utils/transient-rewrite.rkt` ~`defender/defender.rkt`~ rewrites expanded, unoptimized typed code with flat contract checks everywhere that an untyped value can enter at runtime.

- `private/type-contract.rkt` has a new function `type->static-contract/transient` that turns a type into a flat contract

- `cast` and other exports from `base-env/prims-contract.rkt` come in multiple versions with different semantics (Deep, Shallow, Optional)

- Other changes follow the `type-enforcement-mode?` box from `utils/tc-utils.rkt`. This new piece of state gets instantiate like the `typed-context?` box. It decides how to compile types to runtime checks.


### RESOLVED Design questions

Q. Transient code should be able to use typed/rackunit macros, but in general we can't allow guarded macros in non-guarded code. I propose using `unsafe-provide` for macros that are safe in transient (DONE https://github.com/bennn/rackunit/commit/32495bff0badecf6d1d3eea5c7be476fc3c7fcb1).

Q. `define-typed/untyped-identifier` should probably take a 3rd optional argument. Here's the problem: Transient needs to `(require/typed plot (plot-pict ....))` with a huge type because `plot` defines that as a typed/untyped id and so Transient gets an untyped identifier (it can't use the guarded one). That huge type should be defined once and for all with a require/typed on the library side. Sounds good? (YES, DO IT)

Q. The type environment files have changes to let the `defender` know whether transient can trust the results of a base-env function. These annotations are not enough for higher-order library functions; for example, `make-do-sequence` returns a function that we need to trust because TR's types are not dependent enough. For now, I have a hack to trust that function --- should we keep the hack for now, or try changing the type-rep to encode transient trust? (KEEP FOR NOW)


### Issues / TODO

- [x] write an RFC for the transient & erasure modes (#952 )
- [x] add `#lang`s ... instead of `#lang typed/racket #:transient` want `#lang typed/racket/transient` so we can use a repl and so `module+` is no longer unsound
- [x] ~add "expected" results to any `typed-racket-test/succeed` and `..../fail` files that have a different outcome on transient; change the tester to run each file on each mode (ditto for other tests)~ 2021-09-20: to keep this PR moving, I made a new folder `typed-racket-test/fail/transient/` ; the tester changes look difficult
- [x] in the `defender` review all "ignore" expressions ... maybe transient rewriting should never ignore code EDIT 2021-09-20: yes indeed, transient rewriting should not ignore expressions but rather dive into them looking for typed code
- [x] all tests pass
- [x] rename typed/racket/shallow/base to typed/racket/base/shallow etc. so that "how to enforce types" is always the last modifier (just like how no-check works)
- [x] docs for the new languages
  * add reference pages for Shallow and Optional, similar to the no-check page
  * consider splitting ref. section 2 (special forms) into typechecking & runtime forms; extend the docs for runtime forms
  * consider documenting the shape / "transient view" of static types alongside the type ... and maybe do the same for Deep
  * decide how to update the guide
- [ ] measure performance once things are in shape
  * might want to implement a cheap `and/c` to avoid racket/contract inside transient
  
### Future

Long-term issues for Transient. Record these on a project page?

- Transient-specific optimizations to avoid checks and/or improve their representation.
- Deep can optimize the contracts on exports to Shallow (need to change `typecheck/renamer.rkt` with another arg.)
  * `integer?` = no contract
  * `(-> integer? integer?)` = no contract
  * `(-> integer? (vectorof integer?))` = `(-> any (vectorof integer?))`
- edit: DONE ~Instead of keeping a "Transient env" of identifiers that don't need a result check (e.g. `map`), store that info IN the type itself. That way, a function can return a trusted function (e.g. `(negate void?)`).~

