### PR TITLE
add types to unsafe-normalize-inputs in racket/private/for

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -72,6 +72,10 @@
           (->opt -SingleFlonum -Real [-SingleFlonum] (-lst -SingleFlonum))
           (->opt -InexactReal -Real [-InexactReal] (-lst -InexactReal))
           (->opt -Real -Real [-Real] (-lst -Real)))]
+  ;; unsafe-normalise-inputs
+  [(make-template-identifier 'unsafe-normalise-inputs 'racket/private/for)
+   (-poly (a)
+          (-> (-> a -Nat) a -Nat (Un (-val #f) -Nat) -Nat (-values (list a -Index -Index -Index))))]
   ;; normalise-inputs
   [(make-template-identifier 'normalise-inputs 'racket/private/for)
    (-poly (a)


### PR DESCRIPTION
The function was introduced in racket @ 18ff816358f400908b8cdc1071f3f65059da68e3

(This patch should also fix current CI runs, e.g. https://travis-ci.org/github/racket/typed-racket/jobs/741668313)