### PR TITLE
Out-of-scope pattern variable in syntax class var-name

### DIFF
--- a/typed-racket-lib/typed-racket/rep/rep-utils.rkt
+++ b/typed-racket-lib/typed-racket/rep/rep-utils.rkt
@@ -302,7 +302,7 @@
              #:with predicate
              (format-id #'name "~a?" (syntax-e #'name))
              #:with updator
-             (format-id #'var.name "~a-update" (syntax-e #'name))))
+             (format-id #'name "~a-update" (syntax-e #'name))))
   ;; structure accessor parsing
   (define-syntax-class (fld-id struct-name)
     #:attributes (name accessors)


### PR DESCRIPTION
The pattern variable "var" is out of scope inside the definition of the syntax class "var-name"