### PR TITLE
improve handling for structures 

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -410,16 +410,37 @@ those functions.
           (code:line #:type-name type-id)])]{
  Defines a @rtech{structure} with the name @racket[name-id], where the
  fields @racket[f] have types @racket[t], similar to the behavior of @|struct-id|
- from @racketmodname[racket/base]. If @racket[type-id] is specified, then it will
- be used for the name of the type associated with instances of the declared
- structure, otherwise @racket[name-id] will be used for both.
-  When @racket[parent] is present, the
-structure is a substructure of @racket[parent].
+ from @racketmodname[racket/base].
 
 @ex[
   (struct camelia-sinensis ([age : Integer]))
   (struct camelia-sinensis-assamica camelia-sinensis ())
 ]
+
+If @racket[type-id] is not specified, @racket[name-id] will be used for the
+name of the type associated with instances of the declared
+structure. Otherwise, @racket[type-id] will be used for the type name, and
+using @racket[name-id] in this case will cause a type error.
+
+@ex[
+  (struct apple () #:type-name BigApple)
+  (ann (apple) BigApple)
+  (eval:error (ann (apple) apple))
+]
+
+@racket[type-id] can be also used as an alias to @racket[name-id], i.e. it will
+be a transformer binding that encapsulates the same structure information as
+@racket[name-id] does.
+
+@ex[
+  (struct avocado ([amount : Integer]) #:type-name Avocado)
+  (struct hass-avocado Avocado ())
+  (struct-copy Avocado (avocado 0) [amount 42])
+]
+
+When @racket[parent] is present, the
+structure is a substructure of @racket[parent].
+
 
 When @racket[maybe-type-vars] is present, the structure is polymorphic in the type
  variables @racket[v]. If @racket[parent] is also a polymorphic struct, then

--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -9,6 +9,7 @@
          "type-alias-env.rkt"
          "mvar-env.rkt"
          "signature-env.rkt"
+         "struct-name-env.rkt"
          (rep core-rep type-rep
               prop-rep rep-utils
               object-rep values-rep
@@ -461,6 +462,11 @@
     type-env-map
     (λ (id ty) #`(register-type #'#,id #,(quote-type ty)))))
 
+(define (struct-name-env-init)
+  (make-init-code
+    struct-name-map
+    (λ (id tname) #`(register-struct-name! #'#,id #'#,tname))))
+
 (define (mvar-env-init-code mvar-env)
   (make-init-code
     (λ (f) (free-id-table-map mvar-env f))
@@ -494,7 +500,8 @@
           (tvariance-env-init-code)
           (mvar-env-init-code mvar-env)
           (signature-env-init-code)
-          (make-struct-table-code)))
+          (make-struct-table-code)
+          (struct-name-env-init)))
 
   ;; get the lifted common expressions for types which need to come first
   (list* (get-extra-type-definitions)

--- a/typed-racket-lib/typed-racket/env/struct-name-env.rkt
+++ b/typed-racket-lib/typed-racket/env/struct-name-env.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+(require syntax/id-table
+         "../typecheck/renamer.rkt"
+         "env-utils.rkt")
+
+(provide register-struct-name!
+         struct-name-map
+         lookup-struct-name)
+
+(define mapping (make-free-id-table))
+
+(define (register-struct-name! sname tname)
+  (free-id-table-set! mapping sname tname))
+
+(define (lookup-struct-name sname)
+  (or (free-id-table-ref mapping sname #f)
+      (free-id-table-ref mapping (un-rename sname) #f)))
+
+
+(define (struct-name-map f)
+  (sorted-free-id-table-map mapping f))

--- a/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
@@ -33,7 +33,7 @@
   typed-define-values/invoke-unit
   assert-typecheck-failure
   typecheck-failure
-
+  dtsi-fields
   type-alias?
   new-subtype-def?
   typed-struct?

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -8,7 +8,7 @@
          (types utils abbrev type-table struct-table resolve)
          (private parse-type type-annotation syntax-properties type-contract)
          (env global-env init-envs type-name-env type-alias-env
-              lexical-env env-req mvar-env scoped-tvar-env
+              lexical-env env-req mvar-env scoped-tvar-env struct-name-env
               type-alias-helper signature-env signature-helper)
          (utils tc-utils redirect-contract)
          "provide-handling.rkt" "def-binding.rkt" "tc-structs.rkt"
@@ -525,6 +525,7 @@
                 (require typed-racket/types/numeric-tower typed-racket/env/type-name-env
                          typed-racket/env/global-env typed-racket/env/type-alias-env
                          typed-racket/types/struct-table typed-racket/types/abbrev
+                         typed-racket/env/struct-name-env
                          (rename-in racket/private/sort [sort raw-sort]))
                 #,@(make-env-init-codes)
                 #,@(for/list ([a (in-list aliases)])

--- a/typed-racket-test/fail/exported-struct-id-not-type.rkt
+++ b/typed-racket-test/fail/exported-struct-id-not-type.rkt
@@ -1,0 +1,9 @@
+#;(exn-pred "type name `fruit' is unbound")
+#lang typed/racket/base
+
+(module mod1 typed/racket/base
+  (provide (all-defined-out))
+  (struct fruit ()  #:type-name Fruit))
+
+(require 'mod1)
+(ann (fruit) fruit)

--- a/typed-racket-test/fail/gh-issue-1050.rkt
+++ b/typed-racket-test/fail/gh-issue-1050.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred exn:fail:syntax? #rx"type-check: type name used out of context.*? type: Exp")
+(exn-pred #rx"Exp: identifier for static struct-type information cannot be used as an expression")
 #lang typed/racket/base
 
 (module typed1 typed/racket/base

--- a/typed-racket-test/fail/struct-id-not-type.rkt
+++ b/typed-racket-test/fail/struct-id-not-type.rkt
@@ -1,0 +1,5 @@
+#;(exn-pred "type name `fruit' is unbound")
+#lang typed/racket/base
+
+(struct fruit ()  #:type-name Fruit)
+(ann (fruit) fruit)

--- a/typed-racket-test/fail/struct-type-name-not-constr.rkt
+++ b/typed-racket-test/fail/struct-type-name-not-constr.rkt
@@ -1,0 +1,8 @@
+#;
+(exn-pred #rx"Exp: identifier for static struct-type information cannot be used as an expression")
+#lang typed/racket/base
+
+(provide (except-out (all-defined-out) make-exp))
+(struct exp () #:type-name Exp #:constructor-name make-exp)
+
+(Exp)

--- a/typed-racket-test/succeed/gh-issue-506.rkt
+++ b/typed-racket-test/succeed/gh-issue-506.rkt
@@ -8,9 +8,7 @@
 (struct b a ())
 (void (list
        (ann (a 1) A)
-       (ann (b 1) A)
-       (ann (a 1) a)
-       (ann (b 1) a)))
+       (ann (b 1) A)))
 
 ; Test with a polymorphic parent also:
 (struct (T) p ([a : T]) #:type-name P)
@@ -18,5 +16,4 @@
 (void (list
        (ann (p 1) (P Integer))
        (ann (q 1) (P Integer))
-       (ann (p 1) (p Integer))
        (ann (q 1) (q Integer))))

--- a/typed-racket-test/succeed/struct-constructors.rkt
+++ b/typed-racket-test/succeed/struct-constructors.rkt
@@ -1,9 +1,11 @@
-#lang typed/racket/base
+#lang typed/racket
 (module a-mod typed/racket/base
   (provide (except-out (all-defined-out) make-avocado))
   (struct apple ())
   (struct orange () #:constructor-name make-orange)
-  (struct kiwi () #:constructor-name kiwi)
+  (struct kiwi () #:type-name Kiwi)
+  (Kiwi)
+  (struct super-kiwi Kiwi ())
   (struct pear () #:extra-constructor-name pear)
   (struct avocado () #:type-name Avocado #:constructor-name make-avocado))
 
@@ -14,3 +16,14 @@
 (: avocado-id (-> Avocado Avocado))
 (define (avocado-id arg) arg)
 (struct hass-avocado avocado ())
+(struct HASS-AVOCADO Avocado ())
+
+(define-syntax (define-logn-ids stx)
+  (syntax-case stx ()
+    [(_ A)
+     (with-syntax ([(g) (generate-temporaries #'(g))])
+       #`(begin
+           (struct g ())
+           (struct A2 g () #:type-name A)))]))
+
+(define-logn-ids A)

--- a/typed-racket-test/succeed/struct-inheritance-through-exported-macro.rkt
+++ b/typed-racket-test/succeed/struct-inheritance-through-exported-macro.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket
+(module mod1 typed/racket
+  (provide (all-defined-out))
+  (struct ssh-message ([number : Byte] [name : Symbol]) #:type-name SSH-Message)
+
+  (define-syntax (hi stx)
+    (syntax/loc stx
+      (struct hello ssh-message ()))))
+(require 'mod1)
+(hi)

--- a/typed-racket-test/succeed/struct-out-with-exported-type-name.rkt
+++ b/typed-racket-test/succeed/struct-out-with-exported-type-name.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket
+(module mod1 typed/racket
+  (provide (all-defined-out))
+  (struct apple () #:type-name ApplePlus)
+  (struct banana ApplePlus ())
+  (provide (struct-out ApplePlus)))
+
+
+(require 'mod1)
+(provide (struct-out ApplePlus))


### PR DESCRIPTION
1. fix a bug where struct-out is used with an imported type name
2. implement the design intent that the structure name is not allowed to be used
for the type name,when the latter is provided through #:type-name
3. update the documentation