### PR TITLE
Fix bugs in floating point optimizations

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-env-numeric.rkt
@@ -1248,7 +1248,7 @@
     (varop-1+ -InexactReal)
     ;; reals
     (varop-1+ -PosReal -NonNegReal)
-    (-> -NonPosReal -NonPosReal)
+    (-> -NegReal -NonPosReal)
     (-> -NegReal -NegReal -NonNegReal) ; 0.0 is non-neg, but doesn't preserve sign
     (-> -NegReal -PosReal -NonPosReal) ; idem
     (-> -PosReal -NegReal -NonPosReal) ; idem

--- a/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
@@ -208,16 +208,21 @@
                   (define new-imag-id (if both-real?
                                           (mark-as-real (car is))
                                           (car is)))
+                  ;; Helper to convert non-float values to flonum for unsafe ops
+                  (define (maybe-to-float v)
+                    (if (as-non-float v)
+                        #`(real->double-flonum #,v)
+                        v))
                   (loop (car rs) new-imag-id (cdr e1) (cdr e2) (cdr rs) (cdr is)
                         ;; complex multiplication, imag part, then real part (reverse)
                         ;; we eliminate operations on the imaginary parts of reals
                         (list* #`((#,new-imag-id)
                                   #,(cond ((and o-real? e-real?) #'0.0)
-                                          (o-real? #`(unsafe-fl* #,o1 #,(car e2)))
-                                          (e-real? #`(unsafe-fl* #,o2 #,(car e1)))
+                                          (o-real? #`(unsafe-fl* #,(maybe-to-float o1) #,(car e2)))
+                                          (e-real? #`(unsafe-fl* #,o2 #,(maybe-to-float (car e1))))
                                           (else
-                                           #`(unsafe-fl+ (unsafe-fl* #,o2 #,(car e1))
-                                                         (unsafe-fl* #,o1 #,(car e2))))))
+                                           #`(unsafe-fl+ (unsafe-fl* #,o2 #,(maybe-to-float (car e1)))
+                                                         (unsafe-fl* #,(maybe-to-float o1) #,(car e2))))))
                                #`((#,(car rs))
                                   #,(cond [(and o-nf e-nf both-real?)
                                            ;; we haven't seen float operands yet, so

--- a/typed-racket-test/optimizer/known-bugs.rkt
+++ b/typed-racket-test/optimizer/known-bugs.rkt
@@ -19,7 +19,7 @@
 (define (mk-eval lang)
   (call-with-trusted-sandbox-configuration
    (λ ()
-     (parameterize ([sandbox-memory-limit 300])
+     (parameterize ([sandbox-memory-limit 3000])
        (make-evaluator lang)))))
 (define racket-eval (mk-eval 'racket))
 (define tr-eval     (mk-eval 'typed/racket))
@@ -85,6 +85,9 @@
     ;; Multiplication of multiple args should keep exact semantics for exact args
     (good-opt (* (expt 10 500) (expt 10 -500) 1.0+1.0i))
 
+    ;; Multiplication with multiple exact reals and a float complex should not crash
+    (good-opt (* 2 3 1.0+1.0i))
+
     ;; Addition of multiple args should keep exact semantics for exact args
     (good-opt (+ (expt 10 501) (expt -10 501) 1.0+1.0i))
 
@@ -99,7 +102,16 @@
     (good-opt (conjugate 0.0+0.0i))
 
     ;; Magnitude should always return positive results
-    (good-opt (magnitude -1.0-2i))))
+    (good-opt (magnitude -1.0-2i))
+
+    ;; Division of 0.0 should return correct sign
+    (good-opt (/ (min 0.0 0)))
+
+    ;; Subtraction should not convert large numbers to infinity prematurely
+    (good-opt (- (expt 10 309) +inf.0))
+
+    ;; make-polar with NaN should return complex NaN, not real NaN
+    (good-opt (+ 1.0 (make-polar +nan.0 1.0)))))
 
 (module+ main
   (require rackunit/text-ui)


### PR DESCRIPTION
1. Fix type of `(/ 0.0)`: Changed type of `/` from `(-> -NonPosReal -NonPosReal)` to `(-> -NegReal -NonPosReal)` to correctly handle `(/ (min 0.0 0))`.

2. Avoid optimizing large exact values to floats when they might overflow to infinity.

3. Convert exact values to floats before using `unsafe-fl*` in complex multiplication.

Based on and closes PR #1381. Fixes #1042.