### PR TITLE
Add types for some raise functions.

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-indexing-abs.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-indexing-abs.rkt
@@ -4,7 +4,8 @@
  (for-template racket/base racket/list racket/unsafe/ops racket/flonum racket/extflonum racket/fixnum)
  "../utils/tc-utils.rkt"
  (rename-in "../types/abbrev.rkt"  [-Boolean B] [-Symbol Sym])
- (rename-in "../types/numeric-tower.rkt" [-Number N]))
+ (rename-in "../types/numeric-tower.rkt" [-Number N])
+ (only-in "base-structs.rkt" -Arity-At-Least))
 
 (provide indexing)
 
@@ -239,7 +240,7 @@
    [flvector (->* (list) -Flonum -FlVector)]
    [make-flvector (cl->* (-> index-type -FlVector)
                          (-> index-type -Flonum -FlVector))]
-   
+
    [shared-flvector (->* (list) -Flonum -FlVector)]
    [make-shared-flvector (cl->* (-> index-type -FlVector)
                                 (-> index-type -Flonum -FlVector))]
@@ -254,13 +255,13 @@
    [unsafe-flvector-length (-> -FlVector -Index)]
    [unsafe-flvector-ref (-> -FlVector index-type -Flonum)]
    [unsafe-flvector-set! (-> -FlVector index-type -Flonum -Void)]
-   
+
    ;; Section 4.2.5.2 (ExtFlonum Vectors)
    [extflvector? (make-pred-ty -ExtFlVector)]
    [extflvector (->* (list) -ExtFlonum -ExtFlVector)]
    [make-extflvector (cl->* (-> index-type -ExtFlVector)
                             (-> index-type -ExtFlonum -ExtFlVector))]
-   
+
    [shared-extflvector (->* (list) -ExtFlonum -ExtFlVector)]
    [make-shared-extflvector (cl->* (-> index-type -ExtFlVector)
                                    (-> index-type -ExtFlonum -ExtFlVector))]
@@ -275,13 +276,13 @@
    [unsafe-extflvector-length (-> -ExtFlVector -Index)]
    [unsafe-extflvector-ref (-> -ExtFlVector index-type -ExtFlonum)]
    [unsafe-extflvector-set! (-> -ExtFlVector index-type -ExtFlonum -Void)]
-   
+
    ;; Section 4.2.4.2 (Fixnum vectors)
    [fxvector? (make-pred-ty -FxVector)]
    [fxvector (->* (list) -Fixnum -FxVector)]
    [make-fxvector (cl->* (-> index-type -FxVector)
                          (-> index-type -Fixnum -FxVector))]
-   
+
    [shared-fxvector (->* (list) -Fixnum -FxVector)]
    [make-shared-fxvector (cl->* (-> index-type -FxVector)
                                 (-> index-type -Fixnum -FxVector))]
@@ -344,7 +345,12 @@
    [raise-arguments-error
     (->* (list Sym -String) Univ (Un))]
    [raise-range-error
-    (-> Sym -String -String index-type Univ index-type index-type (Un index-type (-val #f)) (Un))]
+    (-> Sym -String -String index-type Univ index-type index-type (-opt index-type) (Un))]
+   [raise-arity-error
+    (->* (list (Un Sym top-func) (Un index-type -Arity-At-Least (-lst (Un index-type -Arity-At-Least)))) Univ (Un))]
+   [raise-arity-mask-error
+    (->* (list (Un Sym top-func) index-type) Univ (Un))]
+   [raise-result-arity-error
+    (->* (list (-opt Sym) index-type (-opt -String)) Univ (Un))]
 
    ))
-

--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1343,10 +1343,9 @@
         (->* (list -String) Univ (Un))
         (->* (list Sym -String) Univ (Un)))]
 
-;raise-type-error (in index)
 [raise-mismatch-error (-> Sym -String Univ (Un))]
-;raise-arity-error
 [raise-syntax-error (->optkey (-opt Sym) -String [Univ Univ (-lst (-Syntax Univ)) -String] #:exn (-> (-lst (-Syntax Univ)) -String -Cont-Mark-Set -Exn) #f (Un))]
+;raise-argument-error, raise-type-error, etc. (in index)
 
 [unquoted-printing-string? (make-pred-ty -Unquoted-Printing-String)]
 [unquoted-printing-string (-> -String -Unquoted-Printing-String)]


### PR DESCRIPTION
I am a little confused when I read code in `base-env-indexing-abs.rkt`.

In the definition of `indexing`, a total of four types are used to represent indexes: `-Integer`, `-Nat`, `-Index` and `index-type` (as `-Integer` in `base-env-indexing.rkt`). And many functions actually use `exact-nonnegative-integer?` to check their arguments, but TR use `index-type` (aka `Integer`) instead of `Natural` (or `Index`) to check them.

I'm not sure why these functions involving index are treated separately in `base-env-indexing-abs.rkt`, in order to be consistent with the types of other functions, I use `index-type` to define the types for these `raise` functions.

Will there be any compatibility problem if I use more precise types instead of `index-type` for all functions in `indexing`? And in addition to vector related functions, should I use `Natural` or `Index` to represent index?