### PR TITLE
Provide typed version fxpopcount functions

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -420,6 +420,13 @@
        (-> -NonPosInt -Int -NonPosFixnum)
        (binop -Int -Fixnum))))
 
+  (define fxpopcount-type
+    (lambda ()
+      (fx-from-cases
+       (-Nat . -> . -NonNegFixnum)
+       (-NonNegFixnum . -> . -NonNegFixnum)
+       (-Int . -> . -Fixnum))))
+
   ;; A bit of machinery to allow floating point operations to be abstracted over double/extended
   ;; floating point types without repetition. 
   (define-syntax (define-fl-type-lambda stx)
@@ -1945,6 +1952,10 @@
 [fxnot (fxnot-type)]
 [fxlshift (fxlshift-type)]
 [fxrshift (fxrshift-type)]
+
+[fxpopcount (fxpopcount-type)]
+[fxpopcount16 (fxpopcount-type)]
+[fxpopcount32 (fxpopcount-type)]
 
 [fx= (fx=-type)]
 [fx< (fx<-type)]

--- a/typed-racket-test/succeed/fixnum.rkt
+++ b/typed-racket-test/succeed/fixnum.rkt
@@ -38,3 +38,6 @@
 (check equal? (fxmin 3 2) 2)
 (check equal? (fxmax 3 4) 4)
 
+(check equal? (fxpopcount #x0fffffffffffffff) 60)
+(check equal? (fxpopcount32 #xffffffff) 32)
+(check equal? (fxpopcount16 #xffff) 16)


### PR DESCRIPTION
This PR provides typed version fxpopcount functions, related to [issue1319](https://github.com/racket/typed-racket/issues/1319).

Before
```
Welcome to Racket v8.15-2024-12-25-34ef1af7ec [cs].
> (require racket/fixnum)
> (fxpopcount 42)
string:1:1: Type Checker: missing type for identifier;
 consider using `require/typed' to import it
  identifier: fxpopcount
  from module: racket/fixnum
  in: fxpopcount
 [,bt for context]
```

After
```
Welcome to Racket v8.15-2024-12-25-34ef1af7ec [cs].
> (require racket/fixnum)
> (fxpopcount 42)
- : Integer [more precisely: Nonnegative-Fixnum]
3
```