### PR TITLE
improve type definition of write-plist

### DIFF
--- a/typed-racket-more/typed/xml/plist.rkt
+++ b/typed-racket-more/typed/xml/plist.rkt
@@ -23,4 +23,4 @@
   [plist-value? (-> Any Boolean)]
   [plist-dict? (-> Any Boolean)]
   [read-plist (-> Input-Port Plist-Value)]
-  [write-plist (-> Plist-Dict Output-Port Void)])
+  [write-plist (-> Plist-Value Output-Port Void)])


### PR DESCRIPTION
The function `write-plist` has been typed

    (-> Plist-Dict Output-Port Void)

However, the untyped version has a less restrictive contract on the first argument:

    (plist-value? output-port? . -> . void?)

This pr relaxes the type of the first argument to Plist-Value, thus being

    (-> Plist-Value Output-Port Void)