### PR TITLE
Add Unicode Aliases for `U` and `->*`.

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -1029,9 +1029,11 @@ prefab types with the (implicitly quoted) prefab-key
   structure type associcated with a @racket[Struct-Property] named @racket[prop].
 }
 
+@defalias[∪ U "type constructor"]
 @defalias[Union U "type constructor"]
 @defalias[Intersection ∩ "type constructor"]
 @defalias[→ -> "type constructor"]
+@defalias[→* ->* "type constructor"]
 @defalias[case→ case-> "type constructor"]
 @defalias[∀ All "type"]
 

--- a/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-types-extra.rkt
@@ -28,6 +28,7 @@
 
 (provide (rename-out [All ∀]
                      [-> →]
+                     [->* →*]
                      [case-> case→]
                      [List Tuple]
                      [Rec mu]

--- a/typed-racket-lib/typed-racket/base-env/base-types.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-types.rkt
@@ -205,7 +205,7 @@
 [Nothing (-Un)]
 [Futureof -future]
 [Pairof -pair]
-[U -Un #:alias (Union Un)]
+[U -Un #:alias (Union Un ∪)]
 [∩ -Inter #:alias (Intersection)]
 [MPairof -mpair]
 [MListof -MListof]

--- a/typed-racket-test/succeed/unicode-aliases.rkt
+++ b/typed-racket-test/succeed/unicode-aliases.rkt
@@ -1,0 +1,8 @@
+#lang typed/racket/base
+
+(: foo (→* ((∪ Symbol String)) (Integer) (Pair Boolean Integer)))
+(define foo
+  (λ (s [i 0])
+    (cons (symbol? s) i)))
+(foo 'abc)
+(foo "abc")


### PR DESCRIPTION
- Added `∪` as an alias for `U`.
- Added `→*` as an alias for `->*`.