### PR TITLE
Bump workflow version for runtime & URL updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
         racket-variant: ["BC", "CS"]
         enable-contracts: [true, false]
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: Bogdanp/setup-racket@v1.6.1
+      - uses: actions/checkout@v3
+      - uses: Bogdanp/setup-racket@v1.9.1
         with:
           architecture: x64
           distribution: full

--- a/.github/workflows/resyntax-analyze.yml
+++ b/.github/workflows/resyntax-analyze.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Racket
-        uses: Bogdanp/setup-racket@v1.8.1
+        uses: Bogdanp/setup-racket@v1.9.1
         with:
           version: current
           packages: resyntax

--- a/typed-racket-test/fail/unit-typed-untyped-2.rkt
+++ b/typed-racket-test/fail/unit-typed-untyped-2.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred #rx"u: contract violation\n  expected: exact-integer?")
+(exn-pred #rx"y: contract violation\n  expected: exact-integer?")
 #lang racket
 
 (module typed typed/racket


### PR DESCRIPTION
Update `checkout` to v3 and `setup-racket` to v1.9.1.

- `checkout`: the runtime of v2 is deprecated (racket/racket#4564)
- `setup-racket`: UUtah's URL has changed (Bogdanp/setup-racket#62)
