### PR TITLE
Fix n-ary float-complex +/- to not over-eagerly switch to unsafe ops

### DIFF
--- a/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
+++ b/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
@@ -85,23 +85,30 @@
   stx)
 
 (define (n-ary->binary/non-floats op unsafe this-syntax cs)
-  (let loop ([o (stx-car cs)] [cs (stx-cdr cs)])
-    ;; we're guaranteed to hit non-"non-float" operands before
-    ;; we hit the end of the list. otherwise we wouldn't be doing
-    ;; float-complex optimizations
-    (define c1 (stx-car cs))
-    (define o-nf (as-non-float o))
-    (define c1-nf (as-non-float c1))
+  ;; Fold left, using the unsafe op for pairs of known-float operands and
+  ;; the generic op (on un-coerced originals) whenever either side is a
+  ;; non-float. Switching to all-unsafe after the first float pair would
+  ;; be incorrect: a later non-float operand has its real-binding eagerly
+  ;; coerced to flonum, so a huge exact integer becomes +/-inf.0, and
+  ;; combining it with another infinity via unsafe-fl- gives NaN instead
+  ;; of the correct infinity that generic arithmetic produces.
+  (let loop ([o (stx-car cs)] [rest (stx-cdr cs)])
     (cond
-      [(or o-nf c1-nf)
-       ;; can't convert those to floats just yet, or may change
-       ;; the result
+      [(stx-null? rest) o]
+      [else
+       (define c1 (stx-car rest))
+       (define o-nf (as-non-float o))
+       (define c1-nf (as-non-float c1))
        (define new-o
-         (mark-as-non-float (quasisyntax/loc this-syntax
-                              (#,op #,(or o-nf o) #,(or c1-nf c1)))))
-       (if (stx-null? (stx-cdr cs)) new-o (loop new-o (stx-cdr cs)))]
-      ;; we've hit floats, can start coercing
-      [else (n-ary->binary this-syntax unsafe (cons #`(real->double-flonum #,(or o-nf o)) cs))])))
+         (cond
+           [(or o-nf c1-nf)
+            (mark-as-non-float
+             (quasisyntax/loc this-syntax
+               (#,op #,(or o-nf o) #,(or c1-nf c1))))]
+           [else
+            (quasisyntax/loc this-syntax
+              (#,unsafe #,o #,c1))]))
+       (loop new-o (stx-cdr rest))])))
 
 
 

--- a/typed-racket-test/optimizer/known-bugs.rkt
+++ b/typed-racket-test/optimizer/known-bugs.rkt
@@ -117,7 +117,14 @@
     ;; (inf * 0 = NaN in IEEE 754, but exp(+inf+0i) = +inf+0i per C99)
     (good-opt (exp (make-rectangular +inf.0 -0.0)))
     (good-opt (exp (make-rectangular +inf.0 0.0)))
-    (good-opt (exp (make-rectangular +nan.0 0.0)))))
+    (good-opt (exp (make-rectangular +nan.0 0.0)))
+
+    ;; n-ary float-complex subtraction should not coerce huge exact integers
+    ;; to flonum before subtracting: an overflowed +inf.0 combined with
+    ;; another infinity operand would yield NaN instead of the correct +inf.0.
+    (good-opt (- +inf.0 0.0+0.0i
+                 (lcm (exact-round 7) (exact-round 2)
+                      (exact-round -1.7976931348623153e+308))))))
 
 (module+ main
   (require rackunit/text-ui)


### PR DESCRIPTION
> **Superseded by the [`tr868-float-complex-fixes`](https://github.com/samth/typed-racket/tree/tr868-float-complex-fixes) branch**, which rebases this fix onto current master and additionally preserves exact/signed-zero complex parts in float-complex `+`/`-` (addresses #868). A replacement PR will close this one.

---

The code assumed that just switching to safe ops once was sufficient,
but things can be trickier than that.

Found by:
https://drdr.racket-lang.org/72865/cs/racket/share/pkgs/typed-racket-test/external/tr-random-testing.rkt
