### PR TITLE
Drop BC CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        racket-variant: ["BC", "CS"]
+        racket-variant: ["CS"]
         enable-contracts: [true, false]
     steps:
       - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Racket BC is no longer built in snapshots, so don't try to use those in CI.