### PR TITLE
Repair `net/head` types.

### DIFF
--- a/typed-racket-more/typed/net/head.rkt
+++ b/typed-racket-more/typed/net/head.rkt
@@ -1,16 +1,23 @@
 #lang typed/racket/base
 
-(require typed/private/utils)
+(require typed/private/utils typed/racket/unsafe)
 
+(unsafe-require/typed/provide net/head
+  [extract-field (case-> (Bytes Bytes -> (Option Bytes))
+                         (String String -> (Option String)))]
+  [remove-field (case-> (Bytes Bytes -> Bytes)
+                        (String String -> String))]
+  [insert-field (case-> (Bytes Bytes Bytes -> Bytes)
+                        (String String String -> String))]
+  [replace-field (case-> (Bytes Bytes Bytes -> Bytes)
+                         (String String String -> String))]
+  [extract-all-fields (case-> (Bytes -> (Listof (cons Bytes Bytes)))
+                              (String -> (Listof (cons String String))))]
+  [append-headers (case-> (Bytes Bytes -> Bytes)
+                          (String String -> String))])
 (require/typed/provide net/head
   [empty-header String]
-  [validate-header (String -> Void)]
-  [extract-field (Bytes Bytes -> (Option Bytes))]
-  [remove-field (String String -> String)]
-  [insert-field (String String String -> String)]
-  [replace-field (String String String -> String)]
-  [extract-all-fields ((U String Bytes) -> (Listof (cons (U String Bytes) (U Bytes String))))]
-  [append-headers (String String -> String)]
+  [validate-header ((U String Bytes) -> Void)]
   [standard-message-header (String (Listof String) (Listof String) (Listof String) String -> String)]
   [data-lines->data ((Listof String) -> String)]
   [extract-addresses (String Symbol -> (U (Listof String) (Listof (Listof String))))]

--- a/typed-racket-more/typed/net/head.rkt
+++ b/typed-racket-more/typed/net/head.rkt
@@ -5,7 +5,7 @@
 (require/typed/provide net/head
   [empty-header String]
   [validate-header (String -> Void)]
-  [extract-field (Bytes (U Bytes String) -> (Option Bytes))]
+  [extract-field (Bytes Bytes -> (Option Bytes))]
   [remove-field (String String -> String)]
   [insert-field (String String String -> String)]
   [replace-field (String String String -> String)]


### PR DESCRIPTION
Solution 2 for the previous message.

Fixes up a bunch of the types in this libarary. Just read the code lol.

---

_old message_:

Solution 1 for https://github.com/racket/typed-racket/issues/1285

Upsides:

- Fixes the problem

Downsides:

- `extract-field` remains inconsistent compared to the rest of the `net/head` exports.