### PR TITLE
Refactor rep

### DIFF
--- a/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -285,9 +285,9 @@
      `(make-Opaque (quote-syntax ,pred))]
     [(Refinement: parent pred)
      `(make-Refinement ,(type->sexp parent) (quote-syntax ,pred))]
-    [(Mu-maybe-name: n (? Type? b))
+    [(Mu-maybe-name: (list n) (? Type? b))
      `(make-Mu (quote ,n) ,(type->sexp b))]
-    [(Mu: n b)
+    [(Mu: (list n) b)
      `(make-Mu (quote ,n) ,(type->sexp b))]
     [(Poly-names: ns b)
      `(make-Poly (list ,@(for/list ([n (in-list ns)])
@@ -297,11 +297,11 @@
      `(make-PolyDots (list ,@(for/list ([n (in-list ns)])
                            `(quote ,n)))
                      ,(type->sexp b))]
-    [(PolyRow-names: ns c b)
+    [(PolyRow-names: ns b c)
      `(make-PolyRow (list ,@(for/list ([n (in-list ns)])
                               `(quote ,n)))
-                    (quote ,c)
-                    ,(type->sexp b))]
+                    ,(type->sexp b)
+                    (quote ,c))]
     [(Row: inits fields methods augments init-rest)
      `(make-Row (list ,@(convert-row-clause inits #t))
                 (list ,@(convert-row-clause fields))

--- a/typed-racket-lib/typed-racket/env/type-alias-helper.rkt
+++ b/typed-racket-lib/typed-racket/env/type-alias-helper.rkt
@@ -70,7 +70,7 @@
     [((Mu: _ body)) (check body)]
     [((Poly: names body)) (check body)]
     [((PolyDots: names body)) (check body)]
-    [((PolyRow: _ _ body)) (check body)]
+    [((PolyRow: _ body _)) (check body)]
     [(_) #t])
   (unless (check type)
     (tc-error/fields
@@ -263,4 +263,3 @@
             (#%plain-app values))
      (values #'nm #'ty (syntax-e #'args))]
     [_ (int-err "not define-type-alias")]))
-

--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -249,8 +249,8 @@
      (make-PolyRow
       (list var*)
       ;; No constraints listed, so we need to infer the constraints
-      (infer-row-constraints body-type)
-      body-type)]
+      body-type
+      (infer-row-constraints body-type))]
     [(:All^ (var:id #:row constr:row-constraints) . t:omit-parens)
      (add-disappeared-use #'kw)
      (define var* (syntax-e #'var))
@@ -259,8 +259,8 @@
        (extend-tvars (list var*)
          (make-PolyRow
           (list var*)
-          constraints
-          (parse-type #'t.type))))]
+          (parse-type #'t.type)
+          constraints)))]
     [(:All^ (_:id ...) _ _ _ ...) (parse-error "too many forms in body of All type")]
     [(:All^ . rest) (parse-error "bad syntax")]))
 
@@ -808,7 +808,7 @@
                                  [(Mu: _ body) (check body)]
                                  [(Poly: names body) (check body)]
                                  [(PolyDots: names body) (check body)]
-                                 [(PolyRow: _ _ body) (check body)]
+                                 [(PolyRow: _ body _) (check body)]
                                  [(? Type?) (void)]
                                  [(? Rep?) (Rep-for-each check ty)]
                                  [_ (void)]))
@@ -1505,7 +1505,7 @@
       [(? Fun?) #t]
       [(Poly: _ body) (function-type? body)]
       [(PolyDots: _ body) (function-type? body)]
-      [(PolyRow: _ _ body) (function-type? body)]
+      [(PolyRow: _ body _) (function-type? body)]
       [_ #f]))
   (for ([(id pre-type) (in-dict method-types)])
     (define type (car pre-type))

--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -603,7 +603,7 @@
        [(? PolyRow?)
         (t->sc/polyrow type fail typed-side recursive-values t->sc)]
 
-       [(Mu: n b)
+       [(Mu: (list n) b)
         (match-define (and n*s (list untyped-n* typed-n* both-n*)) (generate-temporaries (list n n n)))
         (define rv
           (hash-set recursive-values n
@@ -1045,13 +1045,13 @@
 
 ;; Generate a contract for a row-polymorphic function type
 (define (t->sc/polyrow type fail typed-side recursive-values t->sc)
-  (match-define (PolyRow: vs constraints body) type)
+  (match-define (PolyRow: vs body constraints) type)
   (if (not (from-untyped? typed-side))
       (let ((recursive-values (for/fold ([rv recursive-values]) ([v vs])
                                 (hash-set rv v (same any/sc)))))
         (extend-row-constraints vs (list constraints)
           (t->sc body #:recursive-values recursive-values)))
-      (match-let ([(PolyRow-names: vs-nm constraints b) type])
+      (match-let ([(PolyRow-names: vs-nm b constraints) type])
         (unless (is-a-function-type? b)
           (fail #:reason "cannot generate contract for non-function polymorphic type"))
         (let ([temporaries (generate-temporaries vs-nm)])

--- a/typed-racket-lib/typed-racket/rep/base-type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/base-type-rep.rkt
@@ -9,14 +9,9 @@
                      syntax/parse))
 
 (provide define-base-types
-         Base?
-         Base-name
-         Base-predicate
-         Base:
          Base-bits:
          Base-predicate:
-         Base-name/contract:
-         Base-bits)
+         Base-name/contract:)
 
 ;;-----------------
 ;; Base Type
@@ -37,7 +32,7 @@
                 [contract syntax?]
                 [predicate procedure?])
   #:base
-  #:no-provide
+  #:no-provide (Base-contract Base-numeric?)
   [#:mask (λ (t) (if (Base-numeric? t)
                      mask:number
                      mask:base))]

--- a/typed-racket-lib/typed-racket/rep/core-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/core-rep.rkt
@@ -212,7 +212,7 @@
                  [o OptObject?]
                  ;; the number of the existential quantifiers
                  [n-existentials number?])
-  #:no-provide
+  #:no-provide (make-Result Result:)
   [#:frees (f) (combine-frees (list (f t) (f ps) (f o)))]
   [#:fmap (f) (make-Result (f t) (f ps) (f o) n-existentials)]
   [#:for-each (f) (begin (f t) (f ps) (f o))]
@@ -275,6 +275,3 @@
                                (? (lambda (l)
                                     (and (not (null? l)) l))
                                   n))))])))
-
-
-

--- a/typed-racket-lib/typed-racket/rep/object-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/object-rep.rkt
@@ -21,15 +21,10 @@
          -path-elem-of
          -lexp-add1
          -lexp-sub1
-         LExp-const
          constant-LExp?
          -lexp
          -obj+
          -obj*
-         LExp?
-         LExp-const
-         LExp-terms
-         LExp:
          genobj
          make-id-seq
          id-seq-next
@@ -180,7 +175,7 @@
 (def-object LExp ([const exact-integer?]
                   [terms (hash/c Path? (and/c exact-integer?
                                               (not/c zero?)))])
-  #:no-provide
+  #:no-provide (make-LExp)
   [#:frees (f) (combine-frees (for/list ([x (in-terms-vars terms)]) (f x)))]
   [#:fmap (f)
    ;; applies f to each object p in the terms

--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -46,22 +46,15 @@
          -unsafe-intersect
          Mu-unsafe: Poly-unsafe:
          PolyDots-unsafe:
-         Mu? Poly? PolyDots? PolyRow?
-         Poly-n
-         PolyDots-n
-         Class? Row? Row:
          free-vars*
          Name/simple: Name/struct:
          unfold
-         Union?
-         Union-elems
          Union-fmap
          Un
          resolvable?
          Union-all:
          Union-all-flat:
          Union/set:
-         Intersection?
          -refine
          Refine:
          Refine-obj:
@@ -77,10 +70,6 @@
          set-struct-property-pred!
          DepFun/ids:
          Some-names:
-         Struct-Property?
-         Struct-name
-         Struct?
-         Struct-flds
          Struct-subflds
          Struct-update-proc!
          (rename-out [Union:* Union:]
@@ -515,7 +504,7 @@
 
 
 (def-type Mu ([body Type?])
-  #:no-provide
+  #:no-provide (Mu: make-Mu Mu-body)
   [#:frees (f) (f body)]
   [#:fmap (f) (make-Mu (f body))]
   [#:for-each (f) (f body)]
@@ -533,7 +522,7 @@
 ;; body is a type
 (def-type Poly ([n exact-nonnegative-integer?]
                 [body Type?])
-  #:no-provide
+  #:no-provide (Poly: Poly-body make-Poly)
   [#:frees (f) (f body)]
   [#:fmap (f) (make-Poly n (f body))]
   [#:for-each (f) (f body)]
@@ -543,7 +532,7 @@
 ;; there are n-1 'normal' vars and 1 ... var
 (def-type PolyDots ([n exact-nonnegative-integer?]
                     [body Type?])
-  #:no-provide
+  #:no-provide (make-PolyDots PolyDots: PolyDots-body)
   [#:frees (f) (f body)]
   [#:fmap (f) (make-PolyDots n (f body))]
   [#:for-each (f) (f body)]
@@ -554,7 +543,7 @@
 ;; as a set for each of init, field, methods
 (def-type PolyRow ([constraints (list/c list? list? list? list?)]
                    [body Type?])
-  #:no-provide
+  #:no-provide (PolyRow-body make-PolyRow PolyRow:)
   [#:frees (f) (f body)]
   [#:fmap (f) (make-PolyRow constraints (f body))]
   [#:for-each (f) (f body)]
@@ -567,8 +556,8 @@
 
 ;; body is a type
 (def-type Some ([n exact-nonnegative-integer?]
-                 [body Type?])
-  #:no-provide
+                [body Type?])
+  #:no-provide (make-Some Some:)
   [#:frees (f) (f body)]
   [#:fmap (f) (make-Some n (f body))]
   [#:for-each (f) (f body)])
@@ -753,7 +742,7 @@
    ;; when a struct type property is annotated via require/typed, the pred-id is
    ;; immediately set.
    [pred-id (box/c (or/c identifier? false/c))])
-  #:no-provide
+  #:no-provide (make-Struct-Property Struct-Property:)
   [#:frees (f) (f elem)]
   [#:fmap (f) (make-Struct-Property (f elem) pred-id)]
   [#:for-each (f) (f elem)]
@@ -803,7 +792,7 @@
                   [poly? boolean?]
                   [pred-id identifier?]
                   [properties (free-id-set/c identifier?)])
-  #:no-provide
+  #:no-provide (Struct: Struct-proc make-Struct)
   [#:frees (f) (combine-frees (map f (append (let ([bv (unbox proc)])
                                                (if bv (list bv) null))
                                              (if parent (list parent) null)
@@ -952,7 +941,7 @@
                  [base (or/c Bottom? Base? BaseUnion?)]
                  [ts (cons/c Type? (listof Type?))]
                  [elems (hash/c Type? #t #:immutable #t #:flat? #t)])
-  #:no-provide
+  #:no-provide (Union:)
   #:non-transparent
   [#:frees (f) (combine-frees (map f ts))]
   [#:fmap (f) (Union-fmap f base ts)]
@@ -1093,7 +1082,7 @@
                         [prop (and/c Prop? (not/c FalseProp?))]
                         [elems (hash/c Type? #t #:immutable #t #:flat? #t)])
   #:non-transparent
-  #:no-provide
+  #:no-provide (Intersection: make-Intersection Intersection-prop)
   [#:frees (f) (combine-frees (cons (f prop) (map f ts)))]
   [#:fmap (f) (-refine
                (for*/fold ([res Univ])
@@ -1248,7 +1237,7 @@
               [methods (listof (list/c symbol? Type?))]
               [augments (listof (list/c symbol? Type?))]
               [init-rest (or/c Type? #f)])
-  #:no-provide
+  #:no-provide (make-Row)
   [#:frees (f)
    (let ([extract-frees (λ (l) (f (second l)))])
      (combine-frees
@@ -1285,7 +1274,7 @@
 ;;
 (def-type Class ([row-ext (or/c #f F? B? Row?)]
                  [row Row?])
-  #:no-provide
+  #:no-provide (Class: make-Class)
   [#:frees (f)
    (combine-frees
     (append (if row-ext (list (f row-ext)) null)

--- a/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -620,7 +620,7 @@
                                local-private-table private-method-types
                                self-type))
   (do-timestamp "built local tables")
-  
+
   (with-extended-lexical-env
     [#:identifiers lexical-names/top-level
      #:types lexical-types/top-level]
@@ -1632,8 +1632,8 @@
      (make-Poly ns (function->method body self-type))]
     [(PolyDots-names: ns body)
      (make-PolyDots ns (function->method body self-type))]
-    [(PolyRow-names: ns constraints body)
-     (make-PolyRow ns constraints (function->method body self-type))]
+    [(PolyRow-names: ns body constraints)
+     (make-PolyRow ns (function->method body self-type) constraints)]
     [_ (int-err "function->method: ~a" type)]))
 
 ;; method->function : Function -> Function
@@ -1651,8 +1651,8 @@
      (make-Poly ns (method->function body))]
     [(PolyDots-names: ns body)
      (make-PolyDots ns (method->function type))]
-    [(PolyRow-names: ns constraints body)
-     (make-PolyRow ns constraints (method->function type))]
+    [(PolyRow-names: ns body constraints)
+     (make-PolyRow ns (method->function type) constraints)]
     [_ (tc-error/expr #:return -Bottom "expected a function type for method")]))
 
 ;; process-method-syntax : Syntax Type (Option Type) -> Syntax

--- a/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
@@ -39,7 +39,7 @@
     [((Arrow: dom rst (list (Keyword: _ _ #f) ...) rng)
       (list (tc-result1: t-a _ o-a) ...))
      #:when (not (RestDots? rst))
-     
+
      (when check?
        (define extra-arg-count (- (length t-a) (length dom)))
        (cond [(and (not rst) (not (eqv? 0 extra-arg-count)))
@@ -319,12 +319,12 @@
                               msg-rngs)
                       ...)))
          (PolyRow-names:
-          msg-vars _
-          (Fun: (list (Arrow: msg-doms
+          msg-vars (Fun: (list (Arrow: msg-doms
                               msg-rests
                               (list (Keyword: _ _ #f) ...)
                               msg-rngs)
-                      ...))))
+                      ...))
+          _))
      (let ([fcn-string (name->function-str name)])
        (if (and (andmap null? msg-doms)
                 (null? argtypes))
@@ -374,8 +374,8 @@
           (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs) ...)))
          (PolyRow-names:
           msg-vars
-          _
-          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs) ...))))
+          (Fun: (list (Arrow: msg-doms msg-rests kws msg-rngs) ...))
+          _))
      (let ([fcn-string (if name
                            (format "function with keywords ~a" (syntax->datum name))
                            "function with keywords")])
@@ -402,4 +402,3 @@
   (if name
       (format "function `~a'" (syntax->datum name))
       "function"))
-

--- a/typed-racket-lib/typed-racket/typecheck/tc-expression.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-expression.rkt
@@ -130,7 +130,7 @@
      (tc-error/expr #:return -Bottom "Cannot instantiate non-row-polymorphic type ~a"
                     (cleanup-type ty))]
     [else
-     (match-define (PolyRow: _ constraints _) ty)
+     (match-define (PolyRow: _ _ constraints) ty)
      (check-row-constraints
       row constraints
       (λ (name)
@@ -138,4 +138,3 @@
          (~a "Cannot instantiate row with member " name
              " that the given row variable requires to be absent"))))
      (instantiate-poly ty (list row))]))
-

--- a/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
@@ -258,7 +258,7 @@
       ;; Row polymorphism. For now we do really dumb inference that only works
       ;; in very restricted cases, but is probably enough for most cases in
       ;; the Racket codebase. Eventually this should be extended.
-      [(PolyRow: vars constraints (and f-ty (Fun: arrows)))
+      [(PolyRow: vars (and f-ty (Fun: arrows)) constraints)
        ;; check there are no RestDots
        #:when (not (for/or ([a (in-list arrows)])
                      (RestDots? (Arrow-rst a))))

--- a/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
@@ -61,7 +61,7 @@
 ;; might carry out-of-scope type variables. In this case, we need to remove it
 ;; from parameter syntax objects.
 ;;
-;; not-in-poly is #t if the original TR function is polymorphic. 
+;; not-in-poly is #t if the original TR function is polymorphic.
 (define (make-formals stx [not-in-poly #t])
   (define (maybe-remove a)
     (if (and not-in-poly (from-plambda-property a))
@@ -307,7 +307,7 @@
        #:when (andmap free-identifier=? arg-list (syntax->list #'(j ...)))
        #'fun]
       [_ #f]))
-  
+
   (cond
     [(and (> (free-id-table-count aux-table) 0) (not rest-id))
      (tc/opt-lambda-clause arg-list body aux-table)]
@@ -332,11 +332,11 @@
                     [(? RestDots? rst) rst])]
          ;; Lambda with no rest argument
          [else #f]))
-     (cond 
+     (cond
       ;; special case for un-annotated eta-expansions
       [(and eta-expanded? (not rest-id) (andmap not arg-types)
             ;; FIXME: should also handle polymorphic types
-            ;; but we can't return anything but a (listof arr?) here 
+            ;; but we can't return anything but a (listof arr?) here
             ;; FIXME: misses optimization opportunities in this code
             (match (tc-expr eta-expanded?)
               [(tc-result1: (Fun: arrows))
@@ -596,7 +596,7 @@
      ;; we get (case-> (-> Num Num * Num)
      ;;                (-> Num * Zero))
      ;; which is unsound (i.e. we can upcast an intersection to either
-     ;; type, namely in this case to (-> Num * Zero), and then call 
+     ;; type, namely in this case to (-> Num * Zero), and then call
      ;; it as the identity function on any number, which does not
      ;; always produce the constant 0). In other words, our `case->`
      ;; is really an UNORDERED intersection that we just don't work
@@ -745,7 +745,7 @@
          [else
           (tc-error "Expected a polymorphic function with ..., but function/annotation had no ...")]))
      (make-PolyDots (append ns (list dvar)) (extend-and-loop form ns formals bodies (ret expected*)))]
-    [(tc-result1: (app resolve (and t (PolyRow-fresh: ns fresh-ns constraints expected*))))
+    [(tc-result1: (app resolve (and t (PolyRow-fresh: ns fresh-ns expected* constraints))))
      (for ((tvars (in-list tvarss)))
        (when (and (pair? tvars) (list? (car tvars)))
          (tc-error
@@ -756,9 +756,9 @@
      (make-PolyRow
       #:original-names ns
       fresh-ns
-      constraints
       (extend-and-loop form fresh-ns
-                       formals bodies (ret expected*)))]
+                       formals bodies (ret expected*))
+      constraints)]
     [_
      (define lengths
        (remove-duplicates

--- a/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -349,7 +349,7 @@
   (syntax-rules ()
     [(_ (var) consts ty)
      (let ([var (-v var)])
-       (make-PolyRow (list 'var) consts ty))]))
+       (make-PolyRow (list 'var) ty consts))]))
 
 ;; abbreviation for existential types
 (define-syntax -some

--- a/typed-racket-lib/typed-racket/types/path-type.rkt
+++ b/typed-racket-lib/typed-racket/types/path-type.rkt
@@ -86,7 +86,7 @@
       ;; shielded with a check for type indexes/variables/whatever.
       [((Poly: _ body-t) _) (path-type path body-t resolved)]
       [((PolyDots: _ body-t) _) (path-type path body-t resolved)]
-      [((PolyRow: _ _ body-t) _) (path-type path body-t resolved)]
+      [((PolyRow: _ body-t _) _) (path-type path body-t resolved)]
       [((Distinction: _ _ t) _) (path-type path t resolved)]
 
       ;; for private fields in classes

--- a/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/typed-racket-lib/typed-racket/types/printer.rkt
@@ -736,7 +736,7 @@
     [(PolyDots-names: (list names ... dotted) body)
      `(All ,(append names (list dotted '...)) ,(t->s body))]
     ;; FIXME: should this print constraints too
-    [(PolyRow-names: names _ body)
+    [(PolyRow-names: names body _)
      `(All (,(car names) #:row) ,(t->s body))]
     [(Some-names: n body)
      `(Some ,n ,(t->s body))]
@@ -761,7 +761,7 @@
                       #t]
                      [_ #f])))
      'Syntax]
-    [(Mu-maybe-name: name (? Type? body))
+    [(Mu-maybe-name: (list name) (? Type? body))
      `(Rec ,name ,(t->s body))]
     [(Mu-unsafe: raw-body)
      (with-printable-names 1 name-ids

--- a/typed-racket-lib/typed-racket/types/utils.rkt
+++ b/typed-racket-lib/typed-racket/types/utils.rkt
@@ -62,7 +62,7 @@
             [body* (subst-all (make-simple-substitution fixed fixed-tys)
                               body)])
        (substitute-dots rest-tys #f dotted body*))]
-    [(PolyRow: names _ body)
+    [(PolyRow: names body _)
      (unless (= (length types) (length names))
        (int-err "instantiate-poly: wrong number of types: expected ~a, got ~a"
                 (length names) (length types)))

--- a/typed-racket-test/unit-tests/parse-type-tests.rkt
+++ b/typed-racket-test/unit-tests/parse-type-tests.rkt
@@ -400,8 +400,8 @@
    ;; test #:row-var
    [(All (r #:row) (Class #:row-var r))
     (make-PolyRow (list 'r)
-                  (list null null null null)
-                  (-class #:row (make-F 'r)))]
+                  (-class #:row (make-F 'r))
+                  (list null null null null))]
    [FAIL (All (r #:row) (Class #:implements (Class #:row-var r)))]
    [FAIL (All (r #:row) (Class #:implements (Class) #:row-var r))]
    [FAIL (Class #:row-var 5)]
@@ -466,7 +466,7 @@
            ((Class #:row-var r (init y)) -> (Class #:row-var r)))]
    [FAIL (All (r #:row (init x y z) (field f) m n)
            ((Class #:row-var r a b c) -> (Class #:row-var r)))]
-   
+
    ;; parsing tests for Unit types
    ;; These are only simple tests because checking types
    ;; with signatures requires interaction with the Signature

--- a/typed-racket-test/unit-tests/type-printer-tests.rkt
+++ b/typed-racket-test/unit-tests/type-printer-tests.rkt
@@ -308,12 +308,12 @@
     (check-pretty-prints-as? (-lst -Nat) "(Listof Nonnegative-Integer)")
     (check-pretty-prints-as?
      (-polydots (c a b)
-       (cl->*
-        (-> (-> a c) (-pair a (-lst a)) (-pair c (-lst c)))
-        ((list
-          ((list a) (b b) . ->... . c)
-          (-lst a))
-         ((-lst b) b) . ->... .(-lst c))))
+                (cl->*
+                 (-> (-> a c) (-pair a (-lst a)) (-pair c (-lst c)))
+                 ((list
+                   ((list a) (b b) . ->... . c)
+                   (-lst a))
+                  ((-lst b) b) . ->... .(-lst c))))
      (string-append "(All (c a b ...)\n"
                     "  (case->\n"
                     "   (-> (-> a c) (Pairof a (Listof a)) (Pairof c (Listof c)))\n"

--- a/typed-racket-test/unit-tests/type-printer-tests.rkt
+++ b/typed-racket-test/unit-tests/type-printer-tests.rkt
@@ -317,10 +317,9 @@
      (string-append "(All (c a b ...)\n"
                     "  (case->\n"
                     "   (-> (-> a c) (Pairof a (Listof a)) (Pairof c (Listof c)))\n"
-                    "   (-> (-> a b ... b c) (Listof a) (Listof b) ... b (Listof c))))"))
+                     "   (-> (-> a b ... b c) (Listof a) (Listof b) ... b (Listof c))))"))
     (check-pretty-prints-as?
      (-poly (a) (cl->* (-> (-Syntax a) Univ Univ (-Syntax a))
-                       (-> (-Syntax Univ) Univ Univ)))
+                        (-> (-Syntax Univ) Univ Univ)))
      (string-append "(All (a)\n"
                     "  (case-> (-> (Syntaxof a) Any Any (Syntaxof a)) (-> (Syntaxof Any) Any Any)))")))))
-


### PR DESCRIPTION
1. `#:no-provide` supports parameters
2. add `#:type-binder` to greatly reduce the boilerplate code to write `Poly`, `Some` and all the other binders. 