### PR TITLE
avoid calling normalize-type outside of shallow tr

### DIFF
--- a/typed-racket-lib/typed-racket/utils/shallow-utils.rkt
+++ b/typed-racket-lib/typed-racket/utils/shallow-utils.rkt
@@ -11,14 +11,17 @@
   (submod typed-racket/rep/type-rep shallow-exports)
   typed-racket/types/tc-result
   typed-racket/types/type-table
-  typed-racket/types/union)
+  typed-racket/types/union
+  typed-racket/utils/tc-utils)
 
 
 (define (ArrowT+? arr)
   (and (Arrow? arr) (Arrow-rng-shallow-safe? arr)))
 
 (define (shallow-trusted-positive? orig-ty)
-  (let loop ((ty (normalize-type orig-ty)))
+  (define in-shallow? (eq? shallow (current-type-enforcement-mode)))
+  ;; 2022-12-12: normalize only in shallow mode to save time
+  (let loop ((ty ((if in-shallow? normalize-type values) orig-ty)))
     (match ty
       [(Fun: arr*)
        (andmap ArrowT+? arr*)]


### PR DESCRIPTION
Fix the slowdown reported in https://github.com/racket/typed-racket/issues/1293

Saves about 600 seconds on my machine on this command:
```
rm compiled */compiled
time raco make -j 8 cmdline.rkt
```

- Before = `861s`
- After = `250s`
