### PR TITLE
use existential type results for method extraction

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -993,7 +993,7 @@ prefab types with the (implicitly quoted) prefab-key
 
   @ex[(: prop:foo (Struct-Property (-> Self Number)))
       (: foo-pred (-> Any Boolean : (Has-Struct-Property prop:foo)))
-      (: foo-accessor (Some (X) (-> (Has-Struct-Property prop:foo) (-> X Number) : X)))
+      (: foo-accessor (-> (Has-Struct-Property prop:foo) (Some (X) (-> X Number) : X)))
       (define-values (prop:foo foo-pred foo-accessor) (make-struct-type-property 'foo))
      ]
   @history[#:added "1.10"]}

--- a/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -654,6 +654,7 @@ functions and continuation mark functions.
                      mandatory-kw
                      opt-kw]
                 [rng type
+                     (code:line (Some (a ...) type : #:+ proposition))
                      (Values type ...)]
                 [mandatory-kw (code:line keyword type)]
                 [opt-kw [keyword type]]
@@ -746,6 +747,14 @@ functions and continuation mark functions.
 
   @ex[(: add2 (Number -> Number))
       (define (add2 n) (+ n 2))]
+
+  @margin-note{Currently, because explicit packing operations for existential types are
+  not supported, existential type results are only used to annotate accessors
+  for @racket[Struct-Property]}
+  @emph{(Some (a ...) type : #:+ proposition)} for @racket[rng] specifies an
+  @deftech[#:key "Some"]{existential type result}, where the type variables @racket[a ...] may appear
+  in @racket[type] and @racket[opt-proposition]. Unpacking the existential type
+  result is done automatically while checking application of the function.
 }
 
 @;; This is a trick to get a reference to ->* in another manual
@@ -863,14 +872,11 @@ functions and continuation mark functions.
                 0
                 (add1 (list-length (cdr lst)))))
           (list-length (list 1 2 3))]}
-          
-@defform*[[(Some (a ...) t)]]{ is an existential type where fresh variables
-@racket[a ...] may appear in @racket[t].  Currently there are no packing or
-unpacking expression for @racket[(Some (A) t)]. If @racket[t] is a function
-type and @racket[a ...] appear in the return type, unpacking is done
-automatically when the function is applied. Note that existential types are
-currently only used to type accessors for @racket[Struct-Property]}
 
+@defform[(Some (a ...) t)]{
+  See @tech[#:key "Some"]{existential type results}.
+}
+          
 @defform[(Values t ...)]{is the type of a sequence of multiple values, with
 types @racket[t ...].  This can only appear as the return type of a
 function.
@@ -993,7 +999,7 @@ prefab types with the (implicitly quoted) prefab-key
 
   @ex[(: prop:foo (Struct-Property (-> Self Number)))
       (: foo-pred (-> Any Boolean : (Has-Struct-Property prop:foo)))
-      (: foo-accessor (-> (Has-Struct-Property prop:foo) (Some (X) (-> X Number) : X)))
+      (: foo-accessor (-> (Has-Struct-Property prop:foo) (Some (X) (-> X Number) : #:+ X)))
       (define-values (prop:foo foo-pred foo-accessor) (make-struct-type-property 'foo))
      ]
   @history[#:added "1.10"]}

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -2385,16 +2385,17 @@
 ;; Section 13.8
 [prop:custom-write (-struct-property (-> -Self -Output-Port (Un B (-val 1) (-val 0)) ManyUniv)
                                      #'custom-write?)]
-[custom-write? (-> Univ B : (-has-struct-property prop:custom-write))]
-[custom-write-accessor (-some (me) (-> (-has-struct-property prop:custom-write) (-> me -Output-Port (Un B (-val 1) (-val 0)) ManyUniv) : me))]
+[custom-write? (make-pred-ty (-has-struct-property #'prop:custom-write))]
+[custom-write-accessor (-> (-has-struct-property #'prop:custom-write)
+                           (-some-res (me) (-> me -Output-Port (Un B (-val 1) (-val 0)) ManyUniv) : #:+ me))]
 
 [prop:custom-print-quotable (-struct-property (Un (-val 'self)
                                                   (-val 'never)
                                                   (-val 'maybe)
                                                   (-val 'always))
                                               #'custom-print-quotable?)]
-[custom-print-quotable? (-> Univ B : (-has-struct-property prop:custom-print-quotable))]
-[custom-print-quotable-accessor (-> (-has-struct-property prop:custom-print-quotable)
+[custom-print-quotable? (make-pred-ty (-has-struct-property #'prop:custom-print-quotable))]
+[custom-print-quotable-accessor (-> (-has-struct-property #'prop:custom-print-quotable)
                                     (Un (-val 'self)
                                         (-val 'never)
                                         (-val 'maybe)

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -451,8 +451,7 @@
   (pattern (:*^ ~! n:exact-integer o:linear-expression)
            #:attr val (-lexp (list (syntax->datum #'n) (attribute o.val))))
   (pattern o:symbolic-object-w/o-lexp
-           #:attr val (attribute o.val))
-  )
+           #:attr val (attribute o.val)))
 
 
 (define-syntax-class symbolic-object-w/o-lexp
@@ -510,8 +509,7 @@
                             (not (subtype obj-ty -Int)))
            (format "terms in linear expressions must be integers, got ~a for ~a"
                    obj-ty obj)
-           #:attr val (attribute o.val))
-  )
+           #:attr val (attribute o.val)))
 
 ;; [Listof Object?] boolean? -> Object?
 ;; create (+ linear-exps ...) or (- linear-exps ...)

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -1074,17 +1074,11 @@
        (extend-tvars syms
                      (cond
                        [(attribute rng.prop-type)
-                        (define body-type (abstract-type (parse-type (attribute rng.t)) syms))
-                        ;; since `abstract-prop` doesn't exist, abstract-type
-                        ;; doesn't take a path rep, and abstract-obj simply
-                        ;; returns the input rep, we have to abstract the type
-                        ;; before packing it into the proposition.
-                        (define prop-type (abstract-type (parse-type (attribute rng.prop-type)) syms))
-                        (make-Result body-type
-                                     (-PS (-is-type 0 prop-type)
-                                          -tt)
-                                     -empty-obj
-                                     (length (attribute rng.vars)))]
+                        (make-ExitentialResult syms
+                                               (parse-type (attribute rng.t))
+                                               (-PS (-is-type 0 (parse-type (attribute rng.prop-type)))
+                                                    -tt)
+                                               -empty-obj)]
                        [else
                         (parse-type (attribute rng.t))]))]
       [(~or (:->^ dom:non-keyword-ty ... kws:keyword-tys ... rng)

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -881,24 +881,24 @@
        ;; TODO sufficient condition, but may not be necessary
        [(has-optional-args? arrows)
         (define first-arrow (first arrows))
-       (define last-arrow (last arrows))
-       (define (convert-arrow)
-         (match-define (Arrow: first-dom _ kws
-                               (Values: (list (Result: rngs _ _) ...)))
-           first-arrow)
-         (define rst (Arrow-rst last-arrow))
-         ;; kws and rng same for all arrs
-         (define last-dom (Arrow-dom last-arrow))
-         (define mand-args (map t->sc/neg first-dom))
-         (define opt-args (map t->sc/neg (drop last-dom (length first-dom))))
-         (define-values (mand-kws opt-kws)
-           (let*-values ([(mand-kws opt-kws) (partition-kws kws)])
-             (values (map conv mand-kws)
-                     (map conv opt-kws))))
-         (define range (map t->sc rngs))
-         (define rest (and rst (t->sc/neg rst)))
-         (function/sc (from-typed? typed-side) (process-dom mand-args) opt-args mand-kws opt-kws rest range))
-       (handle-arrow-range first-arrow convert-arrow)]
+        (define last-arrow (last arrows))
+        (define (convert-arrow)
+          (match-define (Arrow: first-dom _ kws
+                                (Values: (list (Result: rngs _ _) ...)))
+            first-arrow)
+          (define rst (Arrow-rst last-arrow))
+          ;; kws and rng same for all arrs
+          (define last-dom (Arrow-dom last-arrow))
+          (define mand-args (map t->sc/neg first-dom))
+          (define opt-args (map t->sc/neg (drop last-dom (length first-dom))))
+          (define-values (mand-kws opt-kws)
+            (let*-values ([(mand-kws opt-kws) (partition-kws kws)])
+              (values (map conv mand-kws)
+                      (map conv opt-kws))))
+          (define range (map t->sc rngs))
+          (define rest (and rst (t->sc/neg rst)))
+          (function/sc (from-typed? typed-side) (process-dom mand-args) opt-args mand-kws opt-kws rest range))
+        (handle-arrow-range first-arrow convert-arrow)]
        [else
         (define/match (convert-single-arrow arr)
           [((Arrow: (list dom) rst kws (Values: (list (Result: rng (PropSet: (TypeProp: _ prop+type) _) _ 0)))))
@@ -948,21 +948,21 @@
                      (and rst (t->sc/neg rst))
                      (map t->sc rngs)))])
 
-       (define arities
-         (for/list ([t (in-list arrows)]) (length (Arrow-dom t))))
+        (define arities
+          (for/list ([t (in-list arrows)]) (length (Arrow-dom t))))
 
-       (define maybe-dup (check-duplicates arities))
-       (when maybe-dup
-         (fail #:reason (~a "function type has two cases of arity " maybe-dup)))
+        (define maybe-dup (check-duplicates arities))
+        (when maybe-dup
+          (fail #:reason (~a "function type has two cases of arity " maybe-dup)))
 
-       (if (= (length arrows) 1)
-           (handle-arrow-range (first arrows)
-                               (lambda ()
-                                 (convert-single-arrow (first arrows))))
-           (case->/sc (map (lambda (arr)
-                             (handle-arrow-range arr (lambda ()
-                                                       (convert-one-arrow-in-many arr))))
-                           arrows)))])]
+        (if (= (length arrows) 1)
+            (handle-arrow-range (first arrows)
+                                (lambda ()
+                                  (convert-single-arrow (first arrows))))
+            (case->/sc (map (lambda (arr)
+                              (handle-arrow-range arr (lambda ()
+                                                        (convert-one-arrow-in-many arr))))
+                            arrows)))])]
     [(DepFun/ids: ids dom pre rng)
      (define (continue)
        (match rng

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -906,13 +906,9 @@
            (let-values ([(mand-kws opt-kws) (partition-kws kws)])
              (arr-params->exist/sc opt-exi dom rst kws rng prop+type))]
 
-          [((Arrow: (list dom) rst kws (Values: (list (Result: rng (PropSet: (TypeProp: _ prop+type) _) _ n-exi)))))
-           #:when (> n-exi 0)
-           (let*-values ([(mand-kws opt-kws) (partition-kws kws)]
-                         [(n) (gensym)]
-                         [(var) (make-F n)])
-             (arr-params->exist/sc n dom rst kws (instantiate-type rng var)
-                                   (instantiate-type prop+type var)))]
+          [((Arrow: (list dom) rst kws (Values: (list (ExistentialResult: rng (PropSet: (TypeProp: _ prop+type) _) _ vars)))))
+           (let*-values ([(mand-kws opt-kws) (partition-kws kws)])
+             (arr-params->exist/sc (F-n (car vars)) dom rst kws rng prop+type))]
 
           [((Arrow: dom rst kws (Values: (list (Result: rngs _ _ n-exiss) ...))))
            (define-values (mand-kws opt-kws) (partition-kws kws))

--- a/typed-racket-lib/typed-racket/rep/core-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/core-rep.rkt
@@ -29,8 +29,11 @@
          def-prop
          def-object
          def-path-elem
+         make-ExitentialResult
          Result?
+         instantiate-result
          (rename-out [make-Result* make-Result]
+                     [ExistentialResult:* ExistentialResult:]
                      [Result:* Result:]))
 
 
@@ -222,17 +225,56 @@
 (define (make-Result* t ps o [n-existentials 0])
   (make-Result t ps o n-existentials))
 
+(lazy-require ["type-rep.rkt" (abstract-type abstract-propset instantiate-propset instantiate-type make-F)])
+
+(define type-var-name-table (make-hash))
+
+(define/cond-contract (make-ExitentialResult exi-syms t ps o)
+  (-> (listof symbol?) Type? PropSet? OptObject? Result?)
+  (define v (make-Result (abstract-type t exi-syms)
+                         (abstract-propset ps exi-syms)
+                         o
+                         (length exi-syms)))
+  (hash-set! type-var-name-table v exi-syms)
+  v)
+
+(define/cond-contract (instantiate-result result)
+  (-> Result? Result?)
+  (match-define (Result: type propset optobject n-existentials) result)
+  (cond
+    [(> n-existentials 0)
+     (define syms (hash-ref type-var-name-table result (build-list n-existentials (lambda _ (gensym)))))
+     (define vars (map make-F syms))
+     (make-Result (instantiate-type type vars) (instantiate-propset propset vars) optobject n-existentials)]
+    [else result]))
+
 (define-match-expander Result:*
   (lambda (stx)
     (syntax-case stx ()
       [(_ t ps o)
        #'(? Result? (app (lambda (result)
-                           (match-define (Result: type propset object _) result)
-                           (list type propset object))
+                           (match-define (Result: type propset optobject _) result)
+                           (list type propset optobject))
                          (list t ps o)))]
       [(_ t ps o n)
        #'(? Result? (app (lambda (result)
-                           (match-define (Result: type propset object n-existentials) result)
-                           (list type propset object n-existentials))
+                           (match-define (Result: type propset optobject n-existentials) result)
+                           (list type propset optobject n-existentials))
                          (list t ps o n)))])))
+
+(define-match-expander ExistentialResult:*
+  (lambda (stx)
+    (syntax-case stx ()
+      [(_ t ps o n)
+       #'(? Result? (app (lambda (result)
+                           (match-define (Result: type propset optobject n-existentials) result)
+                           (define syms (build-list n-existentials (lambda _ (gensym))))
+                           (define vars (map make-F syms))
+                           (list (instantiate-type type vars) (instantiate-propset propset vars) optobject vars))
+                         (list t ps o
+                               (? (lambda (l)
+                                    (and (not (null? l)) l))
+                                  n))))])))
+
+
 

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -68,6 +68,9 @@
          save-term-var-names!
          instantiate-type
          abstract-type
+         abstract-type-in-prop
+         abstract-propset
+         instantiate-propset
          instantiate-obj
          abstract-obj
          substitute-names
@@ -1434,7 +1437,40 @@
          [else default]))
      (type-var-transform initial instantiate-idx)]))
 
+(define/cond-contract (abstract-type-in-prop initial names-to-abstract)
+  (-> Prop? (or/c symbol? (listof symbol?)) Prop?)
+  (match initial
+    [(? TypeProp? prop) (TypeProp-update prop type
+                                         (lambda (old-ty)
+                                           (abstract-type old-ty names-to-abstract)))]
+    [tp #:when (or (equal? -tt tp) (equal? -ff tp)) tp]
+  ;; TODO finish the function for other types of props
+    [tp tp]))
 
+
+(define/cond-contract (abstract-propset initial names-to-abstract)
+  (-> PropSet? (or/c symbol? (listof symbol?)) PropSet?)
+  (PropSet-update initial thn els
+                  (lambda (old-p+ old-p-)
+                    (values (abstract-type-in-prop old-p+ names-to-abstract)
+                            (abstract-type-in-prop old-p- names-to-abstract)))))
+
+(define/cond-contract (instantiate-type-in-prop initial images)
+  (-> Prop? (or/c Type? (listof Type?)) Prop?)
+  (match initial
+    [(? TypeProp? prop) (TypeProp-update prop type
+                                         (lambda (old-ty)
+                                           (instantiate-type old-ty images)))]
+    [tp #:when (or (equal? -tt tp) (equal? -ff tp)) tp]
+    ;; TODO finish the function for other types of props
+    [tp tp]))
+
+(define/cond-contract (instantiate-propset initial images)
+  (-> PropSet? (or/c Type? (listof Type?)) PropSet?)
+  (PropSet-update initial thn els
+                  (lambda (old-p+ old-p-)
+                    (values (instantiate-type-in-prop old-p+ images)
+                            (instantiate-type-in-prop old-p- images)))))
 
 ;; type-var-transform
 ;;

--- a/typed-racket-lib/typed-racket/static-contracts/combinators/exist.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/combinators/exist.rkt
@@ -19,32 +19,32 @@
   #:transparent
   #:methods gen:sc
   [(define (sc-map v f)
-     (match-define (exist-combinator (list names lhs rhs)) v)
-     (exist-combinator (list names (f lhs 'invariant) (f rhs 'invariant))))
+     (match-define (exist-combinator (list names doms rngs)) v)
+     (exist-combinator (list names (f doms 'invariant) (f rngs 'invariant))))
    (define (sc-traverse v f)
-     (match-define (exist-combinator (list _ lhs rhs)) v)
-     (f lhs 'invariant)
-     (f rhs 'invariant)
+     (match-define (exist-combinator (list _ doms rngs)) v)
+     (f doms 'invariant)
+     (f rngs 'invariant)
      (void))
    (define (sc->contract v f)
      (match v
-       [(exist-combinator (list names lhs rhs))
+       [(exist-combinator (list names doms rngs))
         (parameterize ([static-contract-may-contain-free-ids? #t])
-          (let ([a (with-syntax ([lhs-stx (f lhs)]
-                                 [rhs-stx (f rhs)]
+          (let ([a (with-syntax ([doms-stx (f doms)]
+                                 [rngs-stx (f rngs)]
                                  [n (car names)])
-                     #'(->i ([n lhs-stx])
+                     #'(->i ([n doms-stx])
                             (_ (n)
-                               rhs-stx)))])
+                               rngs-stx)))])
             a))]))
    (define (sc->constraints v f)
      (simple-contract-restrict 'flat))])
 
 
-(define (exist/sc names lhs rhs)
-  (exist-combinator (list names lhs rhs)))
+(define (exist/sc names doms rngs)
+  (exist-combinator (list names doms rngs)))
 
 (define-match-expander exist/sc:
   (syntax-parser
-    [(_ names lhs rhs rhs-deps)
-     #'(exist-combinator (list names lhs rhs))]))
+    [(_ names doms rngs rngs-deps)
+     #'(exist-combinator (list names doms rngs))]))

--- a/typed-racket-lib/typed-racket/typecheck/error-message.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/error-message.rkt
@@ -43,8 +43,8 @@
 ;; have the same name but are different. Or for types that are too
 ;; long for a subtyping error to be helpful directly.
 (define (expected-but-got t1 t2)
-  (define r1 (resolve t1))
-  (define r2 (resolve t2))
+  (define r1 (if (string? t1) t1 (resolve t1)))
+  (define r2 (if (string? t2) t2 (resolve t2)))
   (match* (r1 r2)
     [((F: s1) (F: s2))
      #:when (string=? (symbol->string s1) (symbol->string s2))

--- a/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
@@ -91,8 +91,8 @@
                                               [ta (in-list/rest t-a Univ)])
                                     (values oa ta)))])
        (match (values->tc-results rng o-a t-a)
-         [(and (tc-results: (list (tc-result: t (PropSet: p+ _) _ #t)) _) res)
-          #:when (not (equal? p+ -ff))
+         [(and (tc-results: (list (tc-result: t (PropSet: p+ _) _ exi?)) _) res)
+          #:when (and (not (equal? p+ -ff)) (or exi? existential?))
           (lexical-env (env+ (lexical-env) (list p+)))
           res]
          [res res]))]

--- a/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
@@ -10,6 +10,7 @@
          "possible-domains.rkt"
          "../utils/tc-utils.rkt"
          "../rep/type-rep.rkt"
+         (only-in "../rep/core-rep.rkt" instantiate-result)
          "../rep/prop-rep.rkt"
          "../rep/values-rep.rkt"
          "../types/utils.rkt"
@@ -90,12 +91,19 @@
                                               [oa (in-list/rest o-a -empty-obj)]
                                               [ta (in-list/rest t-a Univ)])
                                     (values oa ta)))])
-       (match (values->tc-results rng o-a t-a)
-         [(and (tc-results: (list (tc-result: t (PropSet: p+ _) _ exi?)) _) res)
-          #:when (and (not (equal? p+ -ff)) (or exi? existential?))
-          (lexical-env (env+ (lexical-env) (list p+)))
-          res]
-         [res res]))]
+       (let ([rng  (match rng
+                     [(Values: (list res))
+                      ;; if the range is an existential result, we need to
+                      ;; instantiate it with the original names so as to make the
+                      ;; error message readable.
+                      (make-Values (list (instantiate-result res)))]
+                     [_ rng])])
+         (match (values->tc-results rng o-a t-a)
+           [(and (tc-results: (list (tc-result: t (PropSet: p+ _) _ exi?)) _) res)
+            #:when (and (not (equal? p+ -ff)) (or exi? existential?))
+            (lexical-env (env+ (lexical-env) (list p+)))
+            res]
+           [res res])))]
     ;; this case should only match if the function type has mandatory keywords
     ;; but no keywords were provided in the application
     [((Arrow: _ _ kws _) _)

--- a/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
@@ -27,9 +27,8 @@
 
 (provide/cond-contract
   [tc/funapp
-   (syntax? stx-list? Type? (c:listof tc-results1/c)
-    (c:or/c #f tc-results/c)
-    . c:-> . full-tc-results/c)])
+   (syntax? stx-list? Type? (c:listof tc-results1/c) (c:or/c #f tc-results/c)
+            . c:-> . full-tc-results/c)])
 
 ;; macro that abstracts the common structure required to iterate over
 ;; the arrs of a polymorphic case lambda trying to infer the correct
@@ -92,12 +91,7 @@
       [(Some: _ (Fun: (list arrow rst ...)))
        (unless (null? rst)
          (tc-error/fields "currently doesn't support case->" #:delayed? #f))
-       (let ([checked-ret (tc/funapp1 f-stx args-stx arrow args-res expected)])
-         (match checked-ret
-           [(tc-results: (list (tc-result: t (PropSet: p+ p-) o__)) _)
-            (lexical-env (env+ (lexical-env) (list p+)))]
-           [_ #f])
-         checked-ret)]
+       (tc/funapp1 f-stx args-stx arrow args-res expected #:existential? #t)]
       [(DepFun: raw-dom raw-pre raw-rng)
        (parameterize ([with-refinements? #t])
          (define subst (for/list ([o (in-list argobjs)]

--- a/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-structs.rkt
@@ -580,7 +580,7 @@
                                             (-result (make-pred-ty has-spty))
                                             (-result (make-Fun (list (-Arrow (list has-spty) ty
                                                                              #:props (-PS (-is-type 0 -Self)
-                                                                                          (-not-type 0 -Self))))))))
+                                                                                          -tt)))))))
                                              '())]
     [(Struct-Property: ty _) (tc-error "the predicate for ~a should be set manually. use #f instead " (syntax-e prop-name))]
     [_ (tc-error "expected ~a to be a struct type property, got ~a" (syntax-e prop-name) struct-property-ty)]))

--- a/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
@@ -57,7 +57,7 @@
 (define (values->tc-results/explicit-subst v subst)
   (define res->tc-res
     (match-lambda
-      [(Result: t ps o) (-tc-result t ps o)]))
+      [(Result: t ps o n-exi) (-tc-result t ps o (not (zero? n-exi)))]))
   
   (match (instantiate-obj+simplify v subst)
     [(AnyValues: p)

--- a/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-subst.rkt
@@ -58,7 +58,7 @@
   (define res->tc-res
     (match-lambda
       [(Result: t ps o n-exi) (-tc-result t ps o (not (zero? n-exi)))]))
-  
+
   (match (instantiate-obj+simplify v subst)
     [(AnyValues: p)
      (-tc-any-results p)]

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -357,3 +357,16 @@
     [(_ (vars ...) ty)
      (let ([vars (-v vars)] ...)
        (make-Some (list 'vars ...) ty))]))
+
+;; abbreviation for existential type results
+(define-syntax -some-res
+  (syntax-rules (:)
+    [(_ (vars ...) ty : #:+ prop+type)
+     (let* ([n (length '(vars ...))]
+            [vars (-v vars)] ...)
+       (make-Values (list
+                     (make-Result (abstract-type ty (list 'vars ...))
+                                  (-PS (-is-type 0 (abstract-type prop+type (list 'vars ...)))
+                                       -tt)
+                                  -empty-obj
+                                  n))))]))

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -365,8 +365,7 @@
      (let* ([n (length '(vars ...))]
             [vars (-v vars)] ...)
        (make-Values (list
-                     (make-Result (abstract-type ty (list 'vars ...))
-                                  (-PS (-is-type 0 (abstract-type prop+type (list 'vars ...)))
-                                       -tt)
-                                  -empty-obj
-                                  n))))]))
+                     (make-ExitentialResult (list 'vars ...) ty
+                                            (-PS (-is-type 0 prop+type)
+                                                 -tt)
+                                            -empty-obj))))]))

--- a/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require "../utils/utils.rkt"
          racket/match racket/function racket/lazy-require
+         racket/promise
          racket/list
          syntax/id-set
          (contract-req)
@@ -407,13 +408,42 @@
   (-> (listof (cons/c Type? Type?)) Result? Result?
       any/c)
   (match* (res1 res2)
-    [((Result: t1 (PropSet: p1+ p1-) o1)
-      (Result: t2 (PropSet: p2+ p2-) o2))
+    [((Result: t1 (PropSet: p1+ p1-) o1 0)
+      (Result: t2 (PropSet: p2+ p2-) o2 0))
      (and (or (equal? o1 o2) (Empty? o2) (not o2))
           (subtype-seq A
                        (subtype* t1 t2 o1)
                        (prop-subtype* p1+ p2+)
-                       (prop-subtype* p1- p2-)))]))
+                       (prop-subtype* p1- p2-)))]
+    [((Result: t1 (PropSet: p1+ p1-) o1 m-exi)
+      (Result: t2 (PropSet: p2+ p2-) o2 n-exi))
+     (with-fresh-ids m-exi m-exi-ids
+       (define p-m-vars (delay (map make-F (map syntax-e m-exi-ids))))
+       (with-fresh-ids n-exi n-exi-ids
+         (define vars (map make-F (map syntax-e n-exi-ids)))
+         (define (maybe-sub rep)
+           (cond
+             [(eq? m-exi 0)
+              ;; then the type result may contain Self
+              (subst self-var (car vars) rep)]
+             [(eq? n-exi) rep]
+             [else (for/fold ([acc rep])
+                             ([v1 (in-list vars)]
+                              [v2 (in-list (force p-m-vars))])
+                     (subst v2 v1 acc))]))
+         (let ([p2+ (match* ((> n-exi 0) p2+)
+                      [(#t (TypeProp: o ty))
+                       ;; since `instantiate-prop` doesn't exist, instantiate-type
+                       ;; doesn't take a path rep, and instantiate-obj doesn't
+                       ;; actually instantiate the type of a prop rep, we have to
+                       ;; instantiate the type specifically.
+                       (-is-type o (instantiate-type ty vars))]
+                      [(_ _) p2+])])
+           (and (or (equal? o1 o2) (Empty? o2) (not o2))
+                (subtype-seq A
+                             (subtype* (maybe-sub t1) (instantiate-type t2 vars) o1)
+                             (prop-subtype* (maybe-sub p1+) p2+)
+                             (prop-subtype* p1- p2-))))))]))
 
 ;;************************************************************
 ;; Type Subtyping

--- a/typed-racket-lib/typed-racket/types/tc-result.rkt
+++ b/typed-racket-lib/typed-racket/types/tc-result.rkt
@@ -16,7 +16,8 @@
 ;; fields are #f only when the direct result of parsing or annotations
 (def-rep tc-result ([t Type?]
                     [pset (c:or/c PropSet? #f)]
-                    [o (c:or/c OptObject? #f)])
+                    [o (c:or/c OptObject? #f)]
+                    [exi? boolean?])
   #:no-provide
   [#:frees (f)
    (combine-frees (list (f t)
@@ -25,7 +26,8 @@
   [#:fmap (f)
    (make-tc-result (f t)
                    (and pset (f pset))
-                   (and o (f o)))]
+                   (and o (f o))
+                   exi?)]
   [#:for-each (f)
    (f t)
    (when pset (f pset))
@@ -63,7 +65,7 @@
 (define (full-tc-results/c r)
   (match r
     [(tc-any-results: p) (and p #t)]
-    [(tc-results: (list (tc-result: _ pss os) ...) _)
+    [(tc-results: (list (tc-result: _ pss os _) ...) _)
      (and (andmap (λ (x) x) pss)
           (andmap (λ (x) x) os)
           #t)]
@@ -72,18 +74,19 @@
 
 (define-match-expander tc-result:*
   (syntax-rules ()
-   [(_ tp fp op) (tc-result tp fp op)]
-   [(_ tp) (tc-result tp _ _)]))
+    [(_ tp fp op) (tc-result tp fp op _)]
+    [(_ tp fp op exi) (tc-result tp fp op exi)]
+    [(_ tp) (tc-result tp _ _ _)]))
 
 
 (define-match-expander tc-result1:
   (syntax-rules ()
-   [(_ t) (tc-results: (list (tc-result: t _ _)) #f)]
-   [(_ t ps o) (tc-results: (list (tc-result: t ps o)) #f)]))
+   [(_ t) (tc-results: (list (tc-result: t _ _ _)) #f)]
+   [(_ t ps o) (tc-results: (list (tc-result: t ps o _)) #f)]))
 
 (define (tc-results-ts* tc)
   (match tc
-    [(tc-results: (list (tc-result: ts _ _) ...) _) ts]))
+    [(tc-results: (list (tc-result: ts _ _ _) ...) _) ts]))
 
 (define-match-expander Result1:
   (syntax-rules ()
@@ -92,12 +95,12 @@
 
 ;; make-tc-result*: Type? PropSet/c Object? -> tc-result?
 ;; Smart constructor for a tc-result.
-(define (-tc-result type [prop -tt-propset] [object -empty-obj])
+(define (-tc-result type [prop -tt-propset] [object -empty-obj] [existential? #f])
   (cond
     [(or (equal? type -Bottom) (equal? prop -ff-propset))
-     (make-tc-result -Bottom -ff-propset object)]
+     (make-tc-result -Bottom -ff-propset object existential?)]
     [else
-     (make-tc-result type prop object)]))
+     (make-tc-result type prop object existential?)]))
 
 
 ;; convenience function for returning the result of typechecking an expression
@@ -154,19 +157,19 @@
     [(tc-results: ts drst)
      (make-tc-results
       (map (match-lambda
-             [(tc-result: t ps o)
-              (make-tc-result t (fix-props ps) (fix-object o))])
+             [(tc-result: t ps o exi?)
+              (make-tc-result t (fix-props ps) (fix-object o) exi?)])
            ts)
       drst)]))
 
 (define (fix-results/bottom r)
   (match r
     [(tc-any-results: p) (make-tc-any-results (fix-props p -ff))]
-    [(tc-results: (list (tc-result: ts ps os) ...) #f)
+    [(tc-results: (list (tc-result: ts ps os _) ...) #f)
      (ret ts
           (for/list ([p (in-list ps)]) (fix-props p -ff-propset))
           (map fix-object os))]
-    [(tc-results: (list (tc-result: ts ps os) ...) (RestDots: dty dbound))
+    [(tc-results: (list (tc-result: ts ps os _) ...) (RestDots: dty dbound))
      (ret ts
           (for/list ([p (in-list ps)]) (fix-props p -ff-propset))
           (map fix-object os)
@@ -194,7 +197,8 @@
  [-tc-result
   (c:case->
    (Type? . c:-> . tc-result?)
-   (Type? PropSet? OptObject? . c:-> . tc-result?))]
+   (Type? PropSet? OptObject? . c:-> . tc-result?)
+   (Type? PropSet? OptObject? boolean? . c:-> . tc-result?))]
  [tc-result-t (tc-result? . c:-> . Type?)]
  [rename make-tc-results -tc-results
          (c:-> (c:listof tc-result?)

--- a/typed-racket-test/fail/extract-sp-apply-not-self.rkt
+++ b/typed-racket-test/fail/extract-sp-apply-not-self.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred "Type Checker: type mismatch")
+(exn-pred "Type Checker: type mismatch.*expected: X.*given: posn")
 #lang typed/racket
 
 (: prop-ins-to-num (Struct-Property (-> Self Number)))

--- a/typed-racket-test/fail/extract-sp-apply-not-self.rkt
+++ b/typed-racket-test/fail/extract-sp-apply-not-self.rkt
@@ -5,7 +5,7 @@
 (: prop-ins-to-num (Struct-Property (-> Self Number)))
 (: prop-ins-to-num? : Any -> Boolean : (Has-Struct-Property prop-ins-to-num))
 
-(: prop-ins-to-num-ref (Some (X) (-> (Has-Struct-Property prop-ins-to-num) (-> X Number) : X) ))
+(: prop-ins-to-num-ref (-> (Has-Struct-Property prop-ins-to-num) (Some (X) (-> X Number) : #:+ X)))
 (define-values (prop-ins-to-num prop-ins-to-num? prop-ins-to-num-ref) (make-struct-type-property 'prop-ins-to-num))
 
 ;; (: bar? : Any -> Boolean : (Has-Struct-Property prop-ins-to-num))

--- a/typed-racket-test/succeed/extract-sp-apply-self.rkt
+++ b/typed-racket-test/succeed/extract-sp-apply-self.rkt
@@ -3,7 +3,7 @@
 (: prop-ins-to-num (Struct-Property (-> Self Number)))
 (: prop-ins-to-num? : Any -> Boolean : (Has-Struct-Property prop-ins-to-num))
 
-(: prop-ins-to-num-ref (Some (X) (-> (Has-Struct-Property prop-ins-to-num) (-> X Number) : X) ))
+(: prop-ins-to-num-ref (-> (Has-Struct-Property prop-ins-to-num) (Some (X) (-> X Number) : #:+ X)))
 (define-values (prop-ins-to-num prop-ins-to-num? prop-ins-to-num-ref) (make-struct-type-property 'prop-ins-to-num))
 
 ;; (: bar? : Any -> Boolean : (Has-Struct-Property prop-ins-to-num))

--- a/typed-racket-test/succeed/structs-has-subtype.rkt
+++ b/typed-racket-test/succeed/structs-has-subtype.rkt
@@ -3,7 +3,7 @@
 (: prop-ins-to-num (Struct-Property (-> Self Number)))
 (: prop-ins-to-num? : Any -> Boolean : (Has-Struct-Property prop-ins-to-num))
 
-(: prop-ins-to-num-ref (Some (X) (-> (Has-Struct-Property prop-ins-to-num) (-> X Number) : X) ))
+(: prop-ins-to-num-ref (-> (Has-Struct-Property prop-ins-to-num) (Some (X) (-> X Number) : #:+ X)))
 (define-values (prop-ins-to-num prop-ins-to-num? prop-ins-to-num-ref) (make-struct-type-property 'prop-ins-to-num))
 
 

--- a/typed-racket-test/succeed/test-spt-typed-untyped.rkt
+++ b/typed-racket-test/succeed/test-spt-typed-untyped.rkt
@@ -4,7 +4,7 @@
   (provide prop:foo foo?)
   (: prop:foo (Struct-Property (-> Self Number)))
   (: foo? (-> Any Boolean : (Has-Struct-Property prop:foo)))
-  (: foo-ref (Some (X) (-> (Has-Struct-Property prop:foo) (-> X Number) : X)))
+  (: foo-ref (-> (Has-Struct-Property prop:foo) (Some (X) (-> X Number) : #:+ X)))
   (define-values (prop:foo foo? foo-ref) (make-struct-type-property 'foo))
 
   (provide bar bar1 foo-ref)

--- a/typed-racket-test/succeed/user-defined-sp.rkt
+++ b/typed-racket-test/succeed/user-defined-sp.rkt
@@ -2,7 +2,7 @@
 
 (: prop:foo (Struct-Property (-> Self Number)))
 (: _1 (-> Any Boolean : (Has-Struct-Property prop:foo)))
-(: _2 (Some (A) (-> (Has-Struct-Property prop:foo) (-> A Number) : A)))
+(: _2 (-> (Has-Struct-Property prop:foo) (Some (A) (-> A Number) : #:+ A)))
 (define-values (prop:foo _1 _2) (make-struct-type-property 'foo))
 
 (struct use-foo () #:property prop:foo (λ ([this : use-foo]) 10))

--- a/typed-racket-test/unit-tests/contract-tests.rkt
+++ b/typed-racket-test/unit-tests/contract-tests.rkt
@@ -175,6 +175,10 @@
    (t (-mu x (-Syntax x)))
    (t (-> (-> Univ -Bottom : -ff-propset) -Bottom : -ff-propset))
    (t (-poly (A B) (-> A B (Un A B))))
+   (t (-> Univ (-some-res (X) (-> X -Boolean) : #:+ X)))
+   (t (-some (X) (-> Univ (-> X -Boolean) : (-PS (-is-type 0 X)
+                                                 -tt))))
+   (t (->opt [-Number] (-> (make-Values (list)))))
 
 
    (t/fail ((-poly (a) (-vec a)) . -> . -Symbol)

--- a/typed-racket-test/unit-tests/interactive-tests.rkt
+++ b/typed-racket-test/unit-tests/interactive-tests.rkt
@@ -105,7 +105,7 @@
                (begin
                  (: prop (Struct-Property (-> Self Number)))
                  (: pred (-> Any Boolean : (Has-Struct-Property prop)))
-                 (: acc (Some (X) (-> (Has-Struct-Property prop) (-> X Number) : X)))
+                 (: acc (-> (Has-Struct-Property prop) (Some (X) (-> X Number) : #:+ X)))
                  (define-values (prop pred acc) (make-struct-type-property 'prop))))
 
     ;; Make sure that optimized expressions work

--- a/typed-racket-test/unit-tests/parse-type-tests.rkt
+++ b/typed-racket-test/unit-tests/parse-type-tests.rkt
@@ -355,6 +355,7 @@
    [FAIL (-> Self Number)]
 
    [(Some (X) (-> Number (-> X Number) : X)) (-some (X) (t:-> -Number (t:-> X -Number) : (-PS (-is-type 0 X) (-not-type 0 X))))]
+   [(-> Number (Some (X) (-> X Number) : #:+ X)) (t:-> -Number (-some-res (X) (t:-> X -Number) : #:+ X))]
 
    ;;; Classes
    [(Class) (-class)]

--- a/typed-racket-test/unit-tests/subtype-tests.rkt
+++ b/typed-racket-test/unit-tests/subtype-tests.rkt
@@ -289,6 +289,8 @@
    [t1a (unfold t1a)]
    [(unfold t1a) t1a]
    [(-> -Number (-> -Self -Number)) (-some (x) (-> -Number (-> x -Number)))]
+   [(-> Univ (-some-res (x) (-> x -Number) : #:+ x)) (-> Univ (-some-res (x) (-> x Univ) : #:+ x))]
+   [FAIL (-> Univ (-some-res (x) (-> x -Number) : #:+ x)) (-> Univ (-some-res (x) (-> x Univ) : #:+ -Number))]
    [FAIL (-some (x) (-> -Number (-> x -Number))) (-> -Number (-> -Self -Number))]
    ;; simple list types
    [(make-Listof -Number) (make-Listof Univ)]


### PR DESCRIPTION
In this PR, existential type results are added to better annotate method extraction.
a property accessor previously annotated `(Some (x) (-> (Has-Struct-Property prop) (-> x Number) : x)` is now annotated `(-> (Has-Struct-Property prop) (Some (-> x Number) : #:+ x))`, i.e. the existential quantification has been pushed downward.

## Notes on implementation
-  An existential type `Result` are `Result` with at least one existential quantifier. It has a constructor and destructor, and there is a function `instantiate-result` used to turn de brunji indexes to names in an existential result when the type checker is checking application of a single arrow function. 
- `subresult*` was changed to reason about subtyping between a (-> Self ....) and a (Some (x) (-> x ....) : x), and two existential type results.
- added some helper functions like `abstract/instantiate-propset` and some tests
- relevant parts of documentations were updated. 
- refactored `type-contract.rkt` and `tc-funapp.rkt`
- The changes are almost backward-compatible with old `Some` types, except one point: In the example shown above, previously `x` in proposition position (`: x`), was symmetricial, whereas it is now symmetricial (`: #: x`). Thus how structure properties definition is checked has been [adjusted](https://github.com/racket/typed-racket/pull/1117/files#diff-516cab1093154106286b0cff961a6e54c2468f64a452f70f4bb8a47b73e82df3R583). If this change broke existing packages, we could either fix those packages or make `tc/make-struct-type-property` account for both old `some` types and new existential type results.
- fixed several bugs 