### PR TITLE
Update make-readtable type

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -2352,9 +2352,9 @@
       (make-Rest
        (list (-opt -Char)
              (Un (one-of/c 'terminating-macro 'non-terminating-macro 'dispatch-macro) -Char)
-             (-opt (Un (one-of/c (-> -Char -Input-Port (-opt -PosInt) (-opt -Nat)
-                                     (-opt -PosInt) (-opt -Nat) Univ)
-                                 -Read-Table)))))
+             (Un (-> -Char -Input-Port (-opt -PosInt) (-opt -Nat)
+                     (-opt -PosInt) (-opt -Nat) Univ)
+                 (-opt -Read-Table))))
       -Read-Table)]
 
 [readtable-mapping (-> -Read-Table -Char

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -2348,18 +2348,14 @@
 ;; Section 13.7.1
 [readtable? (make-pred-ty -Read-Table)]
 [make-readtable
- (cl->*
-  (-> (-opt -Read-Table) -Read-Table)
-  (-> (-opt -Read-Table)
-      (-opt -Char) (Un (one-of/c 'terminating-macro 'non-terminating-macro 'dispatch-macro) -Char)
-      (-> -Char -Input-Port (-opt -PosInt) (-opt -Nat) (-opt -PosInt) (-opt -Nat) Univ)
-      -Read-Table)
-  (-> (-opt -Read-Table)
-      (-opt -Char) (Un (one-of/c 'terminating-macro 'non-terminating-macro 'dispatch-macro) -Char)
-      (-> -Char -Input-Port (-opt -PosInt) (-opt -Nat) (-opt -PosInt) (-opt -Nat) Univ)
-      (-opt -Char) (Un (one-of/c 'terminating-macro 'non-terminating-macro 'dispatch-macro) -Char)
-      (-> -Char -Input-Port (-opt -PosInt) (-opt -Nat) (-opt -PosInt) (-opt -Nat) Univ)
-      -Read-Table))]
+ (->* (list (-opt -Read-Table))
+      (make-Rest
+       (list (-opt -Char)
+             (Un (one-of/c 'terminating-macro 'non-terminating-macro 'dispatch-macro) -Char)
+             (-opt (Un (one-of/c (-> -Char -Input-Port (-opt -PosInt) (-opt -Nat)
+                                     (-opt -PosInt) (-opt -Nat) Univ)
+                                 -Read-Table)))))
+      -Read-Table)]
 
 [readtable-mapping (-> -Read-Table -Char
                        (-values (list

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -2349,12 +2349,12 @@
 [readtable? (make-pred-ty -Read-Table)]
 [make-readtable
  (cl->*
-  (-> -Read-Table -Read-Table)
-  (-> -Read-Table
+  (-> (-opt -Read-Table) -Read-Table)
+  (-> (-opt -Read-Table)
       (-opt -Char) (Un (one-of/c 'terminating-macro 'non-terminating-macro 'dispatch-macro) -Char)
       (-> -Char -Input-Port (-opt -PosInt) (-opt -Nat) (-opt -PosInt) (-opt -Nat) Univ)
       -Read-Table)
-  (-> -Read-Table
+  (-> (-opt -Read-Table)
       (-opt -Char) (Un (one-of/c 'terminating-macro 'non-terminating-macro 'dispatch-macro) -Char)
       (-> -Char -Input-Port (-opt -PosInt) (-opt -Nat) (-opt -PosInt) (-opt -Nat) Univ)
       (-opt -Char) (Un (one-of/c 'terminating-macro 'non-terminating-macro 'dispatch-macro) -Char)

--- a/typed-racket-test/succeed/make-readtable.rkt
+++ b/typed-racket-test/succeed/make-readtable.rkt
@@ -1,5 +1,7 @@
 #lang typed/racket
 
+(define-namespace-anchor anchor)
+
 (parameterize ([current-readtable
                 (make-readtable
                  (current-readtable)
@@ -10,4 +12,5 @@
   (eval
    (with-input-from-string
      "`(+ ~@(list 1 2 3) #\"xyz\" #✓ #✕)"
-     read)))
+     read)
+   (namespace-anchor->namespace anchor)))

--- a/typed-racket-test/succeed/make-readtable.rkt
+++ b/typed-racket-test/succeed/make-readtable.rkt
@@ -1,0 +1,13 @@
+#lang typed/racket
+
+(parameterize ([current-readtable
+                (make-readtable
+                 (current-readtable)
+                 #\, #\space #f
+                 #\~ #\, (current-readtable)
+                 #\✓ 'dispatch-macro (const #t)
+                 #\✕ 'dispatch-macro (const #f))])
+  (eval
+   (with-input-from-string
+     "`(+ ~@(list 1 2 3) #\"xyz\" #✓ #✕)"
+     read)))


### PR DESCRIPTION
This PR fixes the type of `make-readtable`, to match more closely the contract in untyped Racket.

[Untyped `make-readtable`](https://docs.racket-lang.org/reference/readtables.html#%28def._%28%28quote._~23~25kernel%29._make-readtable%29%29) can take `#false` as its readtable parameter, which is currently not permitted by the typed version.

This causes issues when trying to use `make-readtable` with `(current-readtable)`, which has a type of `(U False Read-Table)` and is thus rejected by the type checker.

Even the contract currently in this PR is incorrect, since it doesn't reflect the variadic nature of `make-readtable`.