### PR TITLE
fix a bug in comparing a parameter and a function

### DIFF
--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -1059,7 +1059,7 @@
      [(Param: in2 out2) (subtype-seq A
                                      (subtype* in2 in1)
                                      (subtype* out1 out2))]
-     [_ (subtype* A (cl->* (t-> out1) (t-> in1 -Void)) t2)]
+     [(Fun: _) (subtype* A (cl->* (t-> out1) (t-> in1 -Void)) t2)]
      [_ (continue<: A t1 t2 obj)])]
   [(case: Poly (Poly: names b1))
    (match t2

--- a/typed-racket-test/succeed/gh-issue-973.rkt
+++ b/typed-racket-test/succeed/gh-issue-973.rkt
@@ -1,0 +1,14 @@
+#lang typed/racket/base
+(define-type Type1 (Parameterof Number))
+(define-type Type2 (U Type1 Symbol))
+(: x Type1)
+(define x (make-parameter 123))
+(ann x Type2)
+
+(define-type Type11 (U Number (Parameter Type11)))
+(define-type Type12 (U Type11 Symbol))
+(ann (ann 123 Type11) Type12)
+
+(define-type Type21 (U Number (Parameter Type22)))
+(define-type Type22 (U Type21 Symbol))
+(ann (ann 123 Type21) Type22)


### PR DESCRIPTION
only turn a paramter into a function when the other type is also a function

closes #973