### PR TITLE
Fix resyntax permissions

### DIFF
--- a/.github/workflows/resyntax-submit-review.yml
+++ b/.github/workflows/resyntax-submit-review.yml
@@ -47,8 +47,6 @@ jobs:
       - run: unzip resyntax-review.zip
       - name: Create pull request review
         uses: actions/github-script@v6.1.0
-        permissions:
-          pull-requests: write
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
I put this bit in the wrong spot, but after reading the docs it shouldn't be necessary in the first place.