### PR TITLE
doc: guide, show lambda return-type annotation and explain ann for ca…

### DIFF
--- a/typed-racket-doc/typed-racket/scribblings/guide/more.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/more.scrbl
@@ -89,6 +89,10 @@ of @racket[Number]s.
 @racketblock[(lambda ([x : String] (unsyntax @tt["."]) [y : Number #,**]) (apply + y))]
 
 This function has the type @racket[(-> String Number #,** Number)].
+To specify the return type, add a type annotation after the arguments:
+
+@racketblock[(lambda ([x : String] (unsyntax @tt["."]) [y : Number #,**]) : (U Number String) (apply + y))]
+
 Functions defined by cases may also be annotated:
 
 @racketblock[(case-lambda [() 0]
@@ -96,6 +100,10 @@ Functions defined by cases may also be annotated:
 
 This function has the type
 @racket[(case-> (-> Number) (-> Number Number))].
+To specify the return type, either annotate the entire function or use the
+@seclink["Annotating_Expressions" #:doc '(lib "typed-racket/scribblings/ts-guide.scrbl")]{expression annotation form}
+(@racket[ann]) inside each case.
+
 
 @subsection{Annotating Single Variables}
 

--- a/typed-racket-doc/typed-racket/scribblings/guide/more.scrbl
+++ b/typed-racket-doc/typed-racket/scribblings/guide/more.scrbl
@@ -101,7 +101,7 @@ Functions defined by cases may also be annotated:
 This function has the type
 @racket[(case-> (-> Number) (-> Number Number))].
 To specify the return type, either annotate the entire function or use the
-@seclink["Annotating_Expressions" #:doc '(lib "typed-racket/scribblings/ts-guide.scrbl")]{expression annotation form}
+@seclink["Annotating_Expressions"]{expression annotation form}
 (@racket[ann]) inside each case.
 
 


### PR DESCRIPTION
…se-lambda returns

- - -

prompted by a confused friend who knew about `(lambda args : TYPE e)` and got stuck trying to guess the equivalent for `case-lambda`

(another idea is to move the `ann` docs up, so they're first rather than last on this page)