### PR TITLE
[Docs] Add section on custom propositions

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/guide/occurrence.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/occurrence.scrbl
@@ -84,6 +84,31 @@ the typechecker learns from the result of applying the function:
 Predicates for all built-in types are annotated with similar propositions
 that allow the type system to reason logically about predicate checks.
 
+@subsection{Custom Propositions}
+
+Although propositions are provided for all built-in type predicates,
+we may want to define propositions from our own predicates as well.
+For instance, consider the following predicate:
+
+@racketblock[
+(: (-> (Listof Any) Boolean))
+(define (listof-string? lst)
+  (andmap string? lst))
+]
+
+This function determines whether a given list contains only strings.
+With Typed Racket, we can use this predicate to refine the type of a given list from
+the general @racket[(Listof Any)] to the more specific @racket[(Listof String)].
+To do so, we must change the type of @racket[listof-string?] to be a proposition:
+
+@racketblock[
+(: (-> (Listof Any) Boolean : (Listof String)))
+]
+
+Here, we adjust the type annotation to include the logical proposition
+@racket[(Listof String)] after the second @racket[_:], from which the typechecker learns
+that this predicate narrows its result type to a list of strings.       
+
 @subsection{One-sided Propositions}
 
 Sometimes, a predicate may provide information when it

--- a/typed-racket-doc/typed-racket/scribblings/guide/occurrence.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/occurrence.scrbl
@@ -107,7 +107,7 @@ To do so, we must change the type of @racket[listof-string?] to be a proposition
 
 Here, we adjust the type annotation to include the logical proposition
 @racket[(Listof String)] after the second @racket[_:], from which the typechecker learns
-that this predicate narrows its result type to a list of strings.       
+that this predicate narrows its input type to a list of strings.       
 
 @subsection{One-sided Propositions}
 


### PR DESCRIPTION
Section 5.2 of the guide describes how Typed Racket narrows types with propositions. However, I don't think this section makes it clear if and how users can define their own propositions from predicates. In 5.2, the proposition for the built-in type predicate `string?` is discussed. Then, in 5.2.1, it jumps to defining custom one-sided propositions, a slightly more advanced concept. I think it could use a section in between that makes it explicit how to create a proposition from a predicate.

Personally, I ran into this issue when I was learning Typed Racket: at the time I didn't understand from the guide how to define my own proposition. [I asked a question](https://stackoverflow.com/questions/69694263/how-to-assert-listof-string-predicate-in-typed-racket) on StackOverflow and got an answer, but I think this would be more clear with an example in the guide.

This PR adds such an example. I was a bit confused on whether to use `@examples` or `@racketblock` so I chose the latter which seemed simpler, but feel free to recommend changes to that, to the writing, or more generally to the structure/position of this section.