### PR TITLE
[Docs] Rename Opt to Maybe in guide

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/guide/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/types.scrbl
@@ -303,9 +303,9 @@ an analog of the @tt{Maybe} type constructor from Haskell:
 @racketmod[
 typed/racket
 (struct Nothing ())
-(struct (a) Some ([v : a]))
+(struct (A) Some ([v : A]))
 
-(define-type (Maybe a) (U Nothing (Some a)))
+(define-type (Maybe A) (U Nothing (Some A)))
 
 (: find (-> Number (Listof Number) (Maybe Number)))
 (define (find v l)
@@ -320,7 +320,7 @@ a structure with no contents.
 The second definition
 
 @racketblock[
-(struct (a) Some ([v : a]))
+(struct (A) Some ([v : A]))
 ]
 
 creates a type constructor, @racket[Some], and defines a namesake structure with
@@ -330,7 +330,7 @@ name, and can be referred to in the types of the fields.
 
 The type definiton
 @racketblock[
-  (define-type (Maybe a) (U Nothing (Some a)))
+  (define-type (Maybe A) (U Nothing (Some A)))
 ]
 creates a type constructor --- @racket[Maybe] is a potential
 container for whatever type is supplied.

--- a/typed-racket-doc/typed-racket/scribblings/guide/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/types.scrbl
@@ -303,14 +303,14 @@ an analog of the @tt{Maybe} type constructor from Haskell:
 @racketmod[
 typed/racket
 (struct Nothing ())
-(struct (A) Some ([v : A]))
+(struct (A) Just ([v : A]))
 
-(define-type (Maybe A) (U Nothing (Some A)))
+(define-type (Maybe A) (U Nothing (Just A)))
 
 (: find (-> Number (Listof Number) (Maybe Number)))
 (define (find v l)
   (cond [(null? l) (Nothing)]
-        [(= v (car l)) (Some v)]
+        [(= v (car l)) (Just v)]
         [else (find v (cdr l))]))
 ]
 
@@ -320,23 +320,23 @@ a structure with no contents.
 The second definition
 
 @racketblock[
-(struct (A) Some ([v : A]))
+(struct (A) Just ([v : A]))
 ]
 
-creates a type constructor, @racket[Some], and defines a namesake structure with
-one element, whose type is that of the type argument to @racket[Some].  Here the
-type parameters (only one, @racket[a], in this case) are written before the type
+creates a type constructor, @racket[Just], and defines a namesake structure with
+one element, whose type is that of the type argument to @racket[Just].  Here the
+type parameters (only one, @racket[A], in this case) are written before the type
 name, and can be referred to in the types of the fields.
 
 The type definiton
 @racketblock[
-  (define-type (Maybe A) (U Nothing (Some A)))
+  (define-type (Maybe A) (U Nothing (Just A)))
 ]
 creates a type constructor --- @racket[Maybe] is a potential
 container for whatever type is supplied.
 
 The @racket[find] function takes a number @racket[v] and list, and
-produces @racket[(Some v)] when the number is found in the list,
+produces @racket[(Just v)] when the number is found in the list,
 and @racket[(Nothing)] otherwise.  Therefore, it produces a
 @racket[(Maybe Number)], just as the annotation specified.
 

--- a/typed-racket-doc/typed-racket/scribblings/guide/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/types.scrbl
@@ -302,19 +302,19 @@ an analog of the @tt{Maybe} type constructor from Haskell:
 
 @racketmod[
 typed/racket
-(struct None ())
+(struct Nothing ())
 (struct (a) Some ([v : a]))
 
-(define-type (Opt a) (U None (Some a)))
+(define-type (Maybe a) (U Nothing (Some a)))
 
-(: find (-> Number (Listof Number) (Opt Number)))
+(: find (-> Number (Listof Number) (Maybe Number)))
 (define (find v l)
-  (cond [(null? l) (None)]
+  (cond [(null? l) (Nothing)]
         [(= v (car l)) (Some v)]
         [else (find v (cdr l))]))
 ]
 
-The first @racket[struct] defines @racket[None] to be
+The first @racket[struct] defines @racket[Nothing] to be
 a structure with no contents.
 
 The second definition
@@ -330,15 +330,15 @@ name, and can be referred to in the types of the fields.
 
 The type definiton
 @racketblock[
-  (define-type (Opt a) (U None (Some a)))
+  (define-type (Maybe a) (U Nothing (Some a)))
 ]
-creates a type constructor --- @racket[Opt] is a potential
+creates a type constructor --- @racket[Maybe] is a potential
 container for whatever type is supplied.
 
 The @racket[find] function takes a number @racket[v] and list, and
 produces @racket[(Some v)] when the number is found in the list,
-and @racket[(None)] otherwise.  Therefore, it produces a
-@racket[(Opt Number)], just as the annotation specified.
+and @racket[(Nothing)] otherwise.  Therefore, it produces a
+@racket[(Maybe Number)], just as the annotation specified.
 
 @subsection{Polymorphic Functions}
 


### PR DESCRIPTION
When I was learning Typed Racket, I was confused by this section of the guide, which gives an example of defining a polymorphic data type. The example used is an optional type called `Opt`, defined analogously to `Maybe` in Haskell. Personally, this example was confusing to me since I then thought the the [Option](https://docs.racket-lang.org/ts-reference/type-ref.html#%28form._%28%28lib._typed-racket%2Fbase-env%2Fbase-types..rkt%29._.Option%29%29) type provided by the standard library was defined in the same way. However, that `(Option t)` type is actually defined as either `t` or `#f`, which aligns better with Racket conventions.

To avoid this confusion, and since `Maybe` from Haskell is already mentioned here, I recommend changing the name of `Opt` to `Maybe` in this example.  I also changed type parameter names to be upper case in this example, for consistency with the rest of the language. 

It also may be helpful to add a note afterward explaining that in a "real" program, for consistency the user should probably use `Option` rather than their own `Maybe` type, but maybe that's unnecessary, so I left it out here.