### PR TITLE
Fix `define-struct` description in Reference.

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -438,7 +438,7 @@ a prefab structure type.
 @defform/subs[#:literals (:)
 (define-struct maybe-type-vars name-spec ([f : t] ...) options ...)
 ([maybe-type-vars code:blank (v ...)]
- [name-spec name-id (code:line name-id parent)]
+ [name-spec name-id (code:line (name-id parent))]
  [options #:transparent #:mutable
           (code:line #:type-name type-id)])]{
 Legacy version of @racket[struct], corresponding to @|define-struct-id|
@@ -447,7 +447,7 @@ from @racketmodname[racket/base].
 
 @defform/subs[#:literals (:)
 (define-struct/exec name-spec ([f : t] ...) [e : proc-t] maybe-type-name)
-([name-spec name-id (code:line name-id parent)]
+([name-spec name-id (code:line (name-id parent))]
  [maybe-type-name (code:line)
                   (code:line #:type-name type-id)])]{
  Like @racket[define-struct], but defines a procedural structure.


### PR DESCRIPTION
To define sub-struct by `define-struct`, following codes fail:

```
(define-struct struct1 ([v1 : Number]) #:type-name Struct1)
(define-struct struct2 struct1 ([v2 : Symbol]) #:type-name Struct2)
(define-struct (T) struct3 struct2 ([v3 : T]) #:type-name Struct3)
```

Error message:
```
define-struct: bad syntax
  in: (define-struct struct2 struct1 ((v2 : Symbol)) #:type-name Struct2)
```

It works if we put `name-id` and `parent` in parentheses.
```
(define-struct struct1 ([v1 : Number]) #:type-name Struct1)
(define-struct (struct2 struct1) ([v2 : Symbol]) #:type-name Struct2)
(define-struct (T) (struct3 struct2) ([v3 : T]) #:type-name Struct3)
```