### PR TITLE
fix random types

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -92,7 +92,7 @@
 
 ;; Section 4.3.2.7 (Random Numbers)
 [random
-  (cl->* (->opt -Int -Int [-Pseudo-Random-Generator] -NonNegFixnum)
+  (cl->* (->opt -Int -Int [-Pseudo-Random-Generator] -Int)
          (->opt -Int [-Pseudo-Random-Generator] -NonNegFixnum)
          (->opt [-Pseudo-Random-Generator] -Flonum))]
 

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -2182,7 +2182,7 @@
                 (pseudo-random-generator->vector pg))
               (-vec* -PosInt -PosInt -PosInt -PosInt -PosInt -PosInt))
         (tc-e (random 1 5 (make-pseudo-random-generator))
-              -NonNegFixnum)
+              -Integer)
 
         ;Structure Type Properties
         (tc-e (make-struct-type-property 'prop)


### PR DESCRIPTION
The result of `(random -20 -10)` is a negative number. See also https://github.com/racket/racket/pull/4562

I'm not sure that I'm using the correct types, because I never remember which is `fixnum?`, which one is `exact-integer?` and which one includes fake integers like `7.0`.

The next line should be fixed too, 

             (->opt -Int [-Pseudo-Random-Generator] -NonNegFixnum)

because the maximal number `4294967086` is not a fixnum in 32 bits.

I tried to add a test with negatives, but I get an error that I don't understand.