### PR TITLE
fix duplicated evaluation of vector-expr after optimizing known-length vector-op

### DIFF
--- a/typed-racket-lib/typed-racket/optimizer/vector.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/vector.rkt
@@ -79,7 +79,7 @@
                          #`(when (immutable? new-v)
                              (op new-v i.opt new.opt ...)) ; produces the correct error message
                          #'(begin))
-                   (op.unsafe v.opt i.opt new.opt ...)))
+                   (op.unsafe new-v i.opt new.opt ...)))
 
   ;; we can do the bounds checking separately, to eliminate some of the checks
   (pattern (#%plain-app op:vector-op v:opt-expr i:fixnum-expr new:opt-expr ...)

--- a/typed-racket-test/optimizer/tests/known-length-vector-op.rkt
+++ b/typed-racket-test/optimizer/tests/known-length-vector-op.rkt
@@ -1,0 +1,15 @@
+#;#;
+#<<END
+TR opt: known-length-vector-op.rkt 3:0 (vector-ref (vector (set! x (+ x 1))) 0) -- vector
+END
+#<<END
+1
+
+END
+#lang typed/racket
+#:optimize
+#reader typed-racket-test/optimizer/reset-port
+
+(define x 0)
+(vector-ref (vector (set! x (+ x 1))) 0)
+x


### PR DESCRIPTION
```
#lang typed/racket

(define x 0)
(vector-ref (vector (set! x (+ x 1))) 0)
x
```
This program yields 2 currently.