### PR TITLE
Shallow TR: fix drdr errors

### DIFF
--- a/rfcs/text/0004-shallow-optional-semantics.md
+++ b/rfcs/text/0004-shallow-optional-semantics.md
@@ -1,7 +1,7 @@
 - Feature Name: shallow-optional-semantics
 - Start Date: 2020-07-21
-- RFC PR: (leave this empty)
-- Feature Commit(s): (leave this empty)
+- RFC PR: #948 / #952
+- Feature Commit(s): PR #948
 
 # Summary
 

--- a/typed-racket-test/info.rkt
+++ b/typed-racket-test/info.rkt
@@ -45,7 +45,7 @@
   '("succeed"
     "external"
     "fail"
-    "shallow" "t-succeed" "t-fail"
+    "unit-tests/shallow-rewrite-expansion"
     "xfail"
     "racketcs-eval-server.rkt"
     "optimizer" ;; FIXME: should be improved by stamourv
@@ -53,6 +53,7 @@
 
 (define test-omit-paths '("fail"
                           "external/fail"
+                          "unit-tests/shallow-rewrite-expansion"
                           "xfail"))
 (define test-command-line-arguments
   '(("succeed/priority-queue.scm" ())


### PR DESCRIPTION
Don't compile or run code in `typed-racket-test/unit-tests/shallow-rewrite-expansion/`

Also fix RFC number.