### PR TITLE
typed/racket/draw: update make-font type

### DIFF
--- a/typed-racket-more/typed/racket/draw.rkt
+++ b/typed-racket-more/typed/racket/draw.rkt
@@ -142,6 +142,8 @@
          #:smoothing -Font-Smoothing #f
          #:size-in-pixels? Univ #f
          #:hinting -Font-Hinting #f
+         #:feature-settings (-Immutable-HT -String -Integer) #f
+         #:font-list (-opt (-inst (parse-type #'Font-List%))) #f
          (-inst (parse-type #'Font%)))]
  [make-monochrome-bitmap
   (->* (list -Integer -Integer) (-opt -Bytes) (-inst -Bitmap%))]

--- a/typed-racket-test/succeed/make-font.rkt
+++ b/typed-racket-test/succeed/make-font.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/base
+
+(require typed/racket/class typed/racket/draw)
+
+(: get-cached-font (-> String Font-Weight Font-Style (Instance Font%)))
+(define (get-cached-font font weight style)
+  (make-font #:size 1024.0 #:style style #:weight weight #:face font))
+


### PR DESCRIPTION
add the two keyword args from:
 https://github.com/racket/racket/commit/cca0deb3ff5a570c1c3c03ea0983d106492444b7

- - -

Related, the error message for this is rough:

```
make-font.rkt:7:2: Type Checker: could not apply function;
 wrong number of arguments provided
  expected: 9
  given: 11
  in: (make-font #:size 1024.0 #:style style #:weight weight #:face font)
make-font.rkt:7:2: Type Checker: type mismatch
  expected: (U #<unsafe-undefined> Font-Smoothing)
  given: Positive-Float-No-NaN
  in: (make-font #:size 1024.0 #:style style #:weight weight #:face font)
make-font.rkt:7:2: Type Checker: type mismatch
  expected: (U #<unsafe-undefined> Font-Style)
  given: False
  in: (make-font #:size 1024.0 #:style style #:weight weight #:face font)
make-font.rkt:7:2: Type Checker: type mismatch
  expected: (U #<unsafe-undefined> Font-Weight)
  given: Font-Style
  in: (make-font #:size 1024.0 #:style style #:weight weight #:face font)
```

I think the best "fix" is to add lots more regression tests so errors like this in a base environment get caught by the TR CI.
