### PR TITLE
Adding typing to match when (? number? c) is involved

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/guide/caveats.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/caveats.scrbl
@@ -244,7 +244,19 @@ anticipate with their pattern matching, e.g.:
   (eval:error
    (size 42))]
 
+Patterns involving an ellipsis @racket[...] for repetition may generate a 
+@racket[for] loop that requires annotations on variables to type check. 
+The (deliberately obscure) code below does not type check without the type 
+annotation on the match pattern variable @racket[c].
 
+@codeblock[#:keep-lang-line? #f]{
+  #lang typed/racket
+  (: do-nothing (-> (Listof Integer) (Listof Integer)))
+  (define (do-nothing lst)
+    (match lst
+      [(list (? number? #{c : (Listof Integer)}) ...)   c]))
+}
+  
 @section{@racket[is-a?] and Occurrence Typing}
 
 Typed Racket does not use the @racket[is-a?] predicate to refine object types


### PR DESCRIPTION
Add a match example with an annotation and ...
Document how type annotations help the expanded code for match type check.