### PR TITLE
Install Racket locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,29 @@ jobs:
         enable-contracts: [true, false]
     steps:
       - uses: actions/checkout@master
-      - uses: Bogdanp/setup-racket@v0.10
+      - uses: Bogdanp/setup-racket@v0.14
         with:
           architecture: x64
           distribution: full
           variant: ${{ matrix.racket-variant }}
           version: ${{ matrix.racket-version }}
+          dest: '"${HOME}/racketdist-${{ matrix.racket-version }}-${{ matrix.racket-variant }}"'
+          sudo: never
+      - name: Add Racket to PATH
+        run: echo "${HOME}/racketdist-${{ matrix.racket-version }}-${{ matrix.racket-variant }}/bin" >> $GITHUB_PATH
+      - name: Check Racket version
+        run: racket -v
       - run: |
-             sudo raco pkg install --auto -i --no-setup --skip-installed typed-racket-test
+             raco pkg config -i --set default-scope installation
+             raco pkg install --auto --no-setup --skip-installed typed-racket-test
              racket -l- pkg/dirs-catalog --link --check-metadata pkgs-catalog .
              echo file://`pwd`/pkgs-catalog/ > catalog-config.txt
              raco pkg config catalogs >> catalog-config.txt
-             sudo raco pkg config --set catalogs `cat catalog-config.txt`
-             sudo raco pkg update -i --auto --no-setup source-syntax/ typed-racket-lib/ typed-racket-more/ typed-racket-compatibility/ typed-racket-doc/ typed-racket/ typed-racket-test/
-      - run: sudo raco setup --check-pkg-deps typed typed-racket typed-racket-test typed-scheme
+             raco pkg config --set catalogs `cat catalog-config.txt`
+             raco pkg update --auto --no-setup source-syntax/ typed-racket-lib/ typed-racket-more/ typed-racket-compatibility/ typed-racket-doc/ typed-racket/ typed-racket-test/
+      - run: raco setup --check-pkg-deps typed typed-racket typed-racket-test typed-scheme
         if: ${{ !matrix.enable-contracts }}
-      - run: sudo raco setup --check-pkg-deps typed typed-racket typed-racket-test typed-scheme
+      - run: raco setup --check-pkg-deps typed typed-racket typed-racket-test typed-scheme
         if: ${{ matrix.enable-contracts }}
         env:
           PLT_TR_CONTRACTS: 1
@@ -42,7 +49,7 @@ jobs:
         if: ${{ !matrix.enable-contracts }}
       - run: racket -l typed-racket-test/test-docs-complete
         if: ${{ !matrix.enable-contracts }}
-      - run: sudo raco setup math
+      - run: raco setup math
         if: ${{ !matrix.enable-contracts }}
       - run: racket -l typed-racket-test -- --math
         if: ${{ !matrix.enable-contracts }}


### PR DESCRIPTION
This commit installs Racket locally in `$HOME`. As a result, the `sudo` uses in the CI can be removed and the default scope can be set to `installation`.
