### PR TITLE
Fix numeric literal type checking against union types

### DIFF
--- a/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -939,7 +939,11 @@
      [0 -Zero]
      [1 -One]
      [(? (lambda (x) (eq? x unsafe-undefined))) -Unsafe-Undefined]
-     [_ (make-Value val)])])
+     [_ (intern-single-ref! value-intern-table
+                            val
+                            #:construct (make-Value val))])])
+
+(define value-intern-table (make-weak-hash))
 
 
 ;;************************************************************

--- a/typed-racket-test/succeed/numeric-literal-union.rkt
+++ b/typed-racket-test/succeed/numeric-literal-union.rkt
@@ -1,0 +1,37 @@
+#lang typed/racket
+
+;; Test for numeric literal type checking against union types
+;; Bug: numeric literals should be typed as Value types when the
+;; expected type is a union of exact numeric values
+
+(define-type Oops (U 1 2))
+
+(: f (Oops -> Oops))
+(define (f x) x)
+
+;; Both of these should work
+(f 1)
+(f 2)
+
+;; Test with larger numeric literals
+(define-type Numbers (U 0 1 2 3 10 100))
+
+(: g (Numbers -> Numbers))
+(define (g x) x)
+
+(g 0)
+(g 1)
+(g 2)
+(g 3)
+(g 10)
+(g 100)
+
+;; Test with negative numbers
+(define-type SignedNumbers (U -1 0 1))
+
+(: h (SignedNumbers -> SignedNumbers))
+(define (h x) x)
+
+(h -1)
+(h 0)
+(h 1)


### PR DESCRIPTION
The bug occurred when checking numeric literals (e.g., 2) against union types containing exact numeric values (e.g., (U 1 2)).

Root cause:
- Value types like (-val 2) were not being interned, so each call to (-val 2) created a new instance
- When unions were created from type annotations like (U 1 2), they stored specific Value instances in their element hash
- During subtype checking, a freshly created (-val 2) would not match the Value instance stored in the union's hash, causing the subtype check to fail
- This made (f 2) fail type checking when f : (U 1 2) -> ...

Solution:
1. Added value-intern-table to intern all Value type instances
2. Modified Value's custom constructor to use intern-single-ref!
3. Now (-val 2) always returns the same instance, making hash lookups in subtype checking work correctly

Behavior:
- Without expected type: literals get general types (e.g., -PosByte)
- With expected type: literals get the expected type after successful subtype checking

This fixes the asymmetry where (f 1) worked but (f 2) failed.

Originally reported by Matthias Felleisen.