### PR TITLE
add missing syntax locations in bad define

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -762,7 +762,7 @@ the typed racket language.
            #'last-body))
      (define-values (defined-id rhs)
        (normalize-definition
-        #`(define formals.erased body ... last-body*)
+        (syntax/loc stx (define formals.erased body ... last-body*))
         #'-lambda
         #t #t))
      ;; insert in type variables if necessary


### PR DESCRIPTION
test code(`test.rkt`):
```rkt
#lang typed/racket

(define a b c)
```

origin:

```
/Applications/Racket v7.9/share/pkgs/typed-racket-lib/typed-racket/base-env/prims.rkt:750:10: define: bad syntax (multiple expressions after identifier)
```

now:

```
test.rkt:3:0: define: bad syntax (multiple expressions after identifier)
```

close #813 