### PR TITLE
add flag to disable static contract optimization

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/optimization.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/optimization.scrbl
@@ -27,3 +27,13 @@ is insufficiently powerful to access @racketmodname[racket/unsafe/ops],
 for example when executing in a sandbox (see @secref["Sandboxed_Evaluation"
 #:doc '(lib "scribblings/reference/reference.scrbl")]). This prevents untrusted
 code from accessing these operations by exploiting errors in the type system.
+
+
+@section{Contract Optimization}
+
+Typed Racket generates contracts for its exports to protect them against
+untyped code.
+By default, these contracts do not check that typed code obeys the types.
+If you want to generate contracts that check both sides equally (for analysis,
+for teaching, etc.) then set the environment variable
+@envvar{PLT_TR_NO_CONTRACT_OPTIMIZE} to any value and recompile.

--- a/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
+++ b/typed-racket-lib/typed-racket/static-contracts/instantiate.rkt
@@ -40,6 +40,8 @@
            compute-recursive-kinds
            instantiate/inner))
 
+(define no-optimize-sc? (and (getenv "PLT_TR_NO_CONTRACT_OPTIMIZE") #t))
+
 (define (instantiate/optimize sc fail [kind 'impersonator] #:cache [cache #f] #:trusted-positive [trusted-positive #f] #:trusted-negative [trusted-negative #f])
   (define recursive-kinds
     (with-handlers [(exn:fail:constraint-failure?
@@ -53,7 +55,7 @@
                       #f))]
       (compute-recursive-kinds
         (contract-restrict-recursive-values (compute-constraints sc kind)))))
-  (define sc/opt (optimize sc #:trusted-positive trusted-positive #:trusted-negative trusted-negative #:recursive-kinds recursive-kinds))
+  (define sc/opt (if no-optimize-sc? sc (optimize sc #:trusted-positive trusted-positive #:trusted-negative trusted-negative #:recursive-kinds recursive-kinds)))
   (instantiate sc/opt fail kind #:cache cache #:recursive-kinds recursive-kinds))
 
 ;; kind is the greatest kind of contract that is supported, if a greater kind would be produced the


### PR DESCRIPTION
Add a switch to turn off contract optimization.

(SCV-CR needs to disable the optimizations to do its analysis, and people like Shriram might want to show the full contracts for teaching)

This switch _could_ piggyback on the `PLT_TR_NO_OPTIMIZE` / `#:no-optimize` flag, but then code that needs to disable those expression-level optimizations for safety is going to be slower than it needs to be at boundaries. So, it seems better to make a new switch.
