### PR TITLE
Fix a bug in running tests and bugs in #1111

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       - run: racket -l typed-racket-test -- --int --excl gui-lang.rkt --excl for-last.rkt
       - run: xvfb-run racket -l typed-racket-test -- --just typed-racket-test/succeed/gui-lang.rkt
         if: ${{ !matrix.enable-contracts }}
+      - run: xvfb-run racket -l typed-racket-test -- --guitests
+        if: ${{ !matrix.enable-contracts }}
       - run: racket -l typed-racket-test -- --opt
         if: ${{ !matrix.enable-contracts }}
       - run: racket -l typed-racket-test -- --missed-opt

--- a/typed-racket-more/typed/racket/private/gui-types.rkt
+++ b/typed-racket-more/typed/racket/private/gui-types.rkt
@@ -1612,8 +1612,7 @@
          [set ((Listof String) -> Void)]
          [set-item-label (Integer String -> Void)]
          [set-selection (Integer -> Void)]
-         (augment [on-reorder ((Listof Exact-Nonnegative-Integer) -> Void)]
-                  [on-close-request (Exact-Nonnegative-Integer -> Void)])))
+         (augment [on-reorder ((Listof Exact-Nonnegative-Integer) -> Void)])))
 
 (define-type Control<%>
   (Class #:implements Subwindow<%>

--- a/typed-racket-test/gui/succeed/test-tab-augments.rkt
+++ b/typed-racket-test/gui/succeed/test-tab-augments.rkt
@@ -12,7 +12,8 @@
                 on-close-request-callback)
     (define/augment (on-reorder tab-list)
       (on-reorder-callback tab-list))
-    (define/augment (on-close-request index)
+    (define/override (on-close-request index)
+      (super on-close-request index)
       (on-close-request-callback index))))
 (define tabs : (Instance Tab-Panel-With-Callbacks%)
   (new tab-panel-with-callbacks%

--- a/typed-racket-test/main.rkt
+++ b/typed-racket-test/main.rkt
@@ -147,7 +147,7 @@
                          (delay/thread
                             (define-values (sp out in err)
                               (subprocess #f #f #f (find-executable-path "racket") "-t" p))
-                            (sync/timeout 10 sp)
+                            (sync/timeout 50 sp)
                             (dynamic-wind (lambda _ (void))
                                           (lambda _
                                             (match (subprocess-status sp)
@@ -161,7 +161,7 @@
                                             (close-input-port err)))))))
   (make-test-suite "gui-tests"
                    (for/list ([prm (in-list prm-li)])
-                     (test-case (car prm) (check-not-exn (lambda _ (force (cdr prm))))))))
+                     (test-suite (car prm) (check-not-exn (lambda _ (force (cdr prm))))))))
 
 (define (just-one p*)
   (define-values (path p b) (split-path p*))


### PR DESCRIPTION
Fix https://drdr.racket-lang.org/57520/. 

The ci jobs for #1111 were successful, because `racket -l typed-racket-test --int`or `racket typed-racket-test/main.rkt --int` never ran any tests under "gui/succeed".

