### PR TITLE
improve let(rec)-values handling

### DIFF
--- a/typed-racket-lib/typed-racket/optimizer/unboxed-let.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/unboxed-let.rkt
@@ -72,30 +72,35 @@
          ;; This ensures that unboxable variables defined in later clauses are detected before
          ;; optimization starts.
          (define-syntax-class unboxed-clause
-            #:attributes (bindings)
-            (pattern v:unboxable-let-clause?
-              #:with (real-binding imag-binding) (binding-names)
-              #:do [(add-unboxed-var! #'v.id #'real-binding #'imag-binding)]
-              #:attr bindings
-                (delay
-                  (syntax-parse #'v
-                    [((id:id) c:unboxed-float-complex-opt-expr)
-                     #:do [(log-opt "unboxed let bindings" arity-raising-opt-msg)]
-                     #'(c.bindings ...
-                        ((real-binding) c.real-binding)
-                        ((imag-binding) c.imag-binding))])))
-            (pattern v:unboxable-fun-clause?
-              #:attr bindings
-                (delay
-                  (syntax-parse #'v
-                    [c:unbox-fun-clause
-                     #'(c.bindings ...)])))
-            (pattern v
-              #:attr bindings
-                (delay
-                  (syntax-parse #'v
-                    [(vs rhs:opt-expr)
-                     #'((vs rhs.opt))]))))
+           #:attributes (bindings)
+           ;; if rhs is unreachable, do nothing
+           (pattern (~and v (lhs rhs:ignore-table^))
+                    #:attr bindings
+                    (delay
+                      #'(v)))
+           (pattern v:unboxable-let-clause?
+                    #:with (real-binding imag-binding) (binding-names)
+                    #:do [(add-unboxed-var! #'v.id #'real-binding #'imag-binding)]
+                    #:attr bindings
+                    (delay
+                      (syntax-parse #'v
+                        [((id:id) c:unboxed-float-complex-opt-expr)
+                         #:do [(log-opt "unboxed let bindings" arity-raising-opt-msg)]
+                         #'(c.bindings ...
+                                       ((real-binding) c.real-binding)
+                                       ((imag-binding) c.imag-binding))])))
+           (pattern v:unboxable-fun-clause?
+                    #:attr bindings
+                    (delay
+                      (syntax-parse #'v
+                        [c:unbox-fun-clause
+                         #'(c.bindings ...)])))
+           (pattern v
+                    #:attr bindings
+                    (delay
+                      (syntax-parse #'v
+                        [(vs rhs:opt-expr)
+                         #'((vs rhs.opt))]))))
          (define-syntax-class unboxed-clauses
            #:attributes (bindings)
            (pattern (clauses:unboxed-clause ...)

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -635,6 +635,47 @@
                 (t:-> -Number -Number -Number : -true-propset)]
         [tc-e/t (let: ([x : Number 5]) x) -Number]
         [tc-e (let-values ([(x) 4]) (+ x 1)) -PosIndex]
+        [tc-e (let ([n : (U String Number) 10])
+                (let-values ([(t) (begin (when (string? n) (error 'hi "hello")) (values 42))])
+                  (+ n 1)))
+              -Number]
+        [tc-e (let ([n : (U String Number) 10])
+                (let-values ([() (begin (when (string? n) (error 'hi "hello")) (values))])
+                  (+ n 1)))
+              -Number]
+        [tc-e (let ([n : (U String Number) 10])
+                (let-values ([() (begin (when (string? n) (error 'hi "hello")) (values))]
+                             [(a) 10])
+                  (+ n 1)))
+              -Number]
+        [tc-e (let ([n : (U String Number) 10])
+                (letrec-values ([(t) (begin (when (string? n) (error 'hi "hello")) (values 42))])
+                  (+ n 1)))
+              -Number]
+        [tc-e (let ([n : (U String Number) 10])
+                (letrec-values ([() (begin (when (string? n) (error 'hi "hello")) (values))])
+                  (+ n 1)))
+              -Number]
+        [tc-e (let ([n : (U String Number) 10])
+                (letrec-values ([() (begin (when (string? n) (error 'hi "hello")) (values))]
+                                [(a) 10])
+                  (+ n 1)))
+              -Number]
+        [tc-e (let ()
+                (tr:define l : (U False [Listof String])  #f)
+                (unless l
+                  (error 'f ""))
+                (tr:define &^%$ l)
+                (ann l (Listof String)))
+              (make-Listof -String)]
+        [tc-e (letrec-values ([([a : (U String Number)]) (values 10)]
+                              [(b) (error "hello")]
+                              [([foo : (-> Number Number)])
+                               (values (tr:lambda ([y : Number]) : Number
+                                          (if (zero? y) 42
+                                              (foo (sub1 "string")))))])
+                42)
+              -Bottom]
         [tc-e (let-values ([(x y) (values 3 #t)]) (and (= x 1) (not y)))
               #:ret (tc-ret -Boolean -false-propset)]
         [tc-e/t (values 3) -PosByte]


### PR DESCRIPTION
when there is no bound variables at LHS, i.e.:
(let-values ([() expr]) body) or (letrec-values ([() expr]) body)

refinements from RHS is still propagated to check the body

close #107