### PR TITLE
Update `unit-from-context` typechecking strategy

### DIFF
--- a/typed-racket-lib/info.rkt
+++ b/typed-racket-lib/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '(("base" #:version "8.7.0.10")
+(define deps '(("base" #:version "8.8.0.7")
                "source-syntax"
                "pconvert-lib"
                "compatibility-lib" ;; to assign types

--- a/typed-racket-lib/typed-racket/env/signature-helper.rkt
+++ b/typed-racket-lib/typed-racket/env/signature-helper.rkt
@@ -80,12 +80,11 @@
 ;; those listed in a require/typed clause
 (define (check-signature-bindings name vars stx)
   (match-define-values (_ inferred-vars inferred-defs _) (signature-members name name))
-  (define (make-id-set set) (immutable-free-id-set set #:phase (add1 (syntax-local-phase-level))))
-  (define inferred-vars-set (make-id-set inferred-vars))
-  (define vars-set (make-id-set vars))
+  (define inferred-vars-set (immutable-bound-id-set inferred-vars))
+  (define vars-set (immutable-bound-id-set vars))
   (unless (empty? inferred-defs)
     (tc-error/stx name "untyped signatures containing definitions are prohibited"))
-  (unless (free-id-set=? inferred-vars-set vars-set)
+  (unless (bound-id-set=? inferred-vars-set vars-set)
     (tc-error/fields "required signature declares inconsistent members"
                      "expected members" (map syntax-e inferred-vars)
                      "received members" (map syntax-e vars)
@@ -149,5 +148,5 @@
 (define (fix-order sig-id sig-bindings)
   (match-define-values (_ members _ _) (signature-members sig-id sig-id))
   (map
-   (lambda (id) (assoc id sig-bindings free-transformer-identifier=?))
+   (lambda (id) (assoc id sig-bindings bound-identifier=?))
    members))

--- a/typed-racket-lib/typed-racket/typecheck/check-unit-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/check-unit-unit.rkt
@@ -230,24 +230,6 @@
   (pattern (#%plain-app list sg:init-depend-sig-tag ...)
            #:with init-depend-tags #'(sg.sig-tag ...)))
 
-(define-syntax-class export-table
-  #:literal-sets (kernel-literals)
-  #:literals (make-immutable-hash list cons vector-immutable check-not-unsafe-undefined unbox)
-  (pattern (#%plain-app
-            make-immutable-hash
-            (#%plain-app
-             list
-             (#%plain-app
-              cons
-              signature-tag:id
-              (#%plain-app
-               vector-immutable
-               (#%plain-lambda () 
-                 (#%plain-app check-not-unsafe-undefined (#%plain-app unbox export-temp-id) external-id))
-               ...))
-             ...))
-           #:attr export-temp-ids (map syntax->list (syntax->list #'((export-temp-id ...) ...)))))
-
 (define-syntax-class unit-expansion-internals
   #:literal-sets (kernel-literals)
   #:attributes (body-stx 
@@ -261,7 +243,6 @@
                 values
                 (#%plain-lambda (import-table:id)
                                 :unit-expansion-internals/import+body)
-                et:export-table
                 _ ...)))
            #:attr export-temp-ids (syntax->list #'(export-temp-id ...))
            #:attr import-internal-ids (map syntax->list (syntax->list #'((import ...) ...)))


### PR DESCRIPTION
This PR updates the way Typed Racket typechecks `unit-from-context` forms to support racket/racket#4567. It should not be merged until that PR is merged, so I’ve marked it a draft for now.

(This branch also includes PR #1303, since it is necessary for it to work. If this PR is merged before that one is, then #1303 can be closed.)