### PR TITLE
Add `flbit-field` to Typed Racket

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -609,6 +609,7 @@
   (define flreal-part-type (lambda () (-FloatComplex . -> . -Flonum)))
   (define flimag-part-type (lambda () (-FloatComplex . -> . -Flonum)))
   (define flrandom-type (lambda () (-Pseudo-Random-Generator . -> . -Flonum)))
+  (define flbit-field-type (lambda () (-Flonum -Byte -Byte . -> . -Nat)))
 
   ;; There's a repetitive pattern in the types of each comparison operator.
   ;; As explained below, this is because props don't do intersections.
@@ -2010,6 +2011,7 @@
 [flreal-part (flreal-part-type)]
 [flimag-part (flimag-part-type)]
 [flrandom (flrandom-type)]
+[flbit-field (flbit-field-type)]
 
 [unsafe-flabs (flabs-type 'flonum)]
 [unsafe-fl+ (fl+-type 'flonum)]
@@ -2023,6 +2025,7 @@
 [unsafe-fl< (fl<-type 'flonum)]
 [unsafe-flmin (flmin-type 'flonum)]
 [unsafe-flmax (flmax-type 'flonum)]
+[unsafe-flbit-field (flbit-field-type)]
 
 ;These are currently the same binding as the safe versions
 ;and so are not needed. If this changes they should be


### PR DESCRIPTION
This is a new addition, as of Racket 8.15, and exposing it would be useful for the `math` library, as in https://github.com/racket/math/pull/116.

It would be cool to add the unsafe version to the compiler but I couldn't really figure out how to do that.