### PR TITLE
Make PLT_TR_CONTRACTS easier to toggle in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,8 @@ jobs:
           raco pkg install -i --auto --no-setup --skip-installed typed-racket-test
           raco pkg update --auto --no-setup source-syntax typed-racket-lib typed-racket-more typed-racket-compatibility typed-racket-doc typed-racket typed-racket-test
       - run: raco setup --check-pkg-deps typed typed-racket typed-racket-test typed-scheme
-        if: ${{ !matrix.enable-contracts }}
-      - run: raco setup --check-pkg-deps typed typed-racket typed-racket-test typed-scheme
-        if: ${{ matrix.enable-contracts }}
         env:
-          PLT_TR_CONTRACTS: 1
+          PLT_TR_CONTRACTS: ${{ matrix.enable-contracts }}
       - run: racket -l typed-racket-test -- --unit
       - run: racket -l typed-racket-test -- --int
       - run: racket -l typed-racket-test -- --just typed-racket-test/succeed/cl.rkt

--- a/typed-racket-lib/typed-racket/utils/utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/utils.rkt
@@ -5,7 +5,9 @@ This file is for utilities that are of general interest,
 at least theoretically.
 |#
 
-(require (for-syntax racket/base racket/string)
+(require (for-syntax racket/base
+                     racket/match
+                     racket/string)
          racket/require-syntax racket/provide-syntax
          racket/match
          racket/list
@@ -43,7 +45,10 @@ at least theoretically.
 
 (define optimize? (make-parameter #t))
 (define with-refinements? (make-parameter #f))
-(define-for-syntax enable-contracts? (and (getenv "PLT_TR_CONTRACTS") #t))
+(define-for-syntax enable-contracts?
+  (match (getenv "PLT_TR_CONTRACTS")
+    ["true" #true]
+    [(or "false" "" #false) #false]))
 
 (define-logger tr-debug)
 (define (debug-print format-string . vs)

--- a/typed-racket-test/with-tr-contracts.rkt
+++ b/typed-racket-test/with-tr-contracts.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-#;(void (putenv "PLT_TR_CONTRACTS" "1"))
+#;(void (putenv "PLT_TR_CONTRACTS" "true"))
 
 (define ns (make-base-namespace))
 (current-namespace ns)


### PR DESCRIPTION
This changes PLT_TR_CONTRACTS so that the legal values are `"true"`, `"false"`, `""`, and unset, and only the first of those choices results in `enable-contracts?` being true. Previously, setting `PLT_TR_CONTRACTS` to any string at all (including explicitly setting it to the empty string) would enable contracts.

I made this change so I could simplify the CI setup a little, since this lets the `${{ matrix.enable-contracts }}` expression be passed directly in the environment.