### PR TITLE
fix: Add server protocol to ssl-listen

### DIFF
--- a/typed-racket-more/typed/openssl.rkt
+++ b/typed-racket-more/typed/openssl.rkt
@@ -24,7 +24,7 @@
 ;;;; 2: TCP-like Server Procedures
 (require/typed/provide openssl
   [ssl-listen (->* (Exact-Positive-Integer) ;; port, <= 65535
-                   (Exact-Nonnegative-Integer Boolean (Option String))
+                   (Exact-Nonnegative-Integer Boolean (Option String) (U SSL-Server-Context SSL-Protocol))
                    SSL-Listener)]
   [ssl-close (-> SSL-Listener Void)]
   ;; ssl-listener? provided above


### PR DESCRIPTION
The optional server protocol parameter type is missing from ssl-listen, as seen here: https://docs.racket-lang.org/openssl/index.html?q=typed%2Fopenssl#%28def._%28%28lib._openssl%2Fmain..rkt%29._ssl-listen%29%29

This updates the type declaration.