### PR TITLE
Analyze pull requests with Resyntax

### DIFF
--- a/.github/workflows/resyntax.yml
+++ b/.github/workflows/resyntax.yml
@@ -1,0 +1,35 @@
+name: Resyntax
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+        # See https://github.com/actions/checkout/issues/118.
+        with:
+          fetch-depth: 0
+      - uses: Bogdanp/setup-racket@v1.8.1
+        with:
+          version: current
+          packages: resyntax
+          local_catalogs: $GITHUB_WORKSPACE
+          dest: '"${HOME}/racketdist-current-CS"'
+          sudo: never
+      - name: Register local packages
+        run: |
+          raco pkg install -i --auto --no-setup --skip-installed typed-racket-test
+          raco pkg update --auto --no-setup source-syntax typed-racket-lib typed-racket-more typed-racket-compatibility typed-racket-doc typed-racket typed-racket-test
+      - run: raco setup typed typed-racket typed-racket-test typed-scheme
+      - run: xvfb-run racket -l- resyntax/cli analyze --local-git-repository . "origin/${GITHUB_BASE_REF}" --output-as-github-review


### PR DESCRIPTION
@samth expressed interest in setting up [Resyntax](https://docs.racket-lang.org/resyntax/) on the Typed Racket repository. This pull request adds a github workflow that runs Resyntax on any changed files in a pull request. Resyntax will suggest changes via a github review, [like this](https://github.com/jackfirth/racket-package-resyntax-action/pull/9#pullrequestreview-1019362007). To apply the changes, the pull request author can click the "Commit suggestion" button that shows up in each comment. Suggestions can be ignored freely; the review does not block merges. Here's an example of what a Resyntax suggestion looks like for someone with commit access:

<img width="824" alt="Screen Shot 2022-06-25 at 5 37 19 PM" src="https://user-images.githubusercontent.com/8175575/175794793-50962133-f7c0-4ac7-9fd4-c911aeb6e378.png">

The Resyntax tool and especially the github integration are still in the early phases of development so there are probably several bugs to work out here. If a suggestion looks wonky, @-mention me and I'll take a look at it.