### PR TITLE
Fix make-log-receiver type signature.

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -3105,7 +3105,7 @@
 [log-level? (->opt -Logger -Log-Level [(-opt -Symbol)] B)]
 
 [log-receiver? (make-pred-ty -Log-Receiver)]
-[make-log-receiver (->opt -Logger -Log-Level [(-opt -Symbol)] -Log-Receiver)]
+[make-log-receiver (->* (list -Logger) (make-Rest (list -Log-Level (-opt -Symbol))) -Log-Receiver)]
 
 ;; Section 15.5.4 (Additional Logging Functions, racket/logging)
 [log-level/c (make-pred-ty (one-of/c 'none 'fatal 'error 'warning 'info 'debug))]

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -3105,7 +3105,7 @@
 [log-level? (->opt -Logger -Log-Level [(-opt -Symbol)] B)]
 
 [log-receiver? (make-pred-ty -Log-Receiver)]
-[make-log-receiver (->* (list -Logger) (make-Rest (list -Log-Level (-opt -Symbol))) -Log-Receiver)]
+[make-log-receiver (opt-fn (list -Logger -Log-Level) (list (-opt -Symbol)) -Log-Receiver #:rest (make-Rest (list -Log-Level (-opt -Symbol))))]
 
 ;; Section 15.5.4 (Additional Logging Functions, racket/logging)
 [log-level/c (make-pred-ty (one-of/c 'none 'fatal 'error 'warning 'info 'debug))]

--- a/typed-racket-test/succeed/log.rkt
+++ b/typed-racket-test/succeed/log.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/base
+
+(make-log-receiver (make-logger) 'error)
+(make-log-receiver (make-logger) 'error 'hi)
+
+;; the expr should type check
+;; (make-log-receiver (make-logger) 'error 'hi 'fatal)
+
+(make-log-receiver (make-logger) 'error 'hi 'fatal 'world)


### PR DESCRIPTION
Extend type signature of make-log-receiver to allow n-ary logging topics and log levels.  Current type signature supports only a single logging topic.

This change is more restrictive than the documented behavior of the untyped make-log-receiver which allows for defaulting the topic to #f.  

This fix allows for a typical usage of make-log-receiver to properly type check. e.g.
(make-log-receiver (current-logger) 'info #f 'debug 'my/lib/logger)
