### PR TITLE
update some tests to pass on windows.

### DIFF
--- a/typed-racket-test/fail/pr13289.rkt
+++ b/typed-racket-test/fail/pr13289.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred #rx"fail/pr13289.rkt:9:10:.*in: Natural")
+(exn-pred #rx"fail(/|\\\\)pr13289.rkt:9:10:.*in: Natural")
 #lang typed/racket
 
 ;; This test ensures that the error message for misuse of

--- a/typed-racket-test/fail/pr13289.rkt
+++ b/typed-racket-test/fail/pr13289.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred #rx"fail(/|\\\\)pr13289.rkt:9:10:.*in: Natural")
+(exn-pred #rx"fail.pr13289.rkt:9:10:.*in: Natural")
 #lang typed/racket
 
 ;; This test ensures that the error message for misuse of

--- a/typed-racket-test/optimizer/run.rkt
+++ b/typed-racket-test/optimizer/run.rkt
@@ -35,7 +35,9 @@
           ;; making program output identical on RacketCS is often worthwhile,
           ;; but optimization logs are too fragile in some cases
           (check-equal? (list (set-subtract log expected-log) (set-subtract expected-log log)) (list (list) (list))))
-        (check-equal? (regexp-split "\n" output) (regexp-split "\n" expected-output))))))
+        (check-equal? (regexp-split "\n" output) (regexp-split "\n" (if (eq? (system-type 'os) 'windows)
+                                                                        (regexp-replace* "\r" expected-output "")
+                                                                        expected-output)))))))
 
 
 (define-runtime-path tests-dir                "./tests")

--- a/typed-racket-test/optimizer/run.rkt
+++ b/typed-racket-test/optimizer/run.rkt
@@ -9,7 +9,7 @@
          generate-log tests-dir missed-optimizations-dir)
 
 (define (get-expected-results file)
-  (with-input-from-file file
+  (with-input-from-file file #:mode 'text
     (lambda () ; from the test file
       (read-line) ; skip the #;#;
       (values (for/list ((l (in-lines (open-input-string (read))))) l)
@@ -35,9 +35,7 @@
           ;; making program output identical on RacketCS is often worthwhile,
           ;; but optimization logs are too fragile in some cases
           (check-equal? (list (set-subtract log expected-log) (set-subtract expected-log log)) (list (list) (list))))
-        (check-equal? (regexp-split "\n" output) (regexp-split "\n" (if (eq? (system-type 'os) 'windows)
-                                                                        (regexp-replace* "\r" expected-output "")
-                                                                        expected-output)))))))
+        (check-equal? (regexp-split "\n" output) (regexp-split "\n" expected-output))))))
 
 
 (define-runtime-path tests-dir                "./tests")

--- a/typed-racket-test/succeed/simple-kw-app.rkt
+++ b/typed-racket-test/succeed/simple-kw-app.rkt
@@ -1,8 +1,11 @@
 #lang typed/racket
 
-((values file->string) "/dev/null" #:mode 'binary)
-(file->string "/dev/null" #:mode 'text)
+(define filename (if (eq? (system-type 'os) 'windows)
+                     "C:\\windows\\system.ini"
+                     "/dev/null"))
+((values file->string) filename #:mode 'binary)
+(file->string filename #:mode 'text)
 
 file->value file->bytes
 
-(file->lines #:mode 'text #:line-mode 'linefeed "/dev/null")
+(file->lines #:mode 'text #:line-mode 'linefeed filename)

--- a/typed-racket-test/succeed/simple-kw-app.rkt
+++ b/typed-racket-test/succeed/simple-kw-app.rkt
@@ -1,8 +1,8 @@
 #lang typed/racket
 
-(define filename (if (eq? (system-type 'os) 'windows)
-                     "C:\\windows\\system.ini"
-                     "/dev/null"))
+(define filename (collection-file-path "simple-kw-app.rkt"
+                                       "typed-racket-test"
+                                       "succeed"))
 ((values file->string) filename #:mode 'binary)
 (file->string filename #:mode 'text)
 


### PR DESCRIPTION
The following 3 test fail (for me) on windows:

- [fail/pr13289.rkt](https://github.com/racket/typed-racket/blob/master/typed-racket-test/fail/pr13289.rkt)
- [optimizer/test/known-length-vector-op.rkt](https://github.com/racket/typed-racket/blob/master/typed-racket-test/optimizer/tests/known-length-vector-op.rkt)
- [succeed/simple-kw-ap.rkt](https://github.com/racket/typed-racket/blob/master/typed-racket-test/succeed/simple-kw-app.rkt)

This PR solves this. But at least for the third test, I'm not convinced my approach is the best solution. The title of the test suggests what is being tested is kw-app but it uses the file system. So maybe a better approach is to use a kw function that doesn't need the filesystem. Or if it is the filesystem being tested, use a file from the typed-racket-test package, that is sure to be present.