### PR TITLE
fix struct-related bugs:

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/def-binding.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/def-binding.rkt
@@ -97,7 +97,7 @@
        (make-quad internal-id def-tbl pos-blame-id mk-redirect-id))
 
      (match-define (def-struct-stx-binding internal-id sname tname si constr-type extra-constr-name) me)
-     (match-define (list type-desc constr pred (list accs ...) muts super) (extract-struct-info si))
+     (match-define (list type-desc constr^ pred (list accs ...) muts super) (extract-struct-info si))
      (define-values (defns export-defns new-ids aliases)
        (for/lists (defns export-defns new-ids aliases)
                   ([e (in-list (list* type-desc pred super accs))])
@@ -105,7 +105,8 @@
              (mk e)
              (mk-ignored-quad e))))
 
-     (define sname-is-constructor? (and (or extra-constr-name (free-identifier=? sname constr)) #t))
+     (define sname-is-constructor? (and (or extra-constr-name (free-identifier=? sname constr^)) #t))
+     (define constr (or extra-constr-name constr^))
      (define type-is-sname? (free-identifier=? tname internal-id))
      ;; Here, we recursively handle all of the identifiers referenced
      ;; in this static struct info.

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -381,6 +381,7 @@
           null))))
 
   (define struct-name (struct-names-struct-name names))
+  (define constructor-name (struct-names-constructor names))
   (define type-name (struct-names-type-name names))
   (define extra-constructor (struct-names-extra-constructor names))
   (define constructor-type (poly-wrapper (->* all-fields poly-base)))
@@ -397,25 +398,29 @@
               bindings)
         bindings))
 
-  (register-type (struct-names-constructor names) constructor-type)
-  (for ([b (in-list def-bindings)])
+  (define constructor-binding (make-def-binding constructor-name constructor-type))
+  (for ([b (in-list (cons constructor-binding def-bindings))])
     (register-type (binding-name b) (def-binding-ty b)))
 
-  (cons struct-binding
-        (append
-         (if (free-identifier=? type-name
-                                struct-name)
-             null
-             ;; since type-name is also an syntax transformer that contains the
-             ;; struct info, we generate a struct stx binding for it here
-             (list (make-def-struct-stx-binding
-                    type-name
-                    struct-name
-                    type-name
-                    si
-                    constructor-type
-                    extra-constructor)))
-         def-bindings)))
+  (append
+   (if (free-identifier=? constructor-name struct-name)
+       null
+       (list constructor-binding))
+   (append
+    (list struct-binding)
+    (if (free-identifier=? type-name
+                           struct-name)
+        null
+        ;; since type-name is also an syntax transformer that contains the
+        ;; struct info, we generate a struct stx binding for it here
+        (list (make-def-struct-stx-binding
+               type-name
+               struct-name
+               type-name
+               si
+               constructor-type
+               extra-constructor)))
+    def-bindings)))
 
 
 

--- a/typed-racket-test/succeed/struct-constructors.rkt
+++ b/typed-racket-test/succeed/struct-constructors.rkt
@@ -1,29 +1,60 @@
 #lang typed/racket
 (module a-mod typed/racket/base
   (provide (except-out (all-defined-out) make-avocado))
-  (struct apple ())
-  (struct orange () #:constructor-name make-orange)
-  (struct kiwi () #:type-name Kiwi)
-  (Kiwi)
-  (struct super-kiwi Kiwi ())
-  (struct pear () #:extra-constructor-name pear)
-  (struct avocado () #:type-name Avocado #:constructor-name make-avocado))
+  (struct kiwi ([a : Number]) #:type-name Kiwi)
+  (Kiwi 42)
+  (struct super-kiwi Kiwi ([a : Number]))
+  (struct avocado ([a : Number]) #:type-name Avocado #:constructor-name make-avocado))
 
-(require 'a-mod)
-(apple)
-(make-orange)
-(kiwi)
-(: avocado-id (-> Avocado Avocado))
-(define (avocado-id arg) arg)
-(struct hass-avocado avocado ())
-(struct HASS-AVOCADO Avocado ())
+(module b-mod typed/racket/base
+  (provide (struct-out apple)
+           (struct-out orange)
+           (struct-out pear)
+           (struct-out pineapple))
 
-(define-syntax (define-logn-ids stx)
-  (syntax-case stx ()
-    [(_ A)
-     (with-syntax ([(g) (generate-temporaries #'(g))])
-       #`(begin
-           (struct g ())
-           (struct A2 g () #:type-name A)))]))
+  (struct apple ([a : Number]))
+  (struct orange ([a : Number]) #:constructor-name make-orange)
+  (struct pear ([a : Number]) #:extra-constructor-name pear)
+  (struct pineapple ([a : Number]) #:extra-constructor-name make-pineapple))
 
-(define-logn-ids A)
+(module test-typed typed/racket
+  (require (submod ".." b-mod))
+  (require (submod ".." a-mod))
+  (apple 42)
+  (make-orange 42)
+  (kiwi 42)
+  (make-pineapple 42)
+  (: avocado-id (-> Avocado Avocado))
+  (define (avocado-id arg) arg)
+  (struct hass-avocado avocado ())
+  (struct HASS-AVOCADO Avocado ())
+
+  (define-syntax (define-logn-ids stx)
+    (syntax-case stx ()
+      [(_ A)
+       (with-syntax ([(g) (generate-temporaries #'(g))])
+         #`(begin
+             (struct g ())
+             (struct A2 g () #:type-name A)))]))
+
+  (define-logn-ids A))
+
+(module test-untyped racket
+  (require (submod ".." b-mod))
+  (require (submod ".." a-mod))
+  (define-syntax-rule (verify-contract expr ...)
+    (begin
+      (with-handlers ([exn:fail:contract? (lambda _
+                                            (void))])
+        expr
+        (error "no contract violation: " (quote expr)))
+      ...))
+  (verify-contract (apple 'xxx)
+                   (make-orange 'xxx)
+                   (Kiwi 'xxx)
+                   (kiwi 'xxx)
+                   (pear 'xxx)
+                   (make-pineapple 'xxx)))
+
+(require 'test-typed)
+(require 'test-untyped)


### PR DESCRIPTION
1. fix a bug where the construct-name wasn't contracted.
2. fix a bug where the struct info was created with the struct name instead of
the extra constructor name when it was supplied