### PR TITLE
remove type anns for parameters in λs generated from kw/opt plambdas 

### DIFF
--- a/typed-racket-lib/typed-racket/private/syntax-properties.rkt
+++ b/typed-racket-lib/typed-racket/private/syntax-properties.rkt
@@ -69,6 +69,8 @@
   (struct-info struct-info)
   (opt-lambda opt-lambda)
   (kw-lambda kw-lambda)
+  ; mark syntax objects for formal parameters in polymorphic lambdas forms.
+  (from-plambda from-plambda)
   (tail-position typechecker:called-in-tail-position #:mark)
   (tr:class tr:class #:mark)
   (tr:class:top-level tr:class:top-level)

--- a/typed-racket-test/succeed/gh-issue-940.rkt
+++ b/typed-racket-test/succeed/gh-issue-940.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket
+(lambda #:forall (A) ([a : A] #:mand mand) 10)
+
+(lambda #:forall (A) ([a : A] #:mand [mand : (Listof A)]) 10)
+
+(define #:forall (A) (bar [a : (Listof A)] #:mand [mand : Integer]) : Integer
+  0)


### PR DESCRIPTION
Optional or keyword lambdas is expanded to more lambdas where
syntax objects for the original paramaters are reused. This is problematic when
those parameters are typed with bound type variables in polymorphic functions,
because in generated lambdas those variables would become unbound.

This patch fixes the problem by throwing the types away before typechecking
the generated lambdas.

closes #940