### PR TITLE
Document: Fix the definition of `defmodule/incl`.

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -52,10 +52,10 @@ The following libraries are included with Typed Racket in the
 @racketfont{typed} collection:
 
 @(define-syntax-rule @defmodule/incl[name rest ...]
-   (list
-      (section #:style '(hidden toc-hidden unnumbered)
-               (string-append "Typed for " (symbol->string 'name)))
-      @defmodule[name rest ...]))
+   (begin
+     (section #:style '(hidden toc-hidden unnumbered)
+              (string-append "Typed for " (symbol->string 'name)))
+     @defmodule[name rest ...]))
 
 @(define-syntax-rule (deftype name . parts)
    (defidform #:kind "type" name . parts))


### PR DESCRIPTION
In the old definition, if we search for `JSExpr` in the `search manuals`, we will get: 
`JSExpr  provided from typed/racket/base, typed/racket`

instead of
`JSExpr  provided from typed/json`