### PR TITLE
Fix correspondence between location/c and Location in typed/racket

### DIFF
--- a/typed-racket-more/typed/xml.rkt
+++ b/typed-racket-more/typed/xml.rkt
@@ -18,12 +18,16 @@
      (Pair Symbol (Pair (Listof XExpr-Attribute) (Listof XExpr)))
      (Pair Symbol (Listof XExpr))))
 
-(require/typed/provide xml
+(require/typed xml
   [#:struct location
    ([line   : (U False Exact-Nonnegative-Integer)]
     [char   : (U False Exact-Nonnegative-Integer)]
-    [offset : Exact-Nonnegative-Integer])
-   #:type-name Location]
+    [offset : Exact-Nonnegative-Integer])])
+   
+(define-type Location
+  (U location Symbol False))
+
+(require/typed/provide xml
   [#:struct source
    ([start : Location]
     [stop  : Location])

--- a/typed-racket-more/typed/xml.rkt
+++ b/typed-racket-more/typed/xml.rkt
@@ -18,19 +18,15 @@
      (Pair Symbol (Pair (Listof XExpr-Attribute) (Listof XExpr)))
      (Pair Symbol (Listof XExpr))))
 
-(require/typed xml
+(require/typed/provide xml
   [#:struct location
    ([line   : (U False Exact-Nonnegative-Integer)]
     [char   : (U False Exact-Nonnegative-Integer)]
-    [offset : Exact-Nonnegative-Integer])])
-   
-(define-type Location
-  (U location Symbol False))
-
-(require/typed/provide xml
+    [offset : Exact-Nonnegative-Integer])
+   #:type-name Location]
   [#:struct source
-   ([start : Location]
-    [stop  : Location])
+   ([start : (U Location Symbol False)]
+    [stop  : (U Location Symbol False)])
    #:type-name Source]
   [#:struct external-dtd
    ([system : String])

--- a/typed-racket-test/unit-tests/xml-tests.rkt
+++ b/typed-racket-test/unit-tests/xml-tests.rkt
@@ -1,0 +1,25 @@
+#lang typed/racket/base
+
+(module+ test
+
+  (require typed/rackunit
+           "../../typed-racket-more/typed/xml.rkt")
+
+  (let ([xml-p-i
+         (p-i #f #f 'xml "version=\"1.0\" encoding=\"UTF-8\"")])
+    (check-eq?
+     (source-start xml-p-i)
+     #f)
+    (check-eq?
+     (source-stop xml-p-i)
+     #f))
+               
+  (let ([xml-p-i
+         (p-i 'racket 'racket 'xml "version=\"1.0\" encoding=\"UTF-8\"")])
+    (check-eq?
+     (source-start xml-p-i)
+     'racket)
+    (check-eq?
+     (source-stop xml-p-i)
+     'racket)))
+               


### PR DESCRIPTION
Checklist

- [x]  Bugfix
- [ ] Feature
- [x] tests included
- [ ] documentation

See also: Issue #1415 

In (untyped) racket, the XML collection uses a `source` struct whose fields `start` and `stop` follow the contract `location/c`. The `location/c` contract is defined as follows:

    (or/c location? symbol? #f)

However, in typed/racket the aforementioned fields are typed as `Location` which represents only the struct but neither symbols nor false.

This pull request extends the typing of `source`'s `start` and `stop` to entail both symbols and false typing them as

    (U Location Symbol False)