### PR TITLE
type-contract: merge vector and hash types earlier

### DIFF
--- a/typed-racket-test/unit-tests/static-contract-conversion-tests.rkt
+++ b/typed-racket-test/unit-tests/static-contract-conversion-tests.rkt
@@ -9,6 +9,8 @@
            racket/base
            typed-racket/private/type-contract
            typed-racket/static-contracts/instantiate
+           typed-racket/static-contracts/structures
+           typed-racket/static-contracts/combinators
            typed-racket/types/abbrev
            typed-racket/types/numeric-tower))
 
@@ -16,6 +18,11 @@
 (gen-test-main)
 
 (begin-for-syntax
+  (define-splicing-syntax-class return
+    #:attributes (e sc)
+    (pattern (~seq e:expr) #:attr sc #f)
+    (pattern (~seq e:expr #:ret sc:expr)))
+
   (define-splicing-syntax-class type-enforcement-flag
     #:attributes (value)
     (pattern (~or #:deep
@@ -28,25 +35,27 @@
 
 (define-syntax t/sc
   (syntax-parser
-    [(_ e:expr te-flag:type-enforcement-flag)
-     (syntax/loc #'e
+    [(_ r:return te-flag:type-enforcement-flag)
+     (syntax/loc #'r.e
        (test-case
-         (format "Conversion:~a" (quote-line-number e))
-         (with-check-info (['type 'e]
-                           ['location (build-source-location-list (quote-srcloc e))]
+         (format "Conversion:~a" (quote-line-number r.e))
+         (with-check-info (['type 'r.e]
+                           ['location (build-source-location-list (quote-srcloc r.e))]
                            ['enforcement-mode 'te-flag.value])
            (phase1-phase0-eval
              (define sc
-                (type->static-contract e (lambda (#:reason _) #f) #:enforcement-mode 'te-flag.value))
+                (type->static-contract r.e (lambda (#:reason _) #f) #:enforcement-mode 'te-flag.value))
              (if sc
-                 #`(with-check-info (['static '#,sc])
-                     (phase1-phase0-eval
-                       (define ctc (cadr
-                                     (instantiate '#,sc
-                                       (lambda (#:reason _) (error "static-contract could not be converted to a contract")))))
-                       #,#'#`(with-check-info (['contract '#,ctc])
-                          (define runtime-contract #,ctc)
-                          (check-pred contract? runtime-contract))))
+                 #`(begin
+                     (~? (check-equal? #,sc #,r.sc))
+                     (with-check-info (['static '#,sc])
+                       (phase1-phase0-eval
+                         (define ctc (cadr
+                                       (instantiate '#,sc
+                                         (lambda (#:reason _) (error "static-contract could not be converted to a contract")))))
+                         #,#'#`(with-check-info (['contract '#,ctc])
+                            (define runtime-contract #,ctc)
+                            (check-pred contract? runtime-contract)))))
                  #'(fail-check "Type could not be converted to a static contract"))))))]))
 
 (define-syntax t/fail
@@ -72,6 +81,7 @@
     (t/sc (cl->* (-Symbol . -> . -Symbol)
                  (-Symbol -Symbol . -> . -Symbol)))
     (t/sc (-Promise -Number))
+    (t/sc (-Promise -Bottom) #:ret (promise/sc (or/sc)))
     (t/sc (-struct-property (-> Univ -Number Univ) #f))
     (t/sc (-struct-property (-> -Self -Number) #f))
     (t/fail (-struct-property (-> -Self -Number) #f)  #:typed-side #f)
@@ -89,10 +99,85 @@
     (t/sc (-seq -Symbol))
     ;; HashTables with non-flat keys and values (Issue 625)
     ;;   https://github.com/racket/typed-racket/issues/625
-    (t/sc (-Mutable-HT (-vec -Symbol) (-vec -Symbol)))
-    (t/sc (-Immutable-HT (-vec -Symbol) (-vec -Symbol)))
-    (t/sc (-Weak-HT (-vec -Symbol) (-vec -Symbol)))
-    (t/sc (-HT (-vec -Symbol) (-vec -Symbol)))
+    (t/sc (-Mutable-HT (-vec Ident) (-vec Ident))
+      #:ret (mutable-hash/sc
+              (vectorof/sc identifier?/sc)
+              (vectorof/sc identifier?/sc)))
+    (t/sc (-Immutable-HT (-vec Ident) (-vec Ident))
+      #:ret (immutable-hash/sc
+              (vectorof/sc identifier?/sc)
+              (vectorof/sc identifier?/sc)))
+    (t/sc (-Weak-HT (-vec Ident) (-vec Ident))
+      #:ret (weak-hash/sc
+              (vectorof/sc identifier?/sc)
+              (vectorof/sc identifier?/sc)))
+    (t/sc (-HT (-vec Ident) (-vec Ident))
+      #:ret (hash/sc
+              (vectorof/sc identifier?/sc)
+              (vectorof/sc identifier?/sc)))
+    ;; Unions of hash types should merge into one hash?/sc
+    (t/sc (Un (-HT Ident Ident) (-Mutable-HT Ident Ident))
+      #:ret (hash/sc identifier?/sc identifier?/sc))
+    (t/sc (Un (-Weak-HT Ident Ident) (-Weak-HT -Bottom -Bottom)
+              (-Immutable-HT Ident Ident)
+              (-Mutable-HT -Bottom -Bottom) (-Mutable-HT Ident Ident))
+      #:ret (or/sc (hash/sc identifier?/sc identifier?/sc)
+                   (hash/sc (or/sc) (or/sc))))
+    (t/sc (Un -Weak-HashTableTop
+              (-Weak-HT Ident Ident)
+              (-Mutable-HT Ident Ident)
+              -Mutable-HashTableTop
+              (-Immutable-HT Univ Univ))
+      #:ret (and/sc hash?/sc any-wrap/sc))
+    ;; Vectors
+    (t/sc (-mvec Ident)
+      #:ret (mutable-vectorof/sc identifier?/sc))
+    (t/sc (-ivec Ident)
+      #:ret (immutable-vectorof/sc identifier?/sc))
+    (t/sc (-vec Ident)
+      #:ret (vectorof/sc identifier?/sc))
+    ;; Hetero vectors
+    (t/sc (-mvec* Ident Ident)
+      #:ret (mutable-vector/sc identifier?/sc identifier?/sc))
+    (t/sc (-ivec* Ident Ident)
+      #:ret (immutable-vector/sc identifier?/sc identifier?/sc))
+    (t/sc (-vec* Ident Ident)
+      #:ret (vector/sc identifier?/sc identifier?/sc))
+    ;; Unions of vectors types should merge into one
+    (t/sc (Un (-ivec Ident) (-mvec -Bottom) (-mvec Ident))
+      #:ret (or/sc (vectorof/sc identifier?/sc) (mutable-vectorof/sc (or/sc))))
+    (t/sc (Un (-ivec Ident) (-mvec Ident)
+              (-ivec (-box Ident)) (-mvec (-box Ident)))
+      #:ret (or/sc (vectorof/sc (box/sc identifier?/sc))
+                   (vectorof/sc identifier?/sc)))
+    (t/sc (Un (-ivec Ident)
+              -Mutable-VectorTop (-ivec Univ))
+      #:ret (and/sc vector?/sc any-wrap/sc))
+    ;; Unions of hetero vectors
+    (t/sc (Un (-ivec* Ident) (-mvec* -Bottom) (-mvec* Ident))
+      #:ret (or/sc (vector/sc identifier?/sc) (mutable-vector/sc (or/sc))))
+    (t/sc (Un (-ivec* Ident Ident Ident) (-mvec* Ident Ident Ident)
+              (-ivec* (-box Ident)) (-mvec* (-box Ident)))
+      #:ret (or/sc (vector/sc (box/sc identifier?/sc))
+                   (vector/sc identifier?/sc identifier?/sc identifier?/sc)))
+    (t/sc (Un (-ivec* Ident)
+              -Mutable-VectorTop
+              (-ivec* Univ))
+      #:ret (or/sc (and/sc mutable-vector?/sc any-wrap/sc)
+                   (immutable-vector/sc (and/sc any/sc any-wrap/sc))))
+    ;; Unions of hashes and vectors
+    (t/sc (Un
+            -Mutable-VectorTop
+            (-Immutable-HT -Bottom -Bottom)
+            (-Immutable-HT Ident Ident)
+            (-Mutable-HT -Bottom -Bottom)
+            (-Weak-HT Ident Ident)
+            (-ivec Univ)
+            (-ivec* Ident Ident Ident)
+            (-mvec* Ident Ident Ident))
+      #:ret (or/sc (hash/sc identifier?/sc identifier?/sc)
+                   (mutable-hash/sc (or/sc) (or/sc))
+                   (and/sc vector?/sc any-wrap/sc)))
     ;; These tests for unit static contracts are insufficient, but
     ;; in order to test Unit types the signature environment must be
     ;; set up correctly. More complex cases of compilation to unit/c
@@ -105,12 +190,12 @@
     (t/sc (-Number . -> . -Number) #:shallow)
     (t/sc (cl->* (-> -Symbol)
                  (-Symbol . -> . -Symbol)) #:shallow)
-    (t/sc (-Promise -Number) #:shallow)
-    (t/sc (-struct-property (-> -Self -Number) #f) #:shallow)
-    (t/sc (-struct-property (-> -Self -Number) #f)  #:shallow)
-    (t/sc (-set Univ) #:shallow)
+    (t/sc (-Promise -Number) #:ret promise?/sc #:shallow)
+    (t/sc (-struct-property (-> -Self -Number) #f) #:ret struct-type-property?/sc #:shallow)
+    (t/sc (-struct-property (-> Univ -Number Univ) #f) #:ret struct-type-property?/sc #:shallow)
+    (t/sc (-set Univ) #:ret set?/sc #:shallow)
     (t/sc ((-poly (a) (-vec a)) . -> . -Symbol) #:shallow)
-    (t/sc (-poly (a) (-lst a)) #:shallow)
+    (t/sc (-poly (a) (-lst a)) #:ret list?/sc #:shallow)
     (t/sc (-mu sexp (Un -Null -Symbol (-pair sexp sexp) (-vec sexp) (-box sexp))) #:shallow)
     (t/sc (-Mutable-HT (-vec -Symbol) (-vec -Symbol)) #:shallow)
     (t/sc (-HT (-vec -Symbol) (-vec -Symbol)) #:shallow)
@@ -118,11 +203,10 @@
     (t/sc (-unit null null null ManyUniv) #:shallow))
 
    (test-suite "Optional (typing) tests"
-    ;; Optional always succeeds with any/sc
-    (t/sc (-Number . -> . -Number) #:optional)
-    (t/sc (-struct-property (-> -Self -Number) #f) #:optional)
-    (t/sc (-struct-property (-> -Self -Number) #f)  #:optional)
-    (t/sc (-set Univ) #:optional)
-    (t/sc (-HT (-vec -Symbol) (-vec -Symbol)) #:optional)
-    (t/sc (-unit null null null ManyUniv) #:optional))
+    (t/sc (-Number . -> . -Number) #:ret any/sc #:optional)
+    (t/sc (-struct-property (-> -Self -Number) #f) #:ret any/sc #:optional)
+    (t/sc (-struct-property (-> -Self -Number) #f) #:ret any/sc  #:optional)
+    (t/sc (-set Univ) #:ret any/sc #:optional)
+    (t/sc (-HT (-vec -Symbol) (-vec -Symbol)) #:ret any/sc #:optional)
+    (t/sc (-unit null null null ManyUniv) #:ret any/sc #:optional))
    ))


### PR DESCRIPTION
Context:
  (Vector T) is implemented as the union of two types. Enforcing the
  type with two contracts is inefficient; we want one merged contract.
  Same for (HashTable K V), which is implemented as three types.

This commit replaces the old static-contract merging with a type merging.

The problem with static contract merging is that it happens after the "typed-side" optimization kicks in --- which meant that two types with equal components could end up as static contracts with unequal components. This was a huge practical problem in the GTP benchmark `dungeon` ... the fix lowers the runtime for one loop in the worst case down from 30 seconds to 1/2 second.