### PR TITLE
Bring type in line with documentation/implementation

### DIFF
--- a/typed-racket-more/typed/racket/private/gui-types.rkt
+++ b/typed-racket-more/typed/racket/private/gui-types.rkt
@@ -65,7 +65,7 @@
                        Real)
                  (List Bytes Integer Integer)))
    [get-argb-pixels
-    (->* [Real Real Exact-Nonnegative-Integer Exact-Nonnegative-Integer Bytes]
+    (->* [Exact-Nonnegative-Integer Exact-Nonnegative-Integer Exact-Nonnegative-Integer Exact-Nonnegative-Integer Bytes]
          [Any Any #:unscaled? Any]
          Void)]
    [get-backing-scale (-> Positive-Real)]
@@ -481,7 +481,7 @@
   (Class #:implements DC<%>
          (init [bitmap (Option (Instance Bitmap%))])
          [get-argb-pixels
-          (->* [Real Real Exact-Nonnegative-Integer Exact-Nonnegative-Integer Bytes]
+          (->* [Exact-Nonnegative-Integer Exact-Nonnegative-Integer Exact-Nonnegative-Integer Bytes]
                [Any Any]
                Void)]
          [get-bitmap (-> (Option (Instance Bitmap%)))]


### PR DESCRIPTION
Sending real values for x and y to bitmap get-argb-pixels exits with  an error
(for example)
```
(send H get-argb-pixels 1. 1. 2 2 (make-bytes 100))
ptr-ref: contract violation
  expected: fixnum?
  given: 2055.0
  argument position: 3rd
  other arguments...:
```
Note that get/set are not mirrored (set does allow real x and y according to the doc)

looking at racket/draw/bitmap it seems that x and y could be Integer (ie neg. values allowed) but since the docs say otherwise I will stick with this for now