### PR TITLE
Support Racket's qq-and-or.rkt -> core-syntax.rkt file rename

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
+++ b/typed-racket-lib/typed-racket/base-env/base-special-env.rkt
@@ -18,6 +18,19 @@
      (module-path-index-join where #f)))
   (syntax-binding-set->syntax s what))
 
+; Like make-template-identifier, but given multiple modules and picks the
+; first module which appears to exist. This is a giant hack and should be
+; removed when no longer necessary, probably late April 2016 or so. See
+; https://github.com/racket/typed-racket/pull/1499
+(define (make-template-identifier* what where-potentials)
+  (define where
+    (for/or ([where (in-list where-potentials)]
+             #:when (module-declared? (module-path-index-join where #f)))
+      where))
+  (make-template-identifier what
+                            (or where
+                                (error 'make-template-identifier* "not found"))))
+
 
 (define-initial-env initialize-special #:default-T+ #true
   ;; make-promise
@@ -38,7 +51,11 @@
   [(make-template-identifier 'all-languages 'string-constants/string-constant)
    (-> (-lst -Symbol))]
   ;; qq-append
-  [(make-template-identifier 'qq-append 'racket/private/qq-and-or)
+  ;; Note that this is being moved between files at present, so TR needs to be aware
+  ;; of both the old and new location. This duplication can be removed April 2026-ish.
+  ;; See https://github.com/racket/racket/pull/5457
+  [(make-template-identifier* 'qq-append '(racket/private/qq-and-or
+                                           racket/private/core-syntax))
    (-poly (a b)
          (cl->*
           (-> (-lst a) -Null (-lst a))


### PR DESCRIPTION
Typed Racket needs to be updated so it's aware of the `qq-append` function
regardless of whether that function is defined in the old place (qq-and-or.rkt)
or the new place (core-syntax.rkt). We can do this through a horrible hack, by
taking advantage of the fact that defines `qq-apend` is being moved wholesale,
so either the `racket/private/qq-and-or` xor `racket/private/core-syntax` will
be declared, and we can determine where `qq-append` is by checking which one.

Once the file rename can be reasonably assumed to be everywhere that somebody
would want to be installing TR's trunk branch, which is to say probably at most
a week after this is committed, we can remove the hack.

Cross-reference: https://github.com/racket/racket/pull/5457


# NOTE coordinated change in Racket

This change only makes sense if https://github.com/racket/racket/pull/5457 is going to be merged. The proper order for things is probably (1) get approval for both PRs, (2) merge the PR to Typed Racket and wait a couple hours for the package server to update, (3) merge this.