### PR TITLE
Propagate a trivial expected type for recursive lambda if neccessary

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1601,7 +1601,7 @@
 ;; Section 11.1 (Threads)
 
 ;; Section 11.1.1
-[thread (->key (-> Univ) #:keep (Un (-val #f) (-val 'results)) #f #:pool Univ #f -Thread)]
+[thread (->key (-> ManyUniv) #:keep (Un (-val #f) (-val 'results)) #f #:pool Univ #f -Thread)]
 [thread? (unsafe-shallow:make-pred-ty -Thread)]
 [current-thread (-> -Thread)]
 [thread/suspend-to-kill (-> (-> Univ) -Thread)]

--- a/typed-racket-lib/typed-racket/rep/rep-utils.rkt
+++ b/typed-racket-lib/typed-racket/rep/rep-utils.rkt
@@ -611,7 +611,8 @@
                   #'(begin)
                   #`(provide #,@non-constr-li)))
             #'(constr-provide nonconstr-provide)])]
-        [struct-def #'(struct var.name parent ... (flds.ids ...)
+        [struct-def (syntax/loc #'var.name
+		      (struct var.name parent ... (flds.ids ...)
                         maybe-transparent ...
                         #:constructor-name constructor-name
                         #:property prop:uid uid-id
@@ -625,7 +626,7 @@
                          Rep-free-idxs-def
                          Rep-for-each-def
                          Rep-fmap-def]
-                        extra-defs ...)])
+                        extra-defs ...))])
        ;; - - - - - - - - - - - - - - -
        ;; macro output
        ;; - - - - - - - - - - - - - - -

--- a/typed-racket-lib/typed-racket/typecheck/signatures.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/signatures.rkt
@@ -61,7 +61,7 @@
 
 (define-signature tc-lambda^
   ([cond-contracted tc/lambda (syntax? syntax? syntax? (or/c tc-results/c #f) . -> . full-tc-results/c)]
-   [cond-contracted tc/rec-lambda/check (syntax? syntax? syntax? (listof Type?) tc-results/c . -> .
+   [cond-contracted tc/rec-lambda/check (syntax? syntax? syntax? (listof Type?) (or/c #f tc-results/c) . -> .
                                                  (values full-tc-results/c full-tc-results/c))]))
 
 (define-signature tc-app^

--- a/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
+++ b/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
@@ -797,7 +797,9 @@
 ;; Returns both the tc-results of the function and of the body
 (define (tc/rec-lambda/check formals* body name args return)
   (define formals (syntax->list formals*))
-  (define ft (t:->* args (tc-results->values return)))
+  (define ft (if return
+		 (t:->* args (tc-results->values return))
+		 (t:->* args ManyUniv)))
   (define names (cons name formals))
   (with-extended-lexical-env
     [#:identifiers (cons name formals)

--- a/typed-racket-test/succeed/events-with-async-channel.rkt
+++ b/typed-racket-test/succeed/events-with-async-channel.rkt
@@ -22,7 +22,7 @@
          (when l ; still something to read
            (intercept l) ; interceptor gets the whole vector
            (clear-events))))
-     (let: loop : Void ()
+     (let loop ()
        (let ([l : (U Log-Receiver-Sync-Result 'stop)
                (sync receiver stop-chan)])
          (cond [(eq? l 'stop)

--- a/typed-racket-test/succeed/events.rkt
+++ b/typed-racket-test/succeed/events.rkt
@@ -21,7 +21,7 @@
          (when l ; still something to read
            (intercept l) ; interceptor gets the whole vector
            (clear-events))))
-     (let: loop : Void ()
+     (let loop ()
        (let: ([l : (U Log-Receiver-Sync-Result 'stop)
                (sync receiver stop-chan)])
          (cond [(eq? l 'stop)

--- a/typed-racket-test/unit-tests/typecheck-tests.rkt
+++ b/typed-racket-test/unit-tests/typecheck-tests.rkt
@@ -5283,6 +5283,10 @@
           d0)
         (-lst* (-val 2) (-val "abc") (-ivec* (-val 1) (-val "b") (-val 'x)))]
 
+       
+
+       [tc-e (let loop () (loop)) #:ret (-tc-any-results -tt)]
+
        ;; comparisons must correctly account for if the
        ;; #false result was caused by a NaN (see TR Github issue #747)
        ;; less-than
@@ -5718,5 +5722,5 @@
      ([call-with-values (t:-> (t:-> (-values (list -String -String) (list -true-propset -true-propset) (list -empty-obj -empty-obj)))
                               (t:-> -String -String (-values -String -true-propset -empty-obj))
                               (-values -String -true-propset -empty-obj))]))
-   )
+)
   ))


### PR DESCRIPTION
This does not apply an expected type to the actual function body,
it just gives a type to the function when referred to recursively.

This addresses a problem with inference for let loop in lambda as
the argument to `thread` now that `thread` is a keyword function and
therefore lifts its arguments to a `let` ahead of the function.

Fixing the relevant problem also requires improving the type of `thread`.