### PR TITLE
Allow dependent function types with no arguments

### DIFF
--- a/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -950,8 +950,8 @@
         [(:Sequenceof^ t ...)
          (parse-sequence-type stx do-parse do-parse-multi)]
         ;; simple dependent functions
-        ;; e.g. (-> ([x : τ] ...+) τ)
-        [(:->^ (args:dependent-fun-arg ...+)
+        ;; e.g. (-> ([x : τ] ...) τ)
+        [(:->^ (args:dependent-fun-arg ...)
                ~!
                (~optional (~seq #:pre (pre-dep-stx:id ...) pre-stx:expr)
                           #:defaults ([pre-stx #'Top]

--- a/typed-racket-test/succeed/dependent-function-type-thunk-prop.rkt
+++ b/typed-racket-test/succeed/dependent-function-type-thunk-prop.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket #:with-refinements
+
+(: n? (-> ([v : Any]) (-> () Boolean #:+ (: v Number) #:- (! v Number))))
+(define ((n? v)) (number? v))
+
+(: f (-> Any Number))
+(define (f x)
+  (cond [((n? x)) (+ x 1)]
+        [else 1]))
+
+(ann (f 5) Number)
+(ann (f #f) Number)


### PR DESCRIPTION
Dependent function types with no arguments allow more expressive propositions than normal function types.

Error message without this change:
```
<pkgs>/typed-racket-test/succeed/dependent-function-type-thunk-prop.rkt:3:22: ->: expected the identifier `:'
  at: Boolean
  in: (-> () Boolean #:+ (: v Number) #:- (! v Number))
  parsing context: 
   while parsing colon^
    term: Boolean
    location: <pkgs>/typed-racket-test/succeed/dependent-function-type-thunk-prop.rkt:3:29
  #(69 7)
```