### PR TITLE
Add `#:indent` types for `write-json` procedure

### DIFF
--- a/typed-racket-more/typed/json.rkt
+++ b/typed-racket-more/typed/json.rkt
@@ -22,7 +22,9 @@
  json
  [jsexpr? (-> Any #:null 'null Boolean)]
  [write-json (->* (JSExpr #:null 'null)
-                  (Output-Port #:encode (U 'control 'all))
+                  (Output-Port
+                   #:encode (U 'control 'all)
+                   #:indent (U False #\tab Natural))
                   Any)]
  [read-json (->* (#:null 'null) (Input-Port) (U JSExpr EOF))]
  [jsexpr->string (-> JSExpr #:null 'null [#:encode (U 'control 'all)] String)]
@@ -35,11 +37,17 @@
   (jsexpr? v #:null 'null))
 
 (: write-json* (->* (JSExpr)
-                    (Output-Port #:encode (U 'control 'all))
+                    (Output-Port
+                     #:encode (U 'control 'all)
+                     #:indent (U False #\tab Natural))
                     Any))
 (define (write-json* js [out (current-output-port)]
-                     #:encode [enc 'control])
-  (write-json js out #:encode enc #:null 'null))
+                     #:encode [enc 'control]
+                     #:indent [indent #f])
+  (write-json js out
+              #:encode enc
+              #:null   'null
+              #:indent indent))
 
 (: read-json* (->* () (Input-Port) (U JSExpr EOF)))
 (define (read-json* [in (current-input-port)])


### PR DESCRIPTION
The `#:indent` keyword was recently introduced to the `write-json` procedure in the main Racket repository[0]. This commit introduces the keyword's corresponding types into the Typed Racket exports.

[0] https://github.com/racket/racket/pull/4686