### PR TITLE
Fix type-checking list elements

### DIFF
--- a/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-list.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-list.rkt
@@ -130,17 +130,8 @@
                   (add-typeof-expr #'op-name (ret (->* arg-tys return-ty :T+ #t)))
                   (ret return-ty)))
               (or result
-                  ;; When arguments to the list function fail to typecheck, the
-                  ;; odds are those argument expressions are ill-typed.  In that
-                  ;; case, we should only report those type errors instead of the error
-                  ;; that the result type of application of list doesn't match
-                  ;; the expected one.
-                  (let-values ([(tys errs) (for/lists (tys errs)
-                                                      ([i (in-list args-list)])
-                                             (tc-expr/t* i))])
-                    (when (andmap not errs)
-                      (expected-but-got t (-Tuple tys)))
-                    (fix-results expected)))]
+                  (begin (expected-but-got t (-Tuple (map tc-expr/t args-list)))
+                         (fix-results expected)))]
              [else
               (define arg-tys (map tc-expr/t args-list))
               (define return-ty (-Tuple arg-tys))


### PR DESCRIPTION
This addresses a regression in commit 8d9cb49.

That commit uses (when (andmap not errs) (expected-but-got ...)) to suppress some errors when type-checking list elements. Before this, there would be two errors reported: one for the list element itself and one for the surrounding list. However, as per #1379 this change suppressed too much. In certain cases it wouldn't report any errors for an invalid list.

I couldn't figure out a way to report errors perfectly, so instead, I decided to revert the relevant change in 8d9cb49. This means list could report multiple errors again, but it's honestly not that bad. It shows the innermost location where the problem happened, as well as the wider context of the list, which can be helpful for locating and understanding the error. An example using the code from #1379:

```
sample.rkt:13:41: Type Checker: type mismatch
  expected: (Listof Xexpr)
  given: (List Positive-Float-No-NaN)
  in: (list invalid)
  - snip -
sample.rkt:9:2: Type Checker: type mismatch
  expected: Xexpr
  given: (List 'html (List 'body (List 'p String) (Pairof 'p Nothing)))
  in: (quasiquote (html (body (p (unquote (~a invalid))) (p (unquote-splicing ((inst map Xexpr Xexpr) values (list invalid)))))))
  - snip -
Type Checker: Summary: 2 errors encountered
  location...:
   sample.rkt:13:41
   sample.rkt:9:2
  - snip -
```

The performance fix from 8d9cb49 still works.