### PR TITLE
magnitude of Float-Complex where one (or both) parts are inf

### DIFF
--- a/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
@@ -422,15 +422,17 @@
                              [(i) (unsafe-flabs c.imag-binding)])
                  (if (zero? i)
                      r
-                     (if (unsafe-fl< i r)
-                         (let-values ([(q) (unsafe-fl/ i r)])
-                           (unsafe-fl* r
-                                       (unsafe-flsqrt (unsafe-fl+ 1.0
-                                                                  (unsafe-fl* q q)))))
-                         (let-values ([(q) (unsafe-fl/ r i)])
-                           (unsafe-fl* i
-                                       (unsafe-flsqrt (unsafe-fl+ 1.0
-                                                                  (unsafe-fl* q q)))))))))])))
+                     (if (or (unsafe-fl= r +inf.0)(unsafe-fl= i +inf.0))
+                         +inf.0
+                         (if (unsafe-fl< i r)
+                             (let-values ([(q) (unsafe-fl/ i r)])
+                               (unsafe-fl* r
+                                           (unsafe-flsqrt (unsafe-fl+ 1.0
+                                                                      (unsafe-fl* q q)))))
+                             (let-values ([(q) (unsafe-fl/ r i)])
+                               (unsafe-fl* i
+                                           (unsafe-flsqrt (unsafe-fl+ 1.0
+                                                                      (unsafe-fl* q q))))))))))])))
 
 
   (pattern (#%plain-app op:float-complex-op e:expr ...)

--- a/typed-racket-test/succeed/pr950-magnitude.rkt
+++ b/typed-racket-test/succeed/pr950-magnitude.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/base
+
+(require typed/rackunit)
+
+(check-equal? (magnitude +inf.0+1.0i) +inf.0)
+(check-equal? (magnitude +inf.0-inf.0i) +inf.0)
+(check-equal? (magnitude +nan.0-inf.0i) +inf.0)
+(check-equal? (magnitude -inf.0-inf.0i) +inf.0)
+(check-equal? (magnitude +inf.0+nan.0i) +inf.0)


### PR DESCRIPTION
Bring in line with main racket:
https://docs.racket-lang.org/reference/generic-numbers.html?q=magnitude#%28def._%28%28quote._~23~25kernel%29._magnitude%29%29
stating that inf takes precedence.