### PR TITLE
cast: add value-name

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -492,7 +492,7 @@
                                  val
                                  '#,pos
                                  '#,neg
-                                 `(cast of ,(object-name val))
+                                 `(cast for ,(object-name val))
                                  (quote-srcloc #,stx)))
                               'feature-profile:TR-dynamic-check #t))
                        #'ty)))

--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -492,7 +492,7 @@
                                  val
                                  '#,pos
                                  '#,neg
-                                 #f
+                                 `(cast of ,(object-name val))
                                  (quote-srcloc #,stx)))
                               'feature-profile:TR-dynamic-check #t))
                        #'ty)))


### PR DESCRIPTION
Replace `#f` with a name in TR's `cast`.

I'm not sure what name to use, but anything seems better than `#f`! The current name is inspired by require/typed's `(interface for _)` names.

cc @mfelleisen who discovered that running the contract profiler on code like this gave confusing output:

```
#lang typed/racket

(define-type Fighter Integer)
(define-type Pill Integer)
(struct interactive [{whose-turn : Symbol} {state : State}] #:prefab #:type-name Interactive)
(struct state [{fighters : [Listof Fighter]} {pills : {Listof Pill}}] #:prefab #:type-name State)

(define mk-state
  (let ((ff 0) (pp 0))
    (lambda ()
      (state
        (begin0 (list ff) (set! ff (+ 1 ff)))
        (begin0 (list pp) (set! pp (+ 1 pp)))))))

(define mk-interactive
  (let ((ww 'who))
    (lambda ()
      (interactive
        ww
        (mk-state)))))

(define NN (expt 10 4))

(define ii*
  (for/list : (Listof Interactive) ((_kk : Natural (in-range NN)))
    (cast (cast (mk-interactive) Any) Interactive)))
```

Contract profile output talks about `Any` and `#f`, so it's not at all clear where the costs came from:

```
Running time is 40.67% contracts
146/359 ms

Any                                                              98 ms
ben.rkt:28:4                                                    
    #f                                                           98 ms

(prefab/c (quote interactive) symbol? (prefab/c (quote state ... 27.5 ms
ben.rkt:28:4                                                    
    #f                                                           27.5 ms

(-> any/c boolean?)                                              20.5 ms
(lib syntax/id-set.rkt)                                         
    #f                                                           20.5 ms
```