### PR TITLE
Allow #:combine and #:combine/key

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1126,9 +1126,21 @@
 [make-weak-custom-hash (->opt (-> Univ Univ Univ) (-> Univ -Nat) [(-> Univ -Nat)] Univ)]
 
 
-[hash-union (-poly (a b) (->* (list (-Immutable-HT a b))  (-HT a b) (-Immutable-HT a b)))]
-[hash-intersect (-poly (a b) (->* (list (-Immutable-HT a b))  (-HT a b) (-Immutable-HT a b)))]
-[hash-union! (-poly (a b) (->* (list (-Mutable-HT a b))  (-HT a b) -Void))]
+[hash-union (-poly (a b) (->optkey (-Immutable-HT a b) []
+                                   #:rest (-HT a b)
+                                   #:combine (-> b b b) #f
+                                   #:combine/key (-> a b b b) #f
+                                   (-Immutable-HT a b)))]
+[hash-intersect (-poly (a b) (->optkey (-Immutable-HT a b) []
+                                       #:rest (-HT a b)
+                                       #:combine (-> b b b) #f
+                                       #:combine/key (-> a b b b) #f
+                                       (-Immutable-HT a b)))]
+[hash-union! (-poly (a b) (->optkey (-Mutable-HT a b) []
+                                   #:rest (-HT a b)
+                                   #:combine (-> b b b) #f
+                                   #:combine/key (-> a b b b) #f
+                                   -Void))]
 
 ;; Section 4.15 (Sequences and Streams)
 [sequence? (unsafe-shallow:make-pred-ty -SequenceTop)]

--- a/typed-racket-test/succeed/hash-union.rkt
+++ b/typed-racket-test/succeed/hash-union.rkt
@@ -1,0 +1,56 @@
+#lang typed/racket
+
+(module+ test
+  (require typed/rackunit)
+
+  (require racket/hash)
+  (check-equal? ((inst hash-union Symbol Integer)
+                 #hash((a . 1)(b . 2))
+                 #hash((a . 3)(c . 4))
+                 #hash((a . 5))
+                 (make-hash '((c . 6)))
+                 #:combine +)
+                #hash((a . 9)(b . 2)(c . 10)))
+
+  (check-equal? ((inst hash-intersect Symbol Integer)
+                 #hash((a . 1)(b . 2))
+                 #hash((a . 2)(c . 4))
+                 #hash((a . 5))
+                 (make-hash '((a . 1)))
+                 #:combine *)
+                #hash((a . 10)))
+
+  (let ([A (make-hash '((a . 1)(b . 2)))])
+    ((inst hash-union! Symbol Integer)
+     A
+     #hash((a . 3)(c . 4))
+     #hash((a . 5))
+     (make-hash '((c . 6)))
+     #:combine +)
+    (check-equal? (hash-ref A 'a) 9))
+  
+
+    (check-equal? ((inst hash-union Symbol Integer)
+                 #hash((a . 1)(b . 2))
+                 #hash((a . 3)(c . 4))
+                 #hash((a . 5))
+                 (make-hash '((c . 6)))
+                 #:combine/key (λ ([k : Symbol][a : Integer][b : Integer]) (+ a b)))
+                #hash((a . 9)(b . 2)(c . 10)))
+
+  (check-equal? ((inst hash-intersect Symbol Integer)
+                 #hash((a . 1)(b . 2))
+                 #hash((a . 2)(c . 4))
+                 #hash((a . 5))
+                 (make-hash '((a . 1)))
+                 #:combine/key (λ ([k : Symbol][a : Integer][b : Integer]) (* a b)))
+                #hash((a . 10)))
+
+  (let ([A (make-hash '((a . 1)(b . 2)))])
+    ((inst hash-union! Symbol Integer)
+     A
+     #hash((a . 3)(c . 4))
+     #hash((a . 5))
+     (make-hash '((c . 6)))
+     #:combine/key (λ ([k : Symbol][a : Integer][b : Integer]) (+ a b)))
+    (check-equal? (hash-ref A 'a) 9)))


### PR DESCRIPTION
for `hash-union`, `hash-union!` and `hash-intersect`

See also: https://racket.discourse.group/t/type-checker-inference-for-polymorphic-keyword-functions-not-supported/145/5

maybe related: following failing test was recently added but I think the first hash should be `#hash()`. However I could be wrong about what is being tested
https://github.com/racket/typed-racket/blob/20acc4bc64907ccf0638c275dccec48461749979/typed-racket-test/fail/hash-union.rkt#L3