### PR TITLE
Fix a bug in generating contracts for prefabs.

### DIFF
--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -22,6 +22,7 @@
                   "utils/tc-utils.rkt"
                   "types/struct-table.rkt"
                   "infer/infer.rkt"
+                  "env/type-name-env.rkt"
                   "types/substitute.rkt")
          (for-syntax racket/base syntax/parse))
 
@@ -573,10 +574,10 @@
 ;; type->sexp : Type -> S-expression
 ;; convert a type to an s-expression that can be printed
 (define (type->sexp type [ignored-names '()])
-  (define (t->s type)
+  (define (t->s type [ignored-names '()])
     (parameterize ([current-print-type-fuel
                     (sub1 (current-print-type-fuel))])
-      (type->sexp type)))
+      (type->sexp type ignored-names)))
   (define (tuple? t)
     (match t
       [(Pair: a (? tuple?)) #t]
@@ -600,13 +601,16 @@
     [(Univ:) 'Any]
     [(Bottom:) 'Nothing]
     ;; struct names are just printed as the original syntax
-    [(Name/struct: id) (syntax-e id)]
+    [(Name/struct: id)
+     (match (lookup-type-name id (lambda () #f))
+       [(and (? Prefab?) ty) (t->s ty (cons id ignored-names))]
+       [_ (syntax-e id)])]
     ;; If a type has a name, then print it with that name.
     ;; However, we expand the alias in some cases
     ;; (i.e., the fuel is > 0) for the :type form.
     [(app has-name? (? values names))
      (=> fail)
-     (when (not (null? ignored-names)) (fail))
+     (unless (null? ignored-names) (fail))
      (define fuel (current-print-type-fuel))
      (cond [(> fuel 0)
             (parameterize ([current-print-type-fuel (sub1 fuel)])

--- a/typed-racket-test/fail/gh-issue-1041.rkt
+++ b/typed-racket-test/fail/gh-issue-1041.rkt
@@ -1,0 +1,10 @@
+#;
+(exn-pred #rx"expected: \\(Prefab container String\\).*given: \\(Prefab container Positive-Byte\\)")
+#lang typed/racket/base
+
+(define val '#s(container 10))
+(struct container
+    ([value : String])
+    #:prefab)
+  (ann val container)
+

--- a/typed-racket-test/succeed/gh-issue-906.rkt
+++ b/typed-racket-test/succeed/gh-issue-906.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket/base
+
+(provide container)
+
+(struct container
+  ([value : (U #f container)])
+  #:prefab)


### PR DESCRIPTION
A recursively defined prefab type caused the expansion to diverge.
The changes fix this issue.

closes #906

also make type error for prefab types more comprehensible

closes #1041 