### PR TITLE
shallow: stop checking output of base numeric fns

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -8,12 +8,15 @@
    (only-in "../rep/values-rep.rkt" make-Values)
    racket/list racket/math racket/flonum racket/extflonum racket/unsafe/ops racket/sequence racket/match
    (for-template racket/flonum racket/extflonum racket/fixnum racket/math racket/unsafe/ops racket/base
+                 (only-in typed-racket/base-env/extra-env-lang with-default-T+)
                  (only-in "../types/numeric-predicates.rkt" index?))
    (only-in (combine-in "../types/abbrev.rkt"
                         "../types/numeric-tower.rkt")
             [-Number N] [-Boolean B] [-Symbol Sym] [-Real R] [-PosInt -Pos]))
 
   ;; TODO having definitions only at the top is really inconvenient.
+
+ (with-default-T+ #true
 
   (define all-int-types
     (list -Zero -One -PosByte -Byte -PosIndex -Index
@@ -773,7 +776,7 @@
         (unless (free-identifier=? id1 id2 (sub1 phase))
           (error 'flonum-operations "The assumption that the safe and unsafe flonum-ops are the same binding has been violated. ~a and ~a are diffferent bindings." id1 id2))])))
 
-  )
+  ))
 
 ;; numeric predicates
 ;; There are 25 values that answer true to zero?. They are either reals, or inexact complexes.

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/base-env-numeric.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/base-env-numeric.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket/shallow
+
+(let ((x : Nonnegative-Integer 5))
+  (= x 0)
+  (* x 1)
+  (+ x 1))
+

--- a/typed-racket-test/unit-tests/shallow-rewrite-expansion/main.rkt
+++ b/typed-racket-test/unit-tests/shallow-rewrite-expansion/main.rkt
@@ -193,6 +193,9 @@
 
 (define test-registry
   (list
+    (list "base-env-numeric.rkt"
+          no-shape-check?)
+
     (list "call-with-values.rkt"
           (lambda (stx)
             (define all-assert* (stx-find-shape-check* stx))


### PR DESCRIPTION
add the default "trust fn result" flag to the definitions at the top of base-env-numeric

thanks @shawnw for the report:
<https://www.reddit.com/r/Racket/comments/11dqjbb/experimenting_with_the_new_typed_racket_modes/?utm_source=share&utm_medium=web2x&context=3>