### PR TITLE
fix how and where `core-method` is used within itself.

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -269,18 +269,18 @@
   ;; part and typecheck the rest. Let other cases pass through.
   (pattern (#%plain-app (~literal chaperone-procedure)
                         meth (quote #f) (~literal prop:typed-method) (quote #t))
-           #:declare meth (core-method register/method register/self)
-           #:with form #'meth.form)
+           #:with (~var meth^ (core-method register/method register/self)) #'meth
+           #:with form #'meth^.form)
   (pattern (#%plain-app (~literal chaperone-procedure) meth . other-args)
-           #:declare meth (core-method register/method register/self)
-           #:with form #'(#%plain-app chaperone-procedure meth.form . other-args))
+           #:with (~var meth^ (core-method register/method register/self)) #'meth
+           #:with form #'(#%plain-app chaperone-procedure meth^.form . other-args))
   (pattern ((~and head (~or let-values letrec-values))
               ([(meth-name:id) meth] ...)
               meth-name-2:id)
-           #:declare meth (core-method register/method register/self)
+           #:with ((~var meth^ (core-method register/method register/self)) ...) #'(meth ...)
            #:do [(register/method #'meth-name-2)]
            #:with (plam-meth ...)
-                  (for/list ([meth (in-list (syntax->list #'(meth.form ...)))])
+                  (for/list ([meth (in-list (syntax->list #'(meth^.form ...)))])
                     (cond [(plambda-property this-syntax)
                            => (λ (plam) (plambda-property meth plam))]
                           [else meth]))
@@ -290,10 +290,10 @@
   (pattern ((~and head (~or let-values letrec-values))
             ([(meth-name) meth1] ...)
             meth2)
-           #:declare meth1 (core-method register/method register/self)
-           #:declare meth2 (core-method register/method register/self)
+           #:with ((~var meth1^ (core-method register/method register/self)) ...) #'(meth1 ...)
+           #:with (~var meth2^ (core-method register/method register/self)) #'meth2
            #:with form
-                  #'(head ([(meth-name) meth1.form] ...) meth2.form)))
+                  #'(head ([(meth-name) meth1^.form] ...) meth2^.form)))
 
 ;; For detecting field mutations for occurrence typing
 (define-syntax-class (field-assignment local-table)

--- a/typed-racket-test/succeed/gh-issue-1020.rkt
+++ b/typed-racket-test/succeed/gh-issue-1020.rkt
@@ -1,0 +1,6 @@
+#lang typed/racket
+
+(class object% (super-new)
+  (public m)
+  (define m (let ([mm (lambda ([x : Number] #:yyy [yyy : String]) (string-length yyy))])
+              mm)))

--- a/typed-racket-test/unit-tests/class-tests.rkt
+++ b/typed-racket-test/unit-tests/class-tests.rkt
@@ -1951,6 +1951,15 @@
                  (let-values ([(m) (tr:lambda (x #:x y) (add1 y))]) m))))
            (send (new c%) m 0 #:x 1))
          -Integer]
+   [tc-e (let ()
+           (define c%
+             (class object% (super-new)
+               (public m)
+               (define-values (m)
+                 (let-values ([(m) (tr:lambda ([x : Integer] #:x [y : String]) : Integer
+                                              (string-length y))]) m))))
+           (send (new c%) m 0 #:x "1"))
+         -Integer]
    ;; This tests a bug that came up while adding support for the test
    ;; cases directly above
    [tc-e (let ()


### PR DESCRIPTION
Previously, when `core-method` was used #:declared, it would be recursively
called in patterns even for an unmatched syntax object. Since `core-method`
contained stateful operations (register-self/method), the typechecker could
mistakenly recognize some lambda forms as methods and register wrong parameters
as `self` (see Issue #1020).

closes #1020