### PR TITLE
Document: Complement the syntax introduction of some operators.

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/legacy.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/legacy.scrbl
@@ -17,31 +17,33 @@
 The following forms are provided by Typed Racket for backwards
 compatibility.
 
-@defform/subs[(lambda: formals . body)
-              ([formals ([v : t] ...)
+@defform/subs[(lambda: formals maybe-ret . body)
+              ([maybe-ret (code:line)
+                          (code:line : type)]
+               [formals ([v : t] ...)
                         ([v : t] ... v : t *)
                         ([v : t] ... v : t ooo bound)])]{
 A function of the formal arguments @racket[v], where each formal
 argument has the associated type.  If a rest argument is present, then
 it has type @racket[(Listof t)].}
 
-@defform[(λ: formals . body)]{
+@defform[(λ: formals maybe-ret . body)]{
 An alias for the same form using @racket[lambda:].}
 
-@defform*[[(plambda: (a ...) formals . body)
-           (plambda: (a ... b ooo) formals . body)]]{
+@defform*[[(plambda: (a ...) formals maybe-ret . body)
+           (plambda: (a ... b ooo) formals maybe-ret . body)]]{
 A polymorphic function, abstracted over the type variables
 @racket[a]. The type variables @racket[a] are bound in both the types
 of the formal, and in any type expressions in the @racket[body].}
 
-@defform/subs[(opt-lambda: formals . body)
+@defform/subs[(opt-lambda: formals maybe-ret . body)
 ([formals ([v : t] ... [v : t default] ...)
           ([v : t] ... [v : t default] ... v : t *)
           ([v : t] ... [v : t default] ... v : t ooo bound)])]{
 A function with optional arguments.}
 
-@defform*[[(popt-lambda: (a ...) formals . body)
-           (popt-lambda: (a ... a ooo) formals . body)]]{
+@defform*[[(popt-lambda: (a ...) formals maybe-ret . body)
+           (popt-lambda: (a ... a ooo) formals maybe-ret . body)]]{
 A polymorphic function with optional arguments.}
 
 @defalias[case-lambda: case-lambda]
@@ -80,7 +82,7 @@ result of @racket[_loop] (and thus the result of the entire
               [(even? (car lst)) (loop (cons (car lst) accum) (cdr lst))]
               [else              (loop accum (cdr lst))])))
     (filter-even-loop (list 1 2 3 4))]}
-@defform[(plet: (a ...) ([v : t e] ...) . body)]{
+@defform[(plet: (a ...) ([v : t e] ...) t0 . body)]{
 A polymorphic version of @racket[let:], abstracted over the type variables
 @racket[a]. The type variables @racket[a] are bound in both the types
 of the formal, and in any type expressions in the @racket[body].

--- a/typed-racket-doc/typed-racket/scribblings/reference/legacy.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/legacy.scrbl
@@ -82,7 +82,7 @@ result of @racket[_loop] (and thus the result of the entire
               [(even? (car lst)) (loop (cons (car lst) accum) (cdr lst))]
               [else              (loop accum (cdr lst))])))
     (filter-even-loop (list 1 2 3 4))]}
-@defform[(plet: (a ...) ([v : t e] ...) t0 . body)]{
+@defform[(plet: (a ...) ([v : t e] ...) : t0 . body)]{
 A polymorphic version of @racket[let:], abstracted over the type variables
 @racket[a]. The type variables @racket[a] are bound in both the types
 of the formal, and in any type expressions in the @racket[body].

--- a/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -393,7 +393,7 @@ the typed racket language.
          stx
        (begin (define-syntax name (define-for-variant #'untyped-name)) ...))]))
 
-;; for/and:, for/or:, for/first: and for/last:'s expansions
+;; for/first: and for/and:'s expansions
 ;; can't currently be handled by the typechecker.
 (define-for-variants
   (for/list: for/list)

--- a/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -393,8 +393,8 @@ the typed racket language.
          stx
        (begin (define-syntax name (define-for-variant #'untyped-name)) ...))]))
 
-;; for/vector:, for/flvector:, for/and:, for/first: and
-;; for/last:'s expansions can't currently be handled by the typechecker.
+;; for/and:, for/or:, for/first: and for/last:'s expansions
+;; can't currently be handled by the typechecker.
 (define-for-variants
   (for/list: for/list)
   (for/and: for/and)


### PR DESCRIPTION
When I was testing the indentation of racket-mode (see https://github.com/greghendershott/racket-mode/issues/569), I accidentally discovered that some grammatical forms of `for` and `let` were not introduced in Document. So I sorted out the document and added these forms.

I'd like to know if these forms are legal, or are they unintentionally defined as such and are not recommended for programmers to use? If it’s the latter, feel free to close this PR.
