### PR TITLE
Fix require/typed/provide constructor name in submodules

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -338,10 +338,15 @@
                   (r/t/p lib other-clause ...))]
         [(_ lib (~and clause [#:struct nm:opt-parent
                                        (body:typed-field ...)
-                                       option ...])
+                                       (~alt (~optional (~seq #:extra-constructor-name extra-ctor:id))
+                                             (~optional (~seq #:constructor-name ctor:id))
+                                             (~optional (~seq #:type-name _:id)))
+                                       ...])
             other-clause ...)
          #'(begin (r/t lib clause)
                   (provide (struct-out nm.nm))
+                  (~? (provide extra-ctor))
+                  (~? (provide ctor))
                   (r/t/p lib other-clause ...))]
         [(_ lib (~and clause [#:opaque t:id pred:id])
             other-clause ...)
@@ -353,15 +358,15 @@
 
 (define-values [require-typed-struct/provide require-typed-struct/provide-shallow require-typed-struct/provide-optional]
   (let ()
-    (define (rtsp-maker te-mode)
+    (define ((rtsp-maker te-mode) stx)
       (define/with-syntax r/t/s (case te-mode ((shallow) #'require-typed-struct-shallow) ((optional) #'require-typed-struct-optional) (else #'require-typed-struct)))
-      (syntax-rules ()
-        [(_ (nm par) . rest)
-         (begin (r/t/s (nm par) . rest)
-                (provide (struct-out nm)))]
-        [(_ nm . rest)
-         (begin (r/t/s nm . rest)
-                (provide (struct-out nm)))]))
+      (syntax-parse stx
+        [(_ (~and name (~or nm:id (nm:id _:id))) . rest)
+         #:with (~or (_ ... (~or #:extra-constructor-name #:constructor-name) ctor:id . _) _)
+                #'rest
+         #'(begin (r/t/s name . rest)
+                  (provide (struct-out nm))
+                  (~? (provide ctor)))]))
     (values (rtsp-maker 'guarder) (rtsp-maker 'shallow) (rtsp-maker 'optional))))
 
 ;; Conversion of types to contracts
@@ -591,9 +596,7 @@
                       [internal-maker (generate-temporary #'maker-name)]
                       ;The actual identifier bound to the constructor
                       [real-maker (if (syntax-e #'id-is-ctor?) #'internal-maker #'maker-name)]
-                      [extra-maker (and (attribute input-maker.extra)
-                                        (not (bound-identifier=? #'maker-name #'nm))
-                                        #'maker-name)]
+                      [main-maker (if (syntax-e #'id-is-ctor?) #'nm #'maker-name)]
                       [type (if (stx-null? #'(tvar ...))
                                 #'type
                                 (untyped-struct-poly #'type))]
@@ -608,6 +611,12 @@
                      (when (and (not (attribute unsafe.unsafe?))
                                 (pair? (syntax->list #'(tvar ...))))
                        (tc-error/stx stx "polymorphic structs are not supported when importing from untyped racket"))
+
+                     (define/syntax-parse ((~optional extra-maker:id))
+                       (if (and (attribute input-maker.extra)
+                                (not (bound-identifier=? #'maker-name #'nm)))
+                           (list #'maker-name)
+                           '()))
 
                      (define (maybe-add-quote-syntax stx)
                        (if (and stx (syntax-e stx)) #`(quote-syntax #,stx) stx))
@@ -670,7 +679,9 @@
                                   (make-struct-info-wrapper* #'internal-maker si #'type)
                                   si))
 
-                         (dtsi* (tvar ...) spec type (body ...) #:maker maker-name)
+                         (dtsi* (tvar ...) spec type (body ...)
+                                #:maker main-maker
+                                (~? (~@ #:extra-maker extra-maker)))
                          #,(ignore
                              (with-syntax ((pred-ctc
                                             (case te-mode
@@ -692,11 +703,9 @@
 
                          ;This needs to be a different identifier to meet the specifications
                          ;of struct (the id constructor shouldn't expand to it)
-                         #,(if (syntax-e #'extra-maker)
-                               #`(r/t/te-mode #:internal (maker-name extra-maker) type lib
-                                                #:struct-maker parent
-                                                #,@(if (attribute unsafe.unsafe?) #'(unsafe-kw) #'()))
-                               #'(begin))
+                         (~? (r/t/te-mode #:internal (maker-name extra-maker) type lib
+                                          #:struct-maker parent
+                                          #,@(if (attribute unsafe.unsafe?) #'(unsafe-kw) #'())))
 
                          #,@(if (attribute unsafe.unsafe?)
                                 #'((r/t/te-mode #:internal sel (All (tvar ...) (self-type -> ty)) lib unsafe-kw) ...)

--- a/typed-racket-test/succeed/require-typed-struct-provide-extra-ctor.rkt
+++ b/typed-racket-test/succeed/require-typed-struct-provide-extra-ctor.rkt
@@ -1,0 +1,62 @@
+#lang typed/racket/base
+
+;; Tests that require/typed/provide and require-typed-struct/provide
+;; correctly export the constructor identifier when used inside a
+;; submodule, including when #:extra-constructor-name or
+;; #:constructor-name is specified.
+
+(module untyped racket/base
+  (struct foo (a b) #:extra-constructor-name make-foo #:transparent)
+  (struct bar (x) #:constructor-name make-bar #:transparent)
+  (struct baz (n) #:transparent)
+  (provide (struct-out foo) (struct-out bar) (struct-out baz)))
+
+;; require/typed/provide with #:extra-constructor-name
+(module test-foo-rtp typed/racket/base
+  (module inner typed/racket/base
+    (require/typed/provide (submod ".." ".." untyped)
+      [#:struct foo ([a : Integer] [b : Integer]) #:extra-constructor-name make-foo]))
+  (require 'inner)
+  (unless (foo? (foo 1 2)) (error "rtp: foo ctor failed"))
+  (unless (foo? (make-foo 3 4)) (error "rtp: make-foo ctor failed"))
+  (unless (= 1 (foo-a (foo 1 2))) (error "rtp: foo-a failed")))
+(require 'test-foo-rtp)
+
+;; require-typed-struct/provide with #:extra-constructor-name
+(module test-foo-rts typed/racket/base
+  (module inner typed/racket/base
+    (require-typed-struct/provide foo ([a : Integer] [b : Integer])
+                                  #:extra-constructor-name make-foo
+                                  (submod ".." ".." untyped)))
+  (require 'inner)
+  (unless (foo? (foo 5 6)) (error "rts: foo failed"))
+  (unless (foo? (make-foo 7 8)) (error "rts: make-foo failed")))
+(require 'test-foo-rts)
+
+;; require/typed/provide with #:constructor-name
+(module test-bar-rtp typed/racket/base
+  (module inner typed/racket/base
+    (require/typed/provide (submod ".." ".." untyped)
+      [#:struct bar ([x : Integer]) #:constructor-name make-bar]))
+  (require 'inner)
+  (unless (bar? (make-bar 9)) (error "rtp: make-bar ctor failed")))
+(require 'test-bar-rtp)
+
+;; require-typed-struct/provide with #:constructor-name
+(module test-bar-rts typed/racket/base
+  (module inner typed/racket/base
+    (require-typed-struct/provide bar ([x : Integer])
+                                  #:constructor-name make-bar
+                                  (submod ".." ".." untyped)))
+  (require 'inner)
+  (unless (bar? (make-bar 10)) (error "rts: make-bar failed")))
+(require 'test-bar-rts)
+
+;; basic case (no constructor option)
+(module test-baz typed/racket/base
+  (module inner typed/racket/base
+    (require/typed/provide (submod ".." ".." untyped)
+      [#:struct baz ([n : Integer])]))
+  (require 'inner)
+  (unless (baz? (baz 11)) (error "baz failed")))
+(require 'test-baz)


### PR DESCRIPTION
Handle `#:extra-constructor-name` and `#:constructor-name` better
to avoid re-providing bugs.

Closes #1507.