### PR TITLE
Reduce per-PR Resyntax limits

### DIFF
--- a/.github/workflows/resyntax-autofixer.yml
+++ b/.github/workflows/resyntax-autofixer.yml
@@ -33,6 +33,6 @@ jobs:
         uses: jackfirth/create-resyntax-pull-request@v0.5.1
         with:
           private-key: ${{ secrets.RESYNTAX_APP_PRIVATE_KEY }}
-          max-fixes: '50'
-          max-modified-files: '20'
+          max-fixes: '20'
+          max-modified-files: '10'
           max-modified-lines: '500'


### PR DESCRIPTION
Resyntax seems to occasionally take an extremely long time to analyze the repository (over four hours), and it seems to fail at the final step of creating a pull request in these cases. The error message mentions "bad credentials" so I suspect the API token given to the workflow is already expired by the time Resyntax is ready to create a PR.

This PR reduces the amount of work Resyntax can do per pull request in the hopes of making it do less work and finish quicker.