### PR TITLE
Fix Resyntax workflows

### DIFF
--- a/.github/workflows/resyntax-analyze.yml
+++ b/.github/workflows/resyntax-analyze.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install local packages
         run: raco setup typed typed-racket typed-racket-test typed-scheme
       - name: Analyze changed files
-        run: xvfb-run racket -l- resyntax/cli analyze --local-git-repository . "origin/${GITHUB_BASE_REF}" --output-as-github-review >> ./resyntax-review.json
+        run: xvfb-run racket -l- resyntax/cli analyze --local-git-repository . "origin/${GITHUB_BASE_REF}" --output-as-github-review --output-to-file ./resyntax-review.json
       - name: Upload analysis artifact
         uses: actions/upload-artifact@v3.1.0
         with:

--- a/.github/workflows/resyntax-submit-review.yml
+++ b/.github/workflows/resyntax-submit-review.yml
@@ -22,9 +22,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Download Resyntax analysis
-        uses: actions/download-artifact@v3.0.0
+        # This uses a github script instead of the download-artifact action because
+        # that action doesn't work for artifacts uploaded by other workflows. See
+        # https://github.com/actions/download-artifact/issues/130 for more info.
+        uses: actions/github-script@v6.1.0
         with:
-          name: resyntax-review
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "resyntax-review"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/resyntax-review.zip', Buffer.from(download.data));
+      - run: unzip resyntax-review.zip
       - name: Create pull request review
         uses: actions/github-script@v6.1.0
         with:

--- a/.github/workflows/resyntax-submit-review.yml
+++ b/.github/workflows/resyntax-submit-review.yml
@@ -47,6 +47,8 @@ jobs:
       - run: unzip resyntax-review.zip
       - name: Create pull request review
         uses: actions/github-script@v6.1.0
+        permissions:
+          pull-requests: write
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
There are two issues with the current workflows: the artifact upload step produces malformed JSON, and the artifact download step doesn't work because the action I'm using for it doesn't support downloading artifacts uploaded by other workflows. This pull request should hopefully fix both issues.