### PR TITLE
bugfix for struct-related names cont'd:

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/def-binding.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/def-binding.rkt
@@ -85,7 +85,7 @@
 
 
 (define-struct (def-struct-stx-binding def-stx-binding)
-  (sname tname static-info constructor-type extra-constr-name)
+  (sname tname static-info constructor-name constructor-type extra-constr-name)
   #:transparent
   #:methods gen:providable
   [(define/generic super-mk-quad mk-quad)
@@ -96,7 +96,7 @@
      (define (mk internal-id)
        (make-quad internal-id def-tbl pos-blame-id mk-redirect-id))
 
-     (match-define (def-struct-stx-binding internal-id sname tname si constr-type extra-constr-name) me)
+     (match-define (def-struct-stx-binding internal-id sname tname si constructor-name constr-type extra-constr-name) me)
      (match-define (list type-desc constr^ pred (list accs ...) muts super) (extract-struct-info si))
      (define-values (defns export-defns new-ids aliases)
        (for/lists (defns export-defns new-ids aliases)
@@ -105,7 +105,7 @@
              (mk e)
              (mk-ignored-quad e))))
 
-     (define sname-is-constructor? (and (or extra-constr-name (free-identifier=? sname constr^)) #t))
+     (define sname-is-constructor? (and (or extra-constr-name (free-identifier=? sname constructor-name)) #t))
      (define constr (or extra-constr-name constr^))
      (define type-is-sname? (free-identifier=? tname internal-id))
      ;; Here, we recursively handle all of the identifiers referenced
@@ -206,5 +206,6 @@
                                            [sname identifier?]
                                            [tname identifier?]
                                            [static-info (or/c #f struct-info?)]
+                                           [constructor-name identifier?]
                                            [constructor-type any/c]
                                            [extra-constr-name (or/c #f identifier?)])))

--- a/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt
@@ -164,7 +164,7 @@
   [typed-struct
     (define-typed-struct-internal . :define-typed-struct-body)]
   [typed-struct/exec
-    (define-typed-struct/exec-internal nm type-name ([fields:id : types] ...) proc-type)]
+   (define-typed-struct/exec-internal nm:struct-name type-name ([fields:id : types] ...) proc-type)]
   [typed-require
     (require/typed-internal name type)]
   [typed-require/struct

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -317,6 +317,7 @@
                                  (struct-names-struct-name names)
                                  (struct-names-type-name names)
                                  si
+                                 (binding-name constructor-binding)
                                  (def-binding-ty constructor-binding)
                                  extra-constructor)
     bindings)))
@@ -389,6 +390,7 @@
                                                       struct-name
                                                       type-name
                                                       si
+                                                      constructor-name
                                                       constructor-type
                                                       extra-constructor))
   (define def-bindings
@@ -418,6 +420,7 @@
                struct-name
                type-name
                si
+               constructor-name
                constructor-type
                extra-constructor)))
     def-bindings)))

--- a/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -3,6 +3,7 @@
 (require (rename-in "../utils/utils.rkt" [infer r:infer])
          racket/syntax syntax/parse syntax/stx syntax/id-table
          racket/list racket/match racket/sequence
+         racket/struct-info
          (prefix-in c: (contract-req))
          (rep core-rep type-rep values-rep)
          (types utils abbrev type-table struct-table resolve)
@@ -57,9 +58,12 @@
                   #:prefab? (attribute t.prefab)
                   #:properties (attribute t.properties))]
       [t:typed-struct/exec
+       (match-define (list* _ extra-maker __) (extract-struct-info (struct-info-property #'t.nm)))
        (tc/struct null #'t.nm #'t.type-name
                   (syntax->list #'(t.fields ...)) (syntax->list #'(t.types ...))
-                  #:proc-ty #'t.proc-type)])))
+                  #:proc-ty #'t.proc-type
+                  #:maker #'t.nm.nm
+                  #:extra-maker extra-maker)])))
 
 
 (define (type-vars-of-struct form)

--- a/typed-racket-test/succeed/gh-issue-1088.rkt
+++ b/typed-racket-test/succeed/gh-issue-1088.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket
+
+(module foo typed/racket
+  (provide (struct-out bar))
+  (define-struct/exec
+    bar () [(λ (self) 42) : (bar -> Integer)])
+  ((bar))
+  ((make-bar)))
+
+(require 'foo)
+((bar))
+((make-bar))


### PR DESCRIPTION
Using the constructor name from the struct info to decide whether a struct name
can be used as its constructor is problematic, because in that case the
constructor name is the extra constructor name when the latter is
supplied. Instead, we should pass the constructor name from (define-) struct
forms directly.

This is also a spinoff bugfix from #1078.

These changes include small fixes for `define-struct/exec`

closes #1088