### PR TITLE
Patched require/untyped-contract to accept a language spec.

### DIFF
--- a/typed-racket-lib/typed/untyped-utils.rkt
+++ b/typed-racket-lib/typed/untyped-utils.rkt
@@ -29,8 +29,8 @@
   (stx-map (lambda (id) ((make-syntax-introducer) id)) ids))
 
 (define-syntax (require/untyped-contract stx)
-  (syntax-parse stx #:literals (begin)
-    [(_ (begin form ...) from-module-spec:expr [name:id T:expr] ...)
+  (syntax-parse stx #:literals (begin quote)
+    [(_ (begin form ...) from-module-spec:expr (quote language-spec:id) [name:id T:expr] ...)
      (with-syntax* ([(typed-name ...)  (generate-temporaries #'(name ...))]
                     [(untyped-name ...)  (freshen #'(name ...))]
                     [(untyped2-name ...)  (generate-temporaries #'(name ...))]
@@ -39,10 +39,9 @@
                     [typed-module  (generate-temporary #'typed-module)]
                     [untyped-module  (generate-temporary #'untyped-module)]
                     [*racket/base (datum->syntax #'from-module-spec 'racket/base)]
-                    [*typed/racket/base (datum->syntax #'from-module-spec
-                                                       'typed/racket/base)]
-                    [*require (datum->syntax #'from-module-spec
-                                             'require)]
+                    [*typed/racket (datum->syntax #'from-module-spec (format-symbol "~a" (syntax-e #'language-spec)))]
+                    [*require (datum->syntax #'from-module-spec 'require)]
+                    [*language-spec (datum->syntax #'racket/base (format-symbol "~a" (syntax-e #'language-spec)))]
                     [from-module-spec-for-submod
                       (syntax-parse #'from-module-spec #:literals (submod)
                         [(submod (~and base (~or "." "..")) elem ...)
@@ -50,8 +49,8 @@
                         [x #'x])])
        (syntax/loc stx
          (begin
-           (module typed-module *typed/racket/base ; to bind in `T`s
-             (*require typed/racket/base) ; to bind introduced `begin`, etc.
+           (module typed-module *typed/racket ; to bind in `T`s
+             (*require *language-spec) ; to bind introduced `begin`, etc.
              (begin form ...)
              (require (only-in from-module-spec-for-submod
                                [name untyped2-name] ...))
@@ -70,5 +69,5 @@
              (define-typed/untyped-identifier macro-name typed-name untyped3-name) ...)
            
            (require (rename-in (submod "." untyped-module) [macro-name name] ...)))))]
-    [(_ from-module-spec:expr [name:id T:expr] ...)
-     (syntax/loc stx (require/untyped-contract (begin) from-module-spec [name T] ...))]))
+    [(_ from-module-spec:expr (quote language-spec:id) [name:id T:expr] ...)
+     (syntax/loc stx (require/untyped-contract (begin) from-module-spec (quote language-spec) [name T] ...))]))


### PR DESCRIPTION
Hi @bennn ,

This is a very modest proposal for #1286. I did not patch the docs yet, but I will do so if there is interest in this pull request. It seems to work with the following test code (changed language to typed/racket/no-check):

**server.rkt**

```
#lang typed/racket/no-check ;shallow ;optional ;no-check

(provide mynum check-array-shape)

(define mynum 42)

(define-type (MVec T) (Mutable-Vectorof T))

(define-type Indexes (MVec Index))
(define-type In-Indexes (U (MVec Integer) Indexes))

(: check-array-shape (In-Indexes (-> Nothing) -> Indexes))
(define (check-array-shape ds fail)
  (define dims (vector-length ds))
  (define: new-ds : Indexes (make-vector dims 0))
  (let loop ([#{i : Nonnegative-Fixnum} 0])
    (cond [(i . < . dims)
           (define di (vector-ref ds i))
           (cond [(index? di)  (vector-set! new-ds i di)
                               (loop (+ i 1))]
                 [else  (fail)])]
          [else  new-ds])))
```

**main.rkt**

```
#lang racket/base

(require typed/untyped-utils
         typed/racket/no-check
         (except-in "server.rkt"
                    check-array-shape))

(require/untyped-contract
 "server.rkt"
 'typed/racket/no-check
 [check-array-shape  #;((Mutable-Vectorof Integer) (-> Nothing) -> (Mutable-Vectorof Index))
                     ((Vectorof Integer) (-> Nothing) -> (Vectorof Index))])

(check-array-shape (vector 1 2 3) (lambda () (error 'die)))

```
Cheers!