### PR TITLE
fix a bug in typechecking partially type-annotated lambdas

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
@@ -137,7 +137,8 @@
           (cond
             [(andmap type-annotation arg-list)
              (get-types arg-list #:default Univ)]
-            [(zero? extra-arg-count) arg-tys]
+            [(zero? extra-arg-count)
+             (map (lambda (a t) (get-type a #:default t)) arg-list arg-tys)]
             [(negative? extra-arg-count) (take arg-tys arg-len)]
             [else
              (define tail-tys (match rst

--- a/typed-racket-test/fail/gh-issue-1011.rkt
+++ b/typed-racket-test/fail/gh-issue-1011.rkt
@@ -1,0 +1,8 @@
+#;
+(exn-pred 1)
+#lang typed/racket
+
+(struct root ([p : Integer] [q : Integer])
+  #:property prop:custom-write
+  (λ ([me : Integer] [port : Output-Port] mode) : Void
+     (void)))

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -840,6 +840,12 @@
         [tc-e/t (let: ([x : (Un 'foo Number) 'foo])
                       (if (eq? 'foo x) 3 x))
                 -Number]
+        [tc-err (let ()
+                  (: f (-> String Integer Number))
+                  (tr:define (f [a : Number] b)
+                             (string-length a))
+                  f)
+                #:ret (tc-ret (t:-> -String -Integer -Number))]
 
         [tc-err (let: ([x : (U String 'foo) 'foo])
                       (if (string=? x 'foo)


### PR DESCRIPTION
When using an expected arrow type to check a lambda with not every parameter
annotated, the existing annotation was thrown away, and the lambda was treated
as non-annotated one.

closes #1011