### PR TITLE
improves error reporting for `(list ....)`

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/signatures.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/signatures.rkt
@@ -13,6 +13,7 @@
    [cond-contracted tc-expr/check/t? (syntax? (or/c tc-results/c #f) . -> . (or/c Type? #f))]
    [cond-contracted tc-body/check (syntax? (or/c tc-results/c #f) . -> . full-tc-results/c)]
    [cond-contracted tc-expr/t (syntax? . -> . Type?)]
+   [cond-contracted tc-expr/t* (syntax? . -> . (values Type? boolean?))]
    [cond-contracted single-value ((syntax?) ((or/c tc-results/c #f)) . ->* . full-tc-results/c)]
    [cond-contracted tc-dep-fun-arg ((syntax?) ((or/c tc-results/c #f)) . ->* . full-tc-results/c)]))
 

--- a/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
@@ -67,6 +67,18 @@
     [(tc-result1: t _ _) t]
     [t (int-err "tc-expr returned ~a, not a single tc-result, for ~a" t (syntax->datum e))]))
 
+;; typecheck an expression. The result contains two values
+;; 1. the type of the expression
+;; 2. whether there are type errors during checking the expression
+;;
+;; Unlike tc-expr/check/t? and tc-expr/check?, this function raises or keeps errors from
+;; checking the expression in the error queue.
+;;
+;; tc-expr/t* : Expr -> (values Type Boolean)
+(define (tc-expr/t* expr)
+  (parameterize ([current-type-error? #f])
+    (values (tc-expr/t expr) (current-type-error?))))
+
 (define (tc-expr/check/t e t)
   (match (tc-expr/check e t)
     [(tc-result1: t) t]))

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -3489,6 +3489,12 @@
         #:ret (tc-ret (-seq (-vec Univ)))
         #:expected (tc-ret (-seq (-vec Univ)))]
 
+       [tc-err
+        (ann (list (symbol->string "10")) (Listof String))
+        #:ret (tc-ret (-lst -String))
+        #:expected (tc-ret (-lst -String))
+        #:msg #rx"expected: Symbol.*given: String.*"]
+
        ;; PR 14557 - apply union of functions with different return values
        [tc-err
         (let ()


### PR DESCRIPTION
closes #995 and #958