### PR TITLE
Mention assert and ann in the docs of cast.

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -614,7 +614,13 @@ protect higher-order uses of the value.
 @ex[
 ((cast (lambda ([s : String]) s) (Any -> Any)) "hello")
 (eval:error ((cast (lambda ([s : String]) s) (Any -> Any)) 5))
-]}
+]
+
+@racket[cast] is mainly useful in the cases in which a thorough check is
+required, in particular when using higher-order or mutable values that cannot
+be fully verified by a flat predicate, or when a good error message from the
+contract system is worth the performance penalty.  In most other cases
+occurrence typing or @racket[assert] should be preferred.}
 
 @defform*[[(inst e t ...)
            (inst e t ... t ooo bound)]]{


### PR DESCRIPTION
`cast` protects the values by two contracts, which is often too much of a performance penalty.  In most cases, `assert`, occurrence typing, or `ann` should be used.

This PR is a follow-up of [this discussion](https://racket.discourse.group/t/managing-cast-performance-penalty/905).