### PR TITLE
Add missing permissions

### DIFF
--- a/.github/workflows/resyntax-submit-review.yml
+++ b/.github/workflows/resyntax-submit-review.yml
@@ -17,6 +17,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Looks like Typed Racket defaults to read-only permissions for all actions.